### PR TITLE
fixed LDAP operation on empty value

### DIFF
--- a/res/res_config_ldap.c
+++ b/res/res_config_ldap.c
@@ -1295,11 +1295,15 @@ static int update_ldap(const char *basedn, const char *table_name, const char *a
 	ldap_mods = ldap_memcalloc(sizeof(LDAPMod *), mods_size);
 	ldap_mods[0] = ldap_memcalloc(1, sizeof(LDAPMod));
 
-	ldap_mods[0]->mod_op = LDAP_MOD_REPLACE;
-	ldap_mods[0]->mod_type = ldap_strdup(newparam);
+	if (strlen(field->value) == 0) {
+		ldap_mods[0]->mod_op = LDAP_MOD_DELETE;
+	} else {
+		ldap_mods[0]->mod_op = LDAP_MOD_REPLACE;
 
-	ldap_mods[0]->mod_values = ast_calloc(sizeof(char *), 2);
-	ldap_mods[0]->mod_values[0] = ldap_strdup(field->value);
+		ldap_mods[0]->mod_type = ldap_strdup(newparam);
+		ldap_mods[0]->mod_values = ast_calloc(sizeof(char *), 2);
+		ldap_mods[0]->mod_values[0] = ldap_strdup(field->value);
+	}
 
 	while ((field = field->next)) {
 		newparam = convert_attribute_name_to_ldap(table_config, field->name);


### PR DESCRIPTION
this is in addition to commit f2b9fc797d59730c531afc1339130b89351cf322, since that only checks the value being empty on all but the first field