### PR TITLE
Patch 1

### DIFF
--- a/contrib/ast-db-manage/config/versions/fe6592859b85_fix_mwi_subscribe_replaces_.py
+++ b/contrib/ast-db-manage/config/versions/fe6592859b85_fix_mwi_subscribe_replaces_.py
@@ -34,7 +34,7 @@ def upgrade():
     op.alter_column('ps_endpoints', 'mwi_subscribe_replaces_unsolicited',
                     type_=sa.String(5))
     op.alter_column('ps_endpoints', 'mwi_subscribe_replaces_unsolicited',
-                    type_=ast_bool_values)
+                    type_=ast_bool_values, postgresql_using='mwi_subscribe_replaces_unsolicited::{0}'.format(AST_BOOL_NAME))
 
 
 def downgrade():

--- a/contrib/realtime/postgresql/postgresql_config.sql
+++ b/contrib/realtime/postgresql/postgresql_config.sql
@@ -1279,7 +1279,7 @@ CREATE TYPE ast_bool_values AS ENUM ('0', '1', 'off', 'on', 'false', 'true', 'no
 
 ALTER TABLE ps_endpoints ALTER COLUMN mwi_subscribe_replaces_unsolicited TYPE VARCHAR(5);
 
-ALTER TABLE ps_endpoints ALTER COLUMN mwi_subscribe_replaces_unsolicited TYPE ast_bool_values;
+ALTER TABLE ps_endpoints ALTER COLUMN mwi_subscribe_replaces_unsolicited TYPE ast_bool_values USING mwi_subscribe_replaces_unsolicited::ast_bool_values;
 
 UPDATE alembic_version SET version_num='fe6592859b85' WHERE alembic_version.version_num = '1d3ed26d9978';
 


### PR DESCRIPTION
Ubuntu 19.10 has asterisk 16.2 and postgres 11. This fix will remedy this configuration's alembic error:
qlalchemy.exc.ProgrammingError: (psycopg2.ProgrammingError) column "mwi_subscribe_replaces_unsolicited" cannot be cast automatically to type ast_bool_values
