### PR TITLE
Clarified "get full variable"

### DIFF
--- a/res/res_agi.c
+++ b/res/res_agi.c
@@ -323,14 +323,14 @@
 			Evaluates a channel expression
 		</synopsis>
 		<syntax>
-			<parameter name="variablename" required="true" />
+			<parameter name="${variablename}" required="true" />
 			<parameter name="channel name" />
 		</syntax>
 		<description>
 			<para>Returns <literal>0</literal> if <replaceable>variablename</replaceable> is not set
 			or channel does not exist. Returns <literal>1</literal> if <replaceable>variablename</replaceable>
 			is set and returns the variable in parenthesis. Understands complex variable names and builtin
-			variables, unlike GET VARIABLE.</para>
+			variables, and must be enclosed in ${dollar_braces} unlike GET VARIABLE.</para>
 			<para>Example return code: 200 result=1 (testvariable)</para>
 		</description>
 		<see-also>


### PR DESCRIPTION
As per discussion on mailing list - submitted to https://issues.asterisk.org/jira/browse/ASTERISK-28673

This works as expected

```
<Local/1000@default-00000020;2>AGI Rx << SET VARIABLE myVar "Hello World!!!"
<Local/1000@default-00000020;2>AGI Tx >> 200 result=1
<Local/1000@default-00000020;2>AGI Rx << GET VARIABLE myVar
<Local/1000@default-00000020;2>AGI Tx >> 200 result=1 (Hello World!!!)
```

But  GET FULL VARIABLE just returns the NAME of the variable

```
<Local/1000@default-0000001f;2>AGI Rx << SET VARIABLE myVar "Hello World!!!"
<Local/1000@default-0000001f;2>AGI Tx >> 200 result=1
<Local/1000@default-0000001f;2>AGI Rx << GET FULL VARIABLE myVar
<Local/1000@default-0000001f;2>AGI Tx >> 200 result=1 (myVar)
```

> From: Sean Bright <xxx@gmail.com>
> Subject: Re: [asterisk-users] AGI: "Get variable" returns variable VALUE vs "Get full variable" returns variable NAME - bug or my misunderstanding?
> I believe the syntax you are looking for is:
> GET FULL VARIABLE ${myVar}
