### PR TITLE
mask frames according to websocket rfc6455 spec

### DIFF
--- a/res/res_http_websocket.c
+++ b/res/res_http_websocket.c
@@ -387,8 +387,8 @@ int AST_OPTIONAL_API_NAME(ast_websocket_write)(struct ast_websocket *session, en
 		put_unaligned_uint64(&frame[2], htonll(payload_size));
 	}
 
-    for(i=0;i<4;i++) {
-    	frame[(header_size-4)+i] = mask[i] & 0xff;
+	for(i=0;i<4;i++) {
+		frame[(header_size-4)+i] = mask[i] & 0xff;
 	}
 
 	memcpy(&frame[header_size], payload, payload_size);


### PR DESCRIPTION
Hello all,

I have been trying to integrate res_http_websocket.c with various websocket servers and I have had some mixed results with my websocket client side implementations.

based on my review, it seems that the websocket module itself is not fully rfc6455 compliant as it does not correctly mask payloads that are sent to the server.

please see:
[https://tools.ietf.org/html/rfc6455#section-5.3](https://tools.ietf.org/html/rfc6455#section-5.3)

I have created a pull request with an updated ast_websocket_write that masks client payloads, according to the RFC, before they are sent to a server.

I have been able to verify that the patch works for Websocket servers that follow the specification.

It would be nice if Asterisk community can review my patch. I hope I can help the development of this project in anyway.

if you have any queries about the patch / need more info let me know.

thanks