### PR TITLE
Return 0 as exit code on MP3 source's script

### DIFF
--- a/contrib/scripts/get_mp3_source.sh
+++ b/contrib/scripts/get_mp3_source.sh
@@ -12,7 +12,7 @@ if [ -f addons/mp3/mpg123.h ]; then
             addons/mp3/interface.c
     fi
 
-    exit 1
+    exit 0
 fi
 
 svn export https://svn.digium.com/svn/thirdparty/mp3/trunk addons/mp3 $@


### PR DESCRIPTION
Avoid exiting with an error when executing the script "get_mp3_source.sh." Using "exit 1" will stop the compilation process for automated scripts or when creating Linux packages.