### PR TITLE
Update geolocation.conf.sample

### DIFF
--- a/configs/samples/geolocation.conf.sample
+++ b/configs/samples/geolocation.conf.sample
@@ -307,6 +307,7 @@ profile_action = discard_incoming
 =======================================================================
 --;
 
+;--
 -- NOTE ---------------------------------------------------------------
 There are 4 built-in profiles that can be assigned to endpoints:
   "<prefer_config>"
@@ -315,4 +316,4 @@ There are 4 built-in profiles that can be assigned to endpoints:
   "<discard_incoming>"
 The profiles are empty except for having their precedence
 set.
-
+--;


### PR DESCRIPTION
Fix ERROR: res_sorcery_config.c:334 sorcery_config_internal_load: Contents of config file 'geolocation.conf' are invalid and cannot be parsed