### PR TITLE
Update install_prereq for aarch64

### DIFF
--- a/contrib/scripts/install_prereq
+++ b/contrib/scripts/install_prereq
@@ -192,9 +192,14 @@ check_installed_debs() {
 	for pack in "$@" ; do
 		tocheck="${tocheck} ^${pack}$ ~P^${pack}$"
 	done
+	arch=$(uname -m)
 	pkgs=$(aptitude -F '%c %p' search ${tocheck} 2>/dev/null | awk '/^p/{print $2}')
 	if [ ${#pkgs} -ne 0 ]; then
-		echo $pkgs | sed -r -e "s/ ?[^ :]+:i386//g"
+		if [ "$arch" = "X86_64" ]; then
+			echo $pkgs | sed -r -e "s/ ?[^ :]+:i386//g"
+		elif [ "$arch" = "aarch64" ]; then
+			echo $pkgs | sed -r -e "s/ ?[^ :]+:armhf//g"
+		fi
 	fi
 }
 

--- a/contrib/scripts/install_prereq
+++ b/contrib/scripts/install_prereq
@@ -195,7 +195,7 @@ check_installed_debs() {
 	arch=$(uname -m)
 	pkgs=$(aptitude -F '%c %p' search ${tocheck} 2>/dev/null | awk '/^p/{print $2}')
 	if [ ${#pkgs} -ne 0 ]; then
-		if [ "$arch" = "X86_64" ]; then
+		if [ "$arch" = "x86_64" ]; then
 			echo $pkgs | sed -r -e "s/ ?[^ :]+:i386//g"
 		elif [ "$arch" = "aarch64" ]; then
 			echo $pkgs | sed -r -e "s/ ?[^ :]+:armhf//g"


### PR DESCRIPTION
Exclude armhf when installing on aarch64
https://github.com/iiab/iiab/issues/3489 has the problem report and debug information. 