### PR TITLE
say.c: Fix French time playback.

### DIFF
--- a/main/say.c
+++ b/main/say.c
@@ -7339,11 +7339,16 @@ int ast_say_time_fr(struct ast_channel *chan, time_t t, const char *ints, const 
 	ast_localtime(&when, &tm, NULL);
 
 	res = ast_say_number(chan, tm.tm_hour, ints, lang, "f");
-	if (!res)
+	if (!res) {
 		res = ast_streamfile(chan, "digits/oclock", lang);
+	}
+	if (!res) {
+		res = ast_waitstream(chan, ints);
+	}
 	if (tm.tm_min) {
-		if (!res)
-		res = ast_say_number(chan, tm.tm_min, ints, lang, (char *) NULL);
+		if (!res) {
+			res = ast_say_number(chan, tm.tm_min, ints, lang, "f");
+		}
 	}
 	return res;
 }


### PR DESCRIPTION
ast_waitstream was not called after ast_streamfile, resulting in "o'clock" being skipped in French.

Additionally, the minute announcements should be feminine.

Reported-by: Danny Lloyd

Imported from Gerrit: https://gerrit.asterisk.org/c/asterisk/+/20035

Resolves: #41
ASTERISK-30488