### PR TITLE
res_pjsip: mediasec: Add Security-Client headers after 401

### DIFF
--- a/include/asterisk/res_pjsip.h
+++ b/include/asterisk/res_pjsip.h
@@ -1176,11 +1176,24 @@ void ast_sip_security_mechanisms_vector_destroy(struct ast_sip_security_mechanis
  *
  * \param security_mechanism Pointer-pointer to the security mechanism to allocate.
  * \param value The security mechanism string as defined in RFC 3329 (section 2.2)
- * \param ... in the form \<mechanism_name>;q=\<q_value>;\<mechanism_parameters>
+ *				in the form <mechanism_name>;q=<q_value>;<mechanism_parameters>
  * \retval 0 Success
  * \retval non-zero Failure
  */
 int ast_sip_str_to_security_mechanism(struct ast_sip_security_mechanism **security_mechanism, const char *value);
+
+/*!
+ * \brief Writes the security mechanisms of an endpoint into a buffer as a string and returns the buffer.
+ *
+ * \note The buffer must be freed by the caller.
+ *
+ * \param endpoint Pointer to endpoint.
+ * \param add_qvalue If non-zero, the q-value is printed as well
+ * \param buf The buffer to write the string into
+ * \retval 0 Success
+ * \retval non-zero Failure
+ */
+int ast_sip_security_mechanisms_to_str(const struct ast_sip_security_mechanism_vector *security_mechanisms, int add_qvalue, char **buf);
 
 /*!
  * \brief Set the security negotiation based on a given string.

--- a/res/res_pjsip/pjsip_configuration.c
+++ b/res/res_pjsip/pjsip_configuration.c
@@ -256,11 +256,32 @@ static int timers_to_str(const void *obj, const intptr_t *args, char **buf)
 	return 0;
 }
 
+static int security_mechanism_to_str(const void *obj, const intptr_t *args, char **buf)
+{
+	const struct ast_sip_endpoint *endpoint = obj;
+
+	return ast_sip_security_mechanisms_to_str(&endpoint->security_mechanisms, 0, buf);
+}
+
 static int security_mechanism_handler(const struct aco_option *opt, struct ast_variable *var, void *obj)
 {
 	struct ast_sip_endpoint *endpoint = obj;
 
 	return ast_sip_security_mechanism_vector_init(&endpoint->security_mechanisms, var->value);
+}
+
+static const char *security_negotiation_map[] = {
+	[AST_SIP_SECURITY_NEG_NONE] = "no",
+	[AST_SIP_SECURITY_NEG_MEDIASEC] = "mediasec",
+};
+
+static int security_negotiation_to_str(const void *obj, const intptr_t *args, char **buf)
+{
+	const struct ast_sip_endpoint *endpoint = obj;
+	if (ARRAY_IN_BOUNDS(endpoint->security_negotiation, security_negotiation_map)) {
+		*buf = ast_strdup(security_negotiation_map[endpoint->security_negotiation]);
+	}
+	return 0;
 }
 
 int ast_sip_set_security_negotiation(enum ast_sip_security_negotiation *security_negotiation, const char *val) {
@@ -2262,8 +2283,8 @@ int ast_res_pjsip_initialize_configuration(void)
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "allow_unauthenticated_options", "no", OPT_BOOL_T, 1, FLDSET(struct ast_sip_endpoint, allow_unauthenticated_options));
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "geoloc_incoming_call_profile", "", OPT_STRINGFIELD_T, 0, STRFLDSET(struct ast_sip_endpoint, geoloc_incoming_call_profile));
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "geoloc_outgoing_call_profile", "", OPT_STRINGFIELD_T, 0, STRFLDSET(struct ast_sip_endpoint, geoloc_outgoing_call_profile));
-	ast_sorcery_object_field_register_custom(sip_sorcery, "endpoint", "security_mechanisms", "", security_mechanism_handler, NULL, NULL, 0, 0);
-	ast_sorcery_object_field_register_custom(sip_sorcery, "endpoint", "security_negotiation", "no", security_negotiation_handler, NULL, NULL, 0, 0);
+	ast_sorcery_object_field_register_custom(sip_sorcery, "endpoint", "security_mechanisms", "", security_mechanism_handler, security_mechanism_to_str, NULL, 0, 0);
+	ast_sorcery_object_field_register_custom(sip_sorcery, "endpoint", "security_negotiation", "no", security_negotiation_handler, security_negotiation_to_str, NULL, 0, 0);
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "send_aoc", "no", OPT_BOOL_T, 1, FLDSET(struct ast_sip_endpoint, send_aoc));
 
 	if (ast_sip_initialize_sorcery_transport()) {

--- a/res/res_pjsip_rfc3329.c
+++ b/res/res_pjsip_rfc3329.c
@@ -34,24 +34,57 @@
 #include "asterisk/causes.h"
 #include "asterisk/threadpool.h"
 
+/*! \brief Private data structure used with the modules's datastore */
+struct rfc3329_store_data {
+	int last_rx_status_code;
+};
+
+static void datastore_destroy_cb(void *data)
+{
+	struct rfc3329_store_data *d = data;
+	if (d) {
+		ast_free(d);
+	}
+}
+
+/*! \brief The channel datastore the module uses to store state */
+static const struct ast_datastore_info rfc3329_store_datastore = {
+	.type = "rfc3329_store",
+	.destroy = datastore_destroy_cb
+};
+
 static void rfc3329_incoming_response(struct ast_sip_session *session, struct pjsip_rx_data *rdata)
 {
+	RAII_VAR(struct ast_datastore *, datastore, ast_sip_session_get_datastore(session, "rfc3329_store"), ao2_cleanup);
 	static const pj_str_t str_security_server = { "Security-Server", 15 };
 	struct ast_sip_contact_status *contact_status = NULL;
 	struct ast_sip_security_mechanism *mech;
+	struct rfc3329_store_data *store_data;
 	pjsip_generic_string_hdr *header;
 	char buf[128];
 	char *hdr_val;
 	char *mechanism;
 
 	if (!session || !session->endpoint || !session->endpoint->security_negotiation
-		|| !session->contact || !(contact_status = ast_sip_get_contact_status(session->contact))) {
+		|| !session->contact || !(contact_status = ast_sip_get_contact_status(session->contact))
+		|| !session->inv_session->dlg) {
 		return;
 	}
 
 	ao2_lock(contact_status);
 	if (AST_VECTOR_SIZE(&contact_status->security_mechanisms)) {
 		goto out;
+	}
+
+	if (!datastore
+		&& (datastore = ast_sip_session_alloc_datastore(&rfc3329_store_datastore, "rfc3329_store"))
+		&& (store_data = ast_calloc(1, sizeof(struct rfc3329_store_data)))) {
+
+		store_data->last_rx_status_code = rdata->msg_info.msg->line.status.code;
+		datastore->data = store_data;
+		ast_sip_session_add_datastore(session, datastore);
+	} else {
+		ast_log(AST_LOG_WARNING, "Could not store session data. Still attempting requests, but they might be missing necessary headers.\n");
 	}
 
 	header = pjsip_msg_find_hdr_by_name(rdata->msg_info.msg, &str_security_server, NULL);
@@ -73,12 +106,14 @@ out:
 	ao2_cleanup(contact_status);
 }
 
-static void add_outgoing_request_headers(struct ast_sip_endpoint *endpoint, struct ast_sip_contact *contact, struct pjsip_tx_data *tdata)
+static void add_outgoing_request_headers(struct ast_sip_endpoint *endpoint, struct ast_sip_contact *contact, struct pjsip_tx_data *tdata,
+	struct ast_datastore *datastore)
 {
 	static const pj_str_t security_verify = { "Security-Verify", 15 };
 	struct pjsip_generic_string_hdr *hdr = NULL;
 	struct ast_sip_contact_status *contact_status = NULL;
-
+	struct rfc3329_store_data *store_data;
+	
 	if (endpoint->security_negotiation != AST_SIP_SECURITY_NEG_MEDIASEC) {
 		return;
 	}
@@ -94,23 +129,26 @@ static void add_outgoing_request_headers(struct ast_sip_endpoint *endpoint, stru
 	if (AST_VECTOR_SIZE(&contact_status->security_mechanisms) && hdr == NULL) {
 		/* Add Security-Verify headers (with q-value) */
 		ast_sip_add_security_headers(&contact_status->security_mechanisms, "Security-Verify", 0, tdata);
-	} else if (!hdr && AST_VECTOR_SIZE(&endpoint->security_mechanisms)) {
-		/* Add Security-Client headers (no q-value) */
-		ast_sip_add_security_headers(&endpoint->security_mechanisms, "Security-Client", 0, tdata);
+	}
+	if (datastore) {
+		store_data = datastore->data;
+		if (store_data->last_rx_status_code == 401) {
+			/* Add Security-Client headers (no q-value) */
+			ast_sip_add_security_headers(&endpoint->security_mechanisms, "Security-Client", 0, tdata);
+		}
 	}
 	ao2_unlock(contact_status);
-	ast_sip_add_header(tdata, "Require", "mediasec");
-	ast_sip_add_header(tdata, "Proxy-Require", "mediasec");
 
 	ao2_cleanup(contact_status);
 }
 
 static void rfc3329_outgoing_request(struct ast_sip_session *session, struct pjsip_tx_data *tdata)
 {
+	RAII_VAR(struct ast_datastore *, datastore, ast_sip_session_get_datastore(session, "rfc3329_store"), ao2_cleanup);
 	if (session->contact == NULL) {
 		return;
 	}
-	add_outgoing_request_headers(session->endpoint, session->contact, tdata);
+	add_outgoing_request_headers(session->endpoint, session->contact, tdata, datastore);
 }
 
 static struct ast_sip_session_supplement rfc3329_supplement = {
@@ -120,7 +158,7 @@ static struct ast_sip_session_supplement rfc3329_supplement = {
 
 static void rfc3329_options_request(struct ast_sip_endpoint *endpoint, struct ast_sip_contact *contact, struct pjsip_tx_data *tdata)
 {
-	add_outgoing_request_headers(endpoint, contact, tdata);
+	add_outgoing_request_headers(endpoint, contact, tdata, NULL);
 }
 
 static struct ast_sip_supplement rfc3329_options_supplement = {
@@ -138,10 +176,11 @@ static int load_module(void)
 static int unload_module(void)
 {
 	ast_sip_session_unregister_supplement(&rfc3329_supplement);
+	ast_sip_unregister_supplement(&rfc3329_options_supplement);
 	return 0;
 }
 
-AST_MODULE_INFO(ASTERISK_GPL_KEY, AST_MODFLAG_LOAD_ORDER, "PJSIP RFC 3329 Support (partial)",
+AST_MODULE_INFO(ASTERISK_GPL_KEY, AST_MODFLAG_LOAD_ORDER, "PJSIP RFC3329 Support (partial)",
 	.support_level = AST_MODULE_SUPPORT_CORE,
 	.load = load_module,
 	.unload = unload_module,


### PR DESCRIPTION
When using mediasec, requests sent after a 401 must still contain the
Security-Client header according to
draft-dawes-sipcore-mediasec-parameter.

Resolves: #48
