### PR TITLE
cel: add local optimization begin event

### DIFF
--- a/include/asterisk/cel.h
+++ b/include/asterisk/cel.h
@@ -73,8 +73,10 @@ enum ast_cel_event_type {
 	AST_CEL_PICKUP = 15,
 	/*! \brief this call was forwarded somewhere else  */
 	AST_CEL_FORWARD = 16,
-	/*! \brief A local channel optimization occurred */
+	/*! \brief A local channel optimization occurred, this marks the end */
 	AST_CEL_LOCAL_OPTIMIZE = 17,
+	/*! \brief A local channel optimization has begun */
+	AST_CEL_LOCAL_OPTIMIZE_BEGIN = 18,
 };
 
 /*!


### PR DESCRIPTION
The current AST_CEL_LOCAL_OPTIMIZE event is and has been
triggered on a local optimization end to serve as a flag
indicating the event occurred. This change adds a second
AST_CEL_LOCAL_OPTIMIZE_BEGIN event for further detail.

Resolves: https://github.com/asterisk/asterisk/issues/52

UpgradeNote: The existing AST_CEL_LOCAL_OPTIMIZE can continue
to be used as-is and the AST_CEL_LOCAL_OPTIMIZE_BEGIN event
can be ignored if desired.

UserNote: The new AST_CEL_LOCAL_OPTIMIZE_BEGIN can be used
by itself or in concert with the existing
AST_CEL_LOCAL_OPTIMIZE to book-end local channel optimization.