### PR TITLE
chan_pjsip: Allow topology/session refreshes in early media state

### DIFF
--- a/include/asterisk/res_pjsip_session.h
+++ b/include/asterisk/res_pjsip_session.h
@@ -231,6 +231,8 @@ struct ast_sip_session {
 	unsigned int ended_while_deferred:1;
 	/*! Whether to pass through hold and unhold using re-invites with recvonly and sendrecv */
 	unsigned int moh_passthrough:1;
+	/*! Whether early media state has been confirmed through PRACK */
+	unsigned int early_confirmed:1;
 	/*! DTMF mode to use with this session, from endpoint but can change */
 	enum ast_sip_dtmf_mode dtmf;
 	/*! Initial incoming INVITE Request-URI.  NULL otherwise. */


### PR DESCRIPTION
With this change, session modifications in the early media state are
possible if the SDP was sent reliably and confirmed by a PRACK. For
details, see RFC 6337, escpecially section 3.2.

Resolves: #73
