### PR TITLE
configure: fix test code to match gethostbyname_r prototype.

### DIFF
--- a/configure
+++ b/configure
@@ -17537,7 +17537,7 @@ $as_echo_n "checking for gethostbyname_r with 6 arguments... " >&6; }
 int
 main ()
 {
-struct hostent *he = gethostbyname_r((const char *)NULL, (struct hostent *)NULL, (char *)NULL, (int)0, (struct hostent **)NULL, (int *)NULL);
+int r = gethostbyname_r((const char *)NULL, (struct hostent *)NULL, (char *)NULL, (int)0, (struct hostent **)NULL, (int *)NULL);
   ;
   return 0;
 }
@@ -17565,7 +17565,7 @@ $as_echo_n "checking for gethostbyname_r with 5 arguments... " >&6; }
 int
 main ()
 {
-struct hostent *he = gethostbyname_r((const char *)NULL, (struct hostent *)NULL, (char *)NULL, (int)0, (int *)NULL);
+int r = gethostbyname_r((const char *)NULL, (struct hostent *)NULL, (char *)NULL, (int)0, (int *)NULL);
   ;
   return 0;
 }

--- a/configure.ac
+++ b/configure.ac
@@ -962,7 +962,7 @@ if test "x$have_gethostbyname_r_public_declaration" = "xyes"; then
         AC_LINK_IFELSE(
                 [AC_LANG_PROGRAM([#include <stdlib.h>
                                  #include <netdb.h>],
-                                [struct hostent *he = gethostbyname_r((const char *)NULL, (struct hostent *)NULL, (char *)NULL, (int)0, (struct hostent **)NULL, (int *)NULL);])],
+                                [int r = gethostbyname_r((const char *)NULL, (struct hostent *)NULL, (char *)NULL, (int)0, (struct hostent **)NULL, (int *)NULL);])],
                 AC_MSG_RESULT(yes)
                 AC_DEFINE([HAVE_GETHOSTBYNAME_R_6], 1, [Define to 1 if your system has gethostbyname_r with 6 arguments.]),
                 AC_MSG_RESULT(no)
@@ -972,7 +972,7 @@ if test "x$have_gethostbyname_r_public_declaration" = "xyes"; then
         AC_LINK_IFELSE(
                 [AC_LANG_PROGRAM([#include <stdlib.h>
 	                         #include <netdb.h>],
-                                [struct hostent *he = gethostbyname_r((const char *)NULL, (struct hostent *)NULL, (char *)NULL, (int)0, (int *)NULL);])],
+                                [int r = gethostbyname_r((const char *)NULL, (struct hostent *)NULL, (char *)NULL, (int)0, (int *)NULL);])],
                 AC_MSG_RESULT(yes)
                 AC_DEFINE([HAVE_GETHOSTBYNAME_R_5], 1, [Define to 1 if your system has gethostbyname_r with 5 arguments.]),
                 AC_MSG_RESULT(no)


### PR DESCRIPTION
This enables the test to work with CC=clang.

Without this the test for 6 args would fail with:

utils.c:99:12: error: static declaration of 'gethostbyname_r' follows non-static declaration static int gethostbyname_r (const char *name, struct hostent *ret, char *buf,
           ^
/usr/include/netdb.h:177:12: note: previous declaration is here extern int gethostbyname_r (const char *__restrict __name,
           ^

Fixing the expected return type to int sorts this out.