### PR TITLE
res_pjsip_pubsub.c: Use pjsip version for pending NOTIFY check.

### DIFF
--- a/configure
+++ b/configure
@@ -929,10 +929,6 @@ PBX_POPT
 POPT_DIR
 POPT_INCLUDE
 POPT_LIB
-PBX_PJSIP_EVSUB_PENDING_NOTIFY
-PJSIP_EVSUB_PENDING_NOTIFY_DIR
-PJSIP_EVSUB_PENDING_NOTIFY_INCLUDE
-PJSIP_EVSUB_PENDING_NOTIFY_LIB
 PBX_PJSIP_TLS_TRANSPORT_RESTART
 PJSIP_TLS_TRANSPORT_RESTART_DIR
 PJSIP_TLS_TRANSPORT_RESTART_INCLUDE
@@ -10303,9 +10299,6 @@ $as_echo "#define HAVE_PJPROJECT_ON_VALID_ICE_PAIR_CALLBACK 1" >>confdefs.h
 $as_echo "#define HAVE_PJSIP_TLS_TRANSPORT_RESTART 1" >>confdefs.h
 
 
-$as_echo "#define HAVE_PJSIP_EVSUB_PENDING_NOTIFY 1" >>confdefs.h
-
-
 
 
 
@@ -12451,18 +12444,6 @@ PJSIP_TLS_TRANSPORT_RESTART_OPTION=pjsip
 PJSIP_TLS_TRANSPORT_RESTART_DIR=${PJPROJECT_DIR}
 
 PBX_PJSIP_TLS_TRANSPORT_RESTART=0
-
-
-
-
-
-
-
-PJSIP_EVSUB_PENDING_NOTIFY_DESCRIP="PJSIP NOTIFY Required on SUBSCRIBE"
-PJSIP_EVSUB_PENDING_NOTIFY_OPTION=pjsip
-PJSIP_EVSUB_PENDING_NOTIFY_DIR=${PJPROJECT_DIR}
-
-PBX_PJSIP_EVSUB_PENDING_NOTIFY=0
 
 
 
@@ -27102,20 +27083,6 @@ _ACEOF
 fi
 
 
-
-      	 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for pending_notify in evsub.c" >&5
-		   $as_echo_n "checking for pending_notify in evsub... " >&6; }
-		 pending_notify=$(${SED} -n -r -e '/^struct\s+pjsip_evsub/,/^\s+void\s+*mod_data/!d ; /pending_notify/p' $(find $PJSIP_EVSUB_PENDING_NOTIFY_DIR -name evsub.c))
-		 if test -n "$pending_notify" ; then
-
-$as_echo "#define HAVE_PJSIP_EVSUB_PENDING_NOTIFY 1" >>confdefs.h
-
-			{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-			  $as_echo "yes" >&6; }
-		 else
-			{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-			  $as_echo "no" >&6; }
-		 fi
       fi
    fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -594,7 +594,6 @@ AST_EXT_LIB_SETUP_OPTIONAL([PJSIP_ENDPOINT_COMPACT_FORM], [PJSIP Compact Form Su
 AST_EXT_LIB_SETUP_OPTIONAL([PJSIP_TRANSPORT_DISABLE_CONNECTION_REUSE], [PJSIP Transport Connection Reuse Disabling], [PJPROJECT], [pjsip])
 AST_EXT_LIB_SETUP_OPTIONAL([PJSIP_OAUTH_AUTHENTICATION], [PJSIP OAuth Authentication Support], [PJPROJECT], [pjsip])
 AST_EXT_LIB_SETUP_OPTIONAL([PJSIP_TLS_TRANSPORT_RESTART], [PJSIP TLS Transport Restart Support], [PJPROJECT], [pjsip])
-AST_EXT_LIB_SETUP_OPTIONAL([PJSIP_EVSUB_PENDING_NOTIFY], [PJSIP NOTIFY Required on SUBSCRIBE], [PJPROJECT], [pjsip])
 fi
 
 AST_EXT_LIB_SETUP([POPT], [popt], [popt])
@@ -2538,18 +2537,6 @@ if test "$USE_PJPROJECT" != "no" ; then
          AST_EXT_LIB_CHECK([PJSIP_AUTH_CLT_DEINIT], [pjsip], [pjsip_auth_clt_deinit], [pjsip.h], [$PJPROJECT_LIB], [$PJPROJECT_CFLAGS])
          AST_EXT_LIB_CHECK([PJSIP_TSX_LAYER_FIND_TSX2], [pjsip], [pjsip_tsx_layer_find_tsx2], [pjsip.h], [$PJPROJECT_LIB], [$PJPROJECT_CFLAGS])
          AST_EXT_LIB_CHECK([PJSIP_TLS_TRANSPORT_RESTART], [pjsip], [pjsip_tls_transport_restart], [pjsip.h], [$PJPROJECT_LIB], [$PJPROJECT_CFLAGS])
-
-      	 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for pending_notify in evsub.c" >&5
-		   $as_echo_n "checking for pending_notify in evsub... " >&6; }
-		 pending_notify=$(${SED} -n -r -e '/^struct\s+pjsip_evsub/,/^\s+void\s+*mod_data/!d ; /pending_notify/p' $(find $PJSIP_EVSUB_PENDING_NOTIFY_DIR -name evsub.c))
-		 if test -n "$pending_notify" ; then
-		 	AC_DEFINE(HAVE_PJSIP_EVSUB_PENDING_NOTIFY, 1, [Define to 1 if evsub requires a NOTIFY on SUBSCRIBE.])
-			{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-			  $as_echo "yes" >&6; }
-		 else
-			{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-			  $as_echo "no" >&6; }
-		 fi
       fi
    fi
 

--- a/include/asterisk/autoconfig.h.in
+++ b/include/asterisk/autoconfig.h.in
@@ -650,9 +650,6 @@
 /* Define to 1 if PJPROJECT has the PJSIP EVSUB Group Lock support feature. */
 #undef HAVE_PJSIP_EVSUB_GRP_LOCK
 
-/* Define to 1 if evsub requires a NOTIFY on SUBSCRIBE. */
-#undef HAVE_PJSIP_EVSUB_PENDING_NOTIFY
-
 /* Define to 1 if PJPROJECT has the PJSIP External Resolver Support feature.
    */
 #undef HAVE_PJSIP_EXTERNAL_RESOLVER

--- a/res/res_pjsip_pubsub.c
+++ b/res/res_pjsip_pubsub.c
@@ -3890,6 +3890,11 @@ static void clean_sub_tree(pjsip_evsub *evsub){
 	ao2_ref(sub_tree, -1);
 }
 
+/* This functionality appeared in pjsip 2.13 */
+#if PJ_VERSION_NUM >= 0x020D0000
+# define HAVE_PJSIP_EVSUB_PENDING_NOTIFY 1
+#endif
+
 /*!
  * \brief PJSIP callback when underlying SIP subscription changes state
  *

--- a/third-party/pjproject/configure.m4
+++ b/third-party/pjproject/configure.m4
@@ -136,7 +136,6 @@ AC_DEFUN([_PJPROJECT_CONFIGURE],
 		AC_DEFINE([HAVE_PJSIP_OAUTH_AUTHENTICATION], 1, [Define if your system has HAVE_PJSIP_OAUTH_AUTHENTICATION declared])
 		AC_DEFINE([HAVE_PJPROJECT_ON_VALID_ICE_PAIR_CALLBACK], 1, [Define if your system has the on_valid_pair pjnath callback.])
 		AC_DEFINE([HAVE_PJSIP_TLS_TRANSPORT_RESTART], 1, [Define if your system has pjsip_tls_transport_restart support.])
-		AC_DEFINE([HAVE_PJSIP_EVSUB_PENDING_NOTIFY], 1, [Define to 1 if evsub requires a NOTIFY on SUBSCRIBE.])
 
 		AC_SUBST([PJPROJECT_BUNDLED])
 		AC_SUBST([PJPROJECT_BUNDLED_OOT])


### PR DESCRIPTION
The functionality we are interested in is present only in pjsip 2.13 and newer.

Resolves: #45