### PR TITLE
sig_analog: Add fuller Caller ID support.

### DIFF
--- a/channels/sig_analog.c
+++ b/channels/sig_analog.c
@@ -1073,6 +1073,8 @@ int analog_call(struct analog_pvt *p, struct ast_channel *ast, const char *rdest
 			}
 
 		}
+
+		/* Name and Number */
 		n = ast_channel_connected(ast)->id.name.valid ? ast_channel_connected(ast)->id.name.str : NULL;
 		l = ast_channel_connected(ast)->id.number.valid ? ast_channel_connected(ast)->id.number.str : NULL;
 		if (l) {
@@ -1087,12 +1089,25 @@ int analog_call(struct analog_pvt *p, struct ast_channel *ast, const char *rdest
 		}
 
 		if (p->use_callerid) {
+			const char *qual_var;
+
+			/* Caller ID Name and Number */
 			p->caller.id.name.str = p->lastcid_name;
 			p->caller.id.number.str = p->lastcid_num;
 			p->caller.id.name.valid = ast_channel_connected(ast)->id.name.valid;
 			p->caller.id.number.valid = ast_channel_connected(ast)->id.number.valid;
 			p->caller.id.name.presentation = ast_channel_connected(ast)->id.name.presentation;
 			p->caller.id.number.presentation = ast_channel_connected(ast)->id.number.presentation;
+
+			/* Redirecting Reason */
+			p->redirecting_reason = ast_channel_redirecting(ast)->from.number.valid ? ast_channel_redirecting(ast)->reason.code : -1;
+
+			/* Call Qualifier */
+			ast_channel_lock(ast);
+			/* XXX In the future, we may want to make this a CALLERID or CHANNEL property and fetch it from there. */
+			qual_var = pbx_builtin_getvar_helper(ast, "CALL_QUALIFIER");
+			p->call_qualifier = ast_true(qual_var) ? 1 : 0;
+			ast_channel_unlock(ast);
 		}
 
 		ast_setstate(ast, AST_STATE_RINGING);

--- a/channels/sig_analog.h
+++ b/channels/sig_analog.h
@@ -342,12 +342,15 @@ struct analog_pvt {
 	 * gives a positive reply.
 	 */
 	unsigned int callwaitcas:1;
+	unsigned int call_qualifier:1;	/*!< Call qualifier delivery */
 
 	char callwait_num[AST_MAX_EXTENSION];
 	char callwait_name[AST_MAX_EXTENSION];
 	char lastcid_num[AST_MAX_EXTENSION];
 	char lastcid_name[AST_MAX_EXTENSION];
 	struct ast_party_caller caller;
+	int redirecting_reason;			/*!< Redirecting reason */
+
 	int cidrings;					/*!< Which ring to deliver CID on */
 	char echorest[20];
 	int polarity;

--- a/configs/samples/chan_dahdi.conf.sample
+++ b/configs/samples/chan_dahdi.conf.sample
@@ -572,6 +572,15 @@ context=public
 ;
 usecallerid=yes
 ;
+; NOTE: If the CALL_QUALIFIER variable on the channel is set to 1,
+; the Stentor Call Qualifier parameter will be sent for Caller ID spills
+; using the Multiple Data Message Format (MDMF).
+; This is used by capable Caller ID units to activate the
+; "LDC" (Long Distance Call) indicator.
+; This variable is not automatically set anywhere. You are responsible
+; for setting it in the dialplan if you want to activate the indicator,
+; and you must have compatible CPE.
+;
 ; Type of caller ID signalling in use
 ;     bell     = bell202 as used in US (default)
 ;     v23      = v23 as used in the UK

--- a/funcs/func_callerid.c
+++ b/funcs/func_callerid.c
@@ -182,6 +182,21 @@
 					<para>Number Unavailable.</para>
 				</enum>
 			</enumlist>
+			<variablelist>
+				<variable name="CALL_QUALIFIER">
+					<para>This is a special Caller ID-related variable
+					that can be used to enable sending the Call Qualifier
+					parameter in MDMF (Multiple Data Message Format)
+					Caller ID spills.</para>
+					<para>This variable is not automatically set by Asterisk.
+					You are responsible for setting it if/when needed.</para>
+					<para>Supporting Caller ID units will display the LDC
+					(Long Distance Call) indicator when they receive this parameter.</para>
+					<para>This option must be used with a channel driver
+					that allows Asterisk to generate the Caller ID spill,
+					which currently only includes <literal>chan_dahdi</literal>.</para>
+				</variable>
+			</variablelist>
 		</description>
 	</function>
 	<function name="CONNECTEDLINE" language="en_US">


### PR DESCRIPTION
A previous change, ASTERISK_29991, made it possible to send additional Caller ID parameters that were
not previously supported.

This change adds support for analog DAHDI channels to now be able to receive these parameters for
on-hook Caller ID, in order to enhance the usability of CPE that support these parameters.

Resolves: #94
ASTERISK-30331

UserNote: Additional Caller ID properties are now supported on incoming calls to FXS stations, namely the
redirecting reason and call qualifier.

Imported from Gerrit: https://gerrit.asterisk.org/c/asterisk/+/19601