### PR TITLE
logrotate: Fix duplicate log entries.

### DIFF
--- a/contrib/scripts/asterisk.logrotate
+++ b/contrib/scripts/asterisk.logrotate
@@ -1,13 +1,13 @@
-__LOGDIR__/debug.log __LOGDIR__/console __LOGDIR__/full.log __LOGDIR__/messages.log __LOGDIR__/*log {
+__LOGDIR__/*.log __LOGDIR__/queue_log __LOGDIR__/mmlog {
 	weekly
 	missingok
 	rotate 52
 	compress
 	delaycompress
 	notifempty
-	create 640 root root 
+	create 640 root root
 	sharedscripts
 	postrotate
-		__SBINDIR__/asterisk -rx 'logger reload' > /dev/null 2> /dev/null	
+		__SBINDIR__/asterisk -rx 'logger reload' > /dev/null 2> /dev/null
 	endscript
-} 
+}


### PR DESCRIPTION
The Asterisk logrotate script contains explicit
references to files with the .log extension,
which are also included when *log is expanded.
This causes issues with newer versions of logrotate. This fixes this by ensuring that a log file cannot be referenced multiple times after expansion occurs.

Resolves: #96
ASTERISK-30442
Reported by: EN Barnett
Tested by: EN Barnett

Imported from Gerrit: https://gerrit.asterisk.org/c/asterisk/+/19929