### PR TITLE
callerid: Allow specifying timezone for date/time.

### DIFF
--- a/include/asterisk/callerid.h
+++ b/include/asterisk/callerid.h
@@ -129,6 +129,26 @@ int callerid_generate(unsigned char *buf, const char *number, const char *name,	
 int callerid_full_generate(unsigned char *buf, const char *number, const char *name, const char *ddn, int redirecting,
 	int flags, int format, int callwaiting, struct ast_format *codec);
 
+/*! \brief Generates a CallerID FSK stream in ulaw format suitable for transmission.
+ * \param buf Buffer to use. If "buf" is supplied, it will use that buffer instead of allocating its own.
+ *   "buf" must be at least 32000 bytes in size of you want to be sure you don't have an overrun.
+ * \param number Use NULL for no number or "P" for "private"
+ * \param name name to be used
+ * \param ddn Dialable Directory Number (or NULL)
+ * \param redirecting Redirecting reason
+ * \param flags passed flags
+ * \param format Message format
+ * \param callwaiting callwaiting flag
+ * \param codec -- either AST_FORMAT_ULAW or AST_FORMAT_ALAW
+ * \param tz TZ-format time zone to use for date/time (NULL for system default)
+ * \details
+ * This function creates a stream of callerid (a callerid spill) data in ulaw format.
+ * \return It returns the size
+ * (in bytes) of the data (if it returns a size of 0, there is probably an error)
+ */
+int callerid_full_tz_generate(unsigned char *buf, const char *number, const char *name, const char *ddn, int redirecting,
+	int flags, int format, int callwaiting, struct ast_format *codec, const char *tz);
+
 /*! \brief Create a callerID state machine
  * \param cid_signalling Type of signalling in use
  *
@@ -220,6 +240,24 @@ int ast_callerid_generate(unsigned char *buf, const char *name, const char *numb
 int ast_callerid_full_generate(unsigned char *buf, const char *name, const char *number,
 	const char *ddn, int redirecting, int pres, int qualifier, int format, struct ast_format *codec);
 
+/*! \brief Generate Caller-ID spill from the "callerid" field of asterisk (in e-mail address like format)
+ * \param buf buffer for output samples. See callerid_generate() for details regarding buffer.
+ * \param name Caller-ID Name
+ * \param number Caller-ID Number
+ * \param ddn Dialable Directory Number (or NULL)
+ * \param redirecting Redirecting Reason (-1 if N/A)
+ * \param pres Presentation (0 for default)
+ * \param qualifier Call Qualifier (0 for no, 1 for yes)
+ * \param format Message Format
+ * \param codec Asterisk codec (either AST_FORMAT_ALAW or AST_FORMAT_ULAW)
+ * \param tz TZ-format time zone name to use for date/time (NULL for system default)
+ *
+ * \details
+ * Like ast_callerid_generate but with additional parameters.
+ */
+int ast_callerid_full_tz_generate(unsigned char *buf, const char *name, const char *number,
+	const char *ddn, int redirecting, int pres, int qualifier, int format, struct ast_format *codec, const char *tz);
+
 /*!
  * \brief Generate message waiting indicator
  * \param buf
@@ -246,6 +284,13 @@ int ast_callerid_callwaiting_generate(unsigned char *buf, const char *name, cons
  */
 int ast_callerid_callwaiting_full_generate(unsigned char *buf, const char *name, const char *number,
 	const char *ddn, int redirecting, int pres, int qualifier, struct ast_format *codec);
+
+/*! \brief Generate Caller-ID spill but in a format suitable for Call Waiting(tm)'s Caller*ID(tm)
+ * \param tz TZ-format time zone for date/time (NULL for system default)
+ * \see ast_callerid_generate() for other details
+ */
+int ast_callerid_callwaiting_full_tz_generate(unsigned char *buf, const char *name, const char *number,
+	const char *ddn, int redirecting, int pres, int qualifier, struct ast_format *codec, const char *tz);
 
 /*! \brief Destructively parse inbuf into name and location (or number)
  * \details


### PR DESCRIPTION
The Caller ID generation routine currently is hardcoded to always use the system time zone. This makes it possible to optionally specify any TZ-format time zone.

Resolves: #98
ASTERISK-30330

Imported from: https://gerrit.asterisk.org/c/asterisk/+/19600