### PR TITLE
chan_dahdi: Fix broken hidecallerid setting.

### DIFF
--- a/channels/chan_dahdi.c
+++ b/channels/chan_dahdi.c
@@ -13178,7 +13178,8 @@ static struct dahdi_pvt *mkintf(int channel, const struct dahdi_chan_conf *conf,
 				analog_p->canpark = conf->chan.canpark;
 				analog_p->dahditrcallerid = conf->chan.dahditrcallerid;
 				analog_p->immediate = conf->chan.immediate;
-				analog_p->permhidecallerid = conf->chan.permhidecallerid;
+				analog_p->permhidecallerid = conf->chan.hidecallerid; /* hidecallerid is the config setting, not permhidecallerid (~permcallwaiting above) */
+				/* It's not necessary to set analog_p->hidecallerid here, sig_analog will set hidecallerid=permhidecaller before each call */
 				analog_p->pulse = conf->chan.pulse;
 				analog_p->threewaycalling = conf->chan.threewaycalling;
 				analog_p->transfer = conf->chan.transfer;


### PR DESCRIPTION
The hidecallerid setting in chan_dahdi.conf currently is broken for a couple reasons.

First, the actual code in sig_analog to "allow" or "block" Caller ID depending on this setting improperly used ast_set_callerid instead of updating the presentation. This issue was mostly fixed in ASTERISK_29991, and that fix is carried forward to this code as well.

Secondly, the hidecallerid setting is set on the DAHDI pvt but not carried forward to the analog pvt properly. This is because the chan_dahdi config loading code improperly set permhidecallerid to permhidecallerid from the config file, even though hidecallerid is what is actually set from the config file. (This is done correctly for call waiting, a few lines above.) This is fixed to read the proper value.

Thirdly, in sig_analog, hidecallerid is set to permhidecallerid only on hangup. This can lead to potential security vulnerabilities as an allowed Caller ID from an initial call can "leak" into subsequent calls if no hangup occurs between them. This is fixed by setting hidecallerid to permcallerid when calls begin, rather than when they end. This also means we don't need to also set hidecallerid in chan_dahdi.c when copying from the config, as we would have to otherwise.

Fourthly, sig_analog currently only allows dialing *67 or *82 if that would actually toggle the presentation. A comment is added clarifying that this behavior is okay.

Finally, a couple log messages are updated to be more accurate.

Resolves: #100
ASTERISK-30349 #close
Imported from Gerrit: https://gerrit.asterisk.org/c/asterisk/+/19707