### PR TITLE
asterisk.c: Fix option warning for remote console.

### DIFF
--- a/doc/asterisk.8
+++ b/doc/asterisk.8
@@ -196,8 +196,7 @@ then move them into the final location when done.
 .TP
 \-T
 Add timestamp to all non-command related output going to the console
-when running with verbose and/or logging to the console. Can only be
-used at startup (e.g. not with remote console mode).
+when running with verbose and/or logging to the console.
 .TP
 \-U \fIuser\fR
 Run as user \fIuser\fR instead of the

--- a/main/asterisk.c
+++ b/main/asterisk.c
@@ -3755,6 +3755,7 @@ int main(int argc, char *argv[])
 			case 'r': /* remote */
 			/*! \note Can ONLY be used with remote console */
 			case 's': /* set socket path */
+			case 'T': /* timestamp */
 			case 'V': /* version */
 			case 'v': /* verbose */
 			case 'W': /* white background */
@@ -3772,7 +3773,6 @@ int main(int argc, char *argv[])
 			case 'i': /* init keys */
 			case 'n': /* no color */
 			case 'p': /* high priority */
-			case 'T': /* timestamp */
 			case 't': /* cache record files */
 			case 'U': /* run user */
 				fprintf(stderr, "'%c' option is not compatible with remote console mode and has no effect.\n", c);


### PR DESCRIPTION
Commit 09e989f972e2583df4e9bf585c246c37322d8d2f
categorized the T option as not being compatible
with remote consoles, but they do affect verbose
messages with remote console. This fixes this.

Resolves: #102