### PR TITLE
Introduces new parameter tech2 for HANGUPCAUSE() function and modifies res_pjsip_rfc3326 to store Reason header in it

### DIFF
--- a/funcs/func_hangupcause.c
+++ b/funcs/func_hangupcause.c
@@ -52,6 +52,7 @@
 				<para>Parameter describing which type of information is requested. Types are:</para>
 				<enumlist>
 					<enum name="tech"><para>Technology-specific cause information</para></enum>
+					<enum name="tech2"><para>Additional technology specific cause information</para></enum>
 					<enum name="ast"><para>Translated Asterisk cause code</para></enum>
 				</enumlist>
 			</parameter>
@@ -112,7 +113,7 @@ static int hangupcause_read(struct ast_channel *chan, const char *cmd, char *dat
 	int res = 0;
 	AST_DECLARE_APP_ARGS(args,
 		AST_APP_ARG(channel);	/*!< Channel name */
-		AST_APP_ARG(type);	/*!< Type of information requested (ast or tech) */
+		AST_APP_ARG(type);	/*!< Type of information requested (ast or tech or tech2) */
 		);
 
 	/* Ensure that the buffer is empty */
@@ -143,6 +144,10 @@ static int hangupcause_read(struct ast_channel *chan, const char *cmd, char *dat
 		ast_copy_string(buf, ast_cause2str(cause_code->ast_cause), len);
 	} else if (!strcmp(args.type, "tech")) {
 		ast_copy_string(buf, cause_code->code, len);
+	} else if (!strcmp(args.type, "tech2")) {
+		if (cause_code->tech2_offset) {
+			ast_copy_string(buf, cause_code->code + cause_code->tech2_offset, len);
+		}
 	} else {
 		ast_log(LOG_WARNING, "Information type not recognized (%s)\n", args.type);
 		res = -1;

--- a/include/asterisk/frame.h
+++ b/include/asterisk/frame.h
@@ -414,6 +414,7 @@ struct ast_control_pvt_cause_code {
 	char chan_name[AST_CHANNEL_NAME];	/*!< Name of the channel that originated the cause information */
 	unsigned int emulate_sip_cause:1;	/*!< Indicates whether this should be used to emulate SIP_CAUSE support */
 	int ast_cause;				/*!< Asterisk cause code associated with this message */
+	unsigned int tech2_offset;		/*!< Offset of second string in .code. If zero second string not present */
 	char code[1];				/*!< Tech-specific cause code information, beginning with the name of the tech */
 };
 


### PR DESCRIPTION
New field tech2_offset is added to struct ast_control_pvt_cause_code. It allows to store 2 strings in struct field 'code'.
If tech2_offset > 0 second string starts on that offset, otherwise second string is not present.
Dialplan function HANGUPCAUSE() is modified to accept parameter value 'tech2' and return the second string from proper
ast_control_pvt_cause_code structure.
res_pjsip_rfc3326.c is updated to store Reason headers in the second string of struct ast_control_pvt_cause_code and
also add processing of preemption Reason headers described in RFC4411

Resolves: #112
