### PR TITLE
app_chanspy: Refactor arguments to allow splitting large functions

### DIFF
--- a/apps/app_chanspy.c
+++ b/apps/app_chanspy.c
@@ -504,7 +504,7 @@ static struct ast_generator spygen = {
 	.generate = spy_generate,
 };
 
-static int start_spying(struct ast_autochan *autochan, const char *spychan_name, struct ast_audiohook *audiohook, struct ast_flags *flags)
+static int start_spying(struct ast_autochan *autochan, const char *spychan_name, struct ast_audiohook *audiohook, const struct ast_flags *flags)
 {
 	int res;
 
@@ -638,8 +638,8 @@ static int attach_barge(struct ast_autochan *spyee_autochan,
 }
 
 static int channel_spy(struct ast_channel *chan, struct ast_autochan *spyee_autochan,
-	int *volfactor, int fd, struct spy_dtmf_options *user_options, struct ast_flags *flags,
-	char *exitcontext)
+	int *volfactor, int fd, const struct spy_dtmf_options *user_options, struct ast_flags *flags,
+	const char *exitcontext)
 {
 	struct chanspy_translation_helper csth;
 	int running = 0, bridge_connected = 0, res, x = 0;
@@ -889,15 +889,23 @@ static int spy_sayname(struct ast_channel *chan, const char *mailbox, const char
 	return ast_app_sayname(chan, mailbox_id);
 }
 
+struct channel_spy_context {
+	const char *mygroup;
+	const char *myenforced;
+	const char *spec;
+	const char *exten;
+	const char *context;
+	const char *mailbox;
+	const char *name_context;
+};
+
 static int common_exec(struct ast_channel *chan, struct ast_flags *flags,
 	int volfactor, const int fd, struct spy_dtmf_options *user_options,
-	const char *mygroup, const char *myenforced, const char *spec, const char *exten,
-	const char *context, const char *mailbox, const char *name_context)
+	const struct channel_spy_context *ctx)
 {
-	char nameprefix[AST_NAME_STRLEN];
 	char exitcontext[AST_MAX_CONTEXT] = "";
 	signed char zero_volume = 0;
-	int waitms;
+	const int waitms = 100;
 	int res;
 	int num_spied_upon = 1;
 	struct ast_channel_iterator *iter = NULL;
@@ -918,7 +926,6 @@ static int common_exec(struct ast_channel *chan, struct ast_flags *flags,
 
 	ast_channel_set_flag(chan, AST_FLAG_SPYING);
 
-	waitms = 100;
 
 	for (;;) {
 		struct ast_autochan *autochan = NULL, *next_autochan = NULL;
@@ -944,11 +951,11 @@ static int common_exec(struct ast_channel *chan, struct ast_flags *flags,
 		}
 
 		/* Set up the iterator we'll be using during this call */
-		if (!ast_strlen_zero(spec)) {
+		if (!ast_strlen_zero(ctx->spec)) {
 			if (ast_test_flag(flags, OPTION_UNIQUEID)) {
 				struct ast_channel *unique_chan;
 
-				unique_chan = ast_channel_get_by_name(spec);
+				unique_chan = ast_channel_get_by_name(ctx->spec);
 				if (!unique_chan) {
 					res = -1;
 					goto exit;
@@ -956,10 +963,10 @@ static int common_exec(struct ast_channel *chan, struct ast_flags *flags,
 				iter = ast_channel_iterator_by_name_new(ast_channel_name(unique_chan), 0);
 				ast_channel_unref(unique_chan);
 			} else {
-				iter = ast_channel_iterator_by_name_new(spec, strlen(spec));
+				iter = ast_channel_iterator_by_name_new(ctx->spec, strlen(ctx->spec));
 			}
-		} else if (!ast_strlen_zero(exten)) {
-			iter = ast_channel_iterator_by_exten_new(exten, context);
+		} else if (!ast_strlen_zero(ctx->exten)) {
+			iter = ast_channel_iterator_by_exten_new(ctx->exten, ctx->context);
 		} else {
 			iter = ast_channel_iterator_all_new();
 		}
@@ -987,8 +994,6 @@ static int common_exec(struct ast_channel *chan, struct ast_flags *flags,
 			}
 		}
 
-		/* reset for the next loop around, unless overridden later */
-		waitms = 100;
 		num_spied_upon = 0;
 
 		for (autochan = next_channel(iter, chan);
@@ -997,8 +1002,8 @@ static int common_exec(struct ast_channel *chan, struct ast_flags *flags,
 				ast_autochan_destroy(autochan),
 				autochan = next_autochan ?: next_channel(iter, chan),
 				next_autochan = NULL) {
-			int igrp = !mygroup;
-			int ienf = !myenforced;
+			int igrp = !ctx->mygroup;
+			int ienf = !ctx->myenforced;
 
 			if (autochan->chan == prev) {
 				ast_autochan_destroy(autochan);
@@ -1024,7 +1029,7 @@ static int common_exec(struct ast_channel *chan, struct ast_flags *flags,
 			}
 			ast_autochan_channel_unlock(autochan);
 
-			if (mygroup) {
+			if (ctx->mygroup) {
 				int num_groups = 0;
 				int num_mygroups = 0;
 				char dup_group[512];
@@ -1034,7 +1039,7 @@ static int common_exec(struct ast_channel *chan, struct ast_flags *flags,
 				const char *group = NULL;
 				int x;
 				int y;
-				ast_copy_string(dup_mygroup, mygroup, sizeof(dup_mygroup));
+				ast_copy_string(dup_mygroup, ctx->mygroup, sizeof(dup_mygroup));
 				num_mygroups = ast_app_separate_args(dup_mygroup, ':', mygroups,
 					ARRAY_LEN(mygroups));
 
@@ -1067,12 +1072,12 @@ static int common_exec(struct ast_channel *chan, struct ast_flags *flags,
 			if (!igrp) {
 				continue;
 			}
-			if (myenforced) {
+			if (ctx->myenforced) {
 				char ext[AST_CHANNEL_NAME + 3];
 				char buffer[512];
 				char *end;
 
-				snprintf(buffer, sizeof(buffer) - 1, ":%s:", myenforced);
+				snprintf(buffer, sizeof(buffer) - 1, ":%s:", ctx->myenforced);
 
 				ast_autochan_channel_lock(autochan);
 				ast_copy_string(ext + 1, ast_channel_name(autochan->chan), sizeof(ext) - 1);
@@ -1112,8 +1117,8 @@ static int common_exec(struct ast_channel *chan, struct ast_flags *flags,
 				}
 
 				if (ast_test_flag(flags, OPTION_NAME)) {
-					const char *local_context = S_OR(name_context, "default");
-					const char *local_mailbox = S_OR(mailbox, ptr);
+					const char *local_context = S_OR(ctx->name_context, "default");
+					const char *local_mailbox = S_OR(ctx->mailbox, ptr);
 
 					if (local_mailbox) {
 						res = spy_sayname(chan, local_mailbox, local_context);
@@ -1155,10 +1160,11 @@ static int common_exec(struct ast_channel *chan, struct ast_flags *flags,
 				ast_autochan_destroy(autochan);
 				iter = ast_channel_iterator_destroy(iter);
 				goto exit;
-			} else if (res > 1 && spec && !ast_test_flag(flags, OPTION_UNIQUEID)) {
+			} else if (res > 1 && ctx->spec && !ast_test_flag(flags, OPTION_UNIQUEID)) {
+				char nameprefix[AST_NAME_STRLEN];
 				struct ast_channel *next;
 
-				snprintf(nameprefix, AST_NAME_STRLEN, "%s/%d", spec, res);
+				snprintf(nameprefix, AST_NAME_STRLEN, "%s/%d", ctx->spec, res);
 
 				if ((next = ast_channel_get_by_name_prefix(nameprefix, strlen(nameprefix)))) {
 					next_autochan = ast_autochan_setup(next);
@@ -1200,8 +1206,6 @@ exit:
 
 static int chanspy_exec(struct ast_channel *chan, const char *data)
 {
-	char *myenforced = NULL;
-	char *mygroup = NULL;
 	char *recbase = NULL;
 	int fd = 0;
 	struct ast_flags flags;
@@ -1211,10 +1215,9 @@ static int chanspy_exec(struct ast_channel *chan, const char *data)
 		.exit = '\0',
 	};
 	RAII_VAR(struct ast_format *, oldwf, NULL, ao2_cleanup);
+	struct channel_spy_context ctx = {0};
 	int volfactor = 0;
 	int res;
-	char *mailbox = NULL;
-	char *name_context = NULL;
 	AST_DECLARE_APP_ARGS(args,
 		AST_APP_ARG(spec);
 		AST_APP_ARG(options);
@@ -1224,14 +1227,15 @@ static int chanspy_exec(struct ast_channel *chan, const char *data)
 
 	AST_STANDARD_APP_ARGS(args, parse);
 
-	if (args.spec && !strcmp(args.spec, "all"))
-		args.spec = NULL;
+	if (args.spec && strcmp(args.spec, "all")) {
+		ctx.spec = args.spec;
+	}
 
 	if (args.options) {
 		char tmp;
 		ast_app_parse_options(spy_opts, &flags, opts, args.options);
 		if (ast_test_flag(&flags, OPTION_GROUP))
-			mygroup = opts[OPT_ARG_GROUP];
+			ctx.mygroup = opts[OPT_ARG_GROUP];
 
 		if (ast_test_flag(&flags, OPTION_RECORD) &&
 			!(recbase = opts[OPT_ARG_RECORD]))
@@ -1268,17 +1272,17 @@ static int chanspy_exec(struct ast_channel *chan, const char *data)
 			ast_set_flag(&flags, OPTION_WHISPER);
 
 		if (ast_test_flag(&flags, OPTION_ENFORCED))
-			myenforced = opts[OPT_ARG_ENFORCED];
+			ctx.myenforced = opts[OPT_ARG_ENFORCED];
 
 		if (ast_test_flag(&flags, OPTION_NAME)) {
 			if (!ast_strlen_zero(opts[OPT_ARG_NAME])) {
 				char *delimiter;
 				if ((delimiter = strchr(opts[OPT_ARG_NAME], '@'))) {
-					mailbox = opts[OPT_ARG_NAME];
+					ctx.mailbox = opts[OPT_ARG_NAME];
 					*delimiter++ = '\0';
-					name_context = delimiter;
+					ctx.name_context = delimiter;
 				} else {
-					mailbox = opts[OPT_ARG_NAME];
+					ctx.mailbox = opts[OPT_ARG_NAME];
 				}
 			}
 		}
@@ -1302,7 +1306,7 @@ static int chanspy_exec(struct ast_channel *chan, const char *data)
 		}
 	}
 
-	res = common_exec(chan, &flags, volfactor, fd, &user_options, mygroup, myenforced, args.spec, NULL, NULL, mailbox, name_context);
+	res = common_exec(chan, &flags, volfactor, fd, &user_options, &ctx);
 
 	if (fd)
 		close(fd);
@@ -1319,8 +1323,7 @@ static int chanspy_exec(struct ast_channel *chan, const char *data)
 
 static int extenspy_exec(struct ast_channel *chan, const char *data)
 {
-	char *ptr, *exten = NULL;
-	char *mygroup = NULL;
+	char *ptr;
 	char *recbase = NULL;
 	int fd = 0;
 	struct ast_flags flags;
@@ -1330,10 +1333,9 @@ static int extenspy_exec(struct ast_channel *chan, const char *data)
 		.exit = '\0',
 	};
 	RAII_VAR(struct ast_format *, oldwf, NULL, ao2_cleanup);
+	struct channel_spy_context ctx = {0};
 	int volfactor = 0;
 	int res;
-	char *mailbox = NULL;
-	char *name_context = NULL;
 	AST_DECLARE_APP_ARGS(args,
 		AST_APP_ARG(context);
 		AST_APP_ARG(options);
@@ -1343,12 +1345,13 @@ static int extenspy_exec(struct ast_channel *chan, const char *data)
 	AST_STANDARD_APP_ARGS(args, parse);
 
 	if (!ast_strlen_zero(args.context) && (ptr = strchr(args.context, '@'))) {
-		exten = args.context;
+		ctx.exten = args.context;
 		*ptr++ = '\0';
-		args.context = ptr;
+		ctx.context = ptr;
 	}
-	if (ast_strlen_zero(args.context))
-		args.context = ast_strdupa(ast_channel_context(chan));
+	if (ast_strlen_zero(ctx.context)) {
+		ctx.context = ast_strdupa(ast_channel_context(chan));
+	}
 
 	if (args.options) {
 		char *opts[OPT_ARG_ARRAY_SIZE];
@@ -1356,7 +1359,7 @@ static int extenspy_exec(struct ast_channel *chan, const char *data)
 
 		ast_app_parse_options(spy_opts, &flags, opts, args.options);
 		if (ast_test_flag(&flags, OPTION_GROUP))
-			mygroup = opts[OPT_ARG_GROUP];
+			ctx.mygroup = opts[OPT_ARG_GROUP];
 
 		if (ast_test_flag(&flags, OPTION_RECORD) &&
 			!(recbase = opts[OPT_ARG_RECORD]))
@@ -1396,11 +1399,11 @@ static int extenspy_exec(struct ast_channel *chan, const char *data)
 			if (!ast_strlen_zero(opts[OPT_ARG_NAME])) {
 				char *delimiter;
 				if ((delimiter = strchr(opts[OPT_ARG_NAME], '@'))) {
-					mailbox = opts[OPT_ARG_NAME];
+					ctx.mailbox = opts[OPT_ARG_NAME];
 					*delimiter++ = '\0';
-					name_context = delimiter;
+					ctx.name_context = delimiter;
 				} else {
-					mailbox = opts[OPT_ARG_NAME];
+					ctx.mailbox = opts[OPT_ARG_NAME];
 				}
 			}
 		}
@@ -1426,8 +1429,7 @@ static int extenspy_exec(struct ast_channel *chan, const char *data)
 		}
 	}
 
-
-	res = common_exec(chan, &flags, volfactor, fd, &user_options, mygroup, NULL, NULL, exten, args.context, mailbox, name_context);
+	res = common_exec(chan, &flags, volfactor, fd, &user_options, &ctx);
 
 	if (fd)
 		close(fd);
@@ -1440,23 +1442,24 @@ static int extenspy_exec(struct ast_channel *chan, const char *data)
 
 static int dahdiscan_exec(struct ast_channel *chan, const char *data)
 {
-	const char *spec = "DAHDI";
 	struct ast_flags flags = {0};
 	struct spy_dtmf_options user_options = {
 		.cycle = '#',
 		.volume = '\0',
 		.exit = '*',
 	};
+	struct channel_spy_context ctx = {0};
 	struct ast_format *oldwf;
 	int res;
-	char *mygroup = NULL;
 
 	/* Coverity - This uninit_use should be ignored since this macro initializes the flags */
 	ast_clear_flag(&flags, AST_FLAGS_ALL);
 
 	if (!ast_strlen_zero(data)) {
-		mygroup = ast_strdupa(data);
+		ctx.mygroup = data;
 	}
+	ctx.spec = "DAHDI";
+
 	ast_set_flag(&flags, OPTION_DTMF_EXIT);
 	ast_set_flag(&flags, OPTION_DTMF_CYCLE);
 	ast_set_flag(&flags, OPTION_DAHDI_SCAN);
@@ -1468,7 +1471,7 @@ static int dahdiscan_exec(struct ast_channel *chan, const char *data)
 		return -1;
 	}
 
-	res = common_exec(chan, &flags, 0, 0, &user_options, mygroup, NULL, spec, NULL, NULL, NULL, NULL);
+	res = common_exec(chan, &flags, 0, 0, &user_options, &ctx);
 
 	if (oldwf && ast_set_write_format(chan, oldwf) < 0)
 		ast_log(LOG_ERROR, "Could Not Set Write Format.\n");


### PR DESCRIPTION
Because of upcoming planned changes/refactoring to app_chanspy, it is convenient to pass some of the many arguments as a struct. This changeset adds a channel_spy_context struct to pass around.

Related: #68