### PR TITLE
sig_analog: Allow immediate fake ring to be suppressed.

### DIFF
--- a/channels/chan_dahdi.c
+++ b/channels/chan_dahdi.c
@@ -1038,6 +1038,7 @@ static struct dahdi_chan_conf dahdi_chan_conf_default(void)
 #endif
 		.chan = {
 			.context = "default",
+			.immediatering = 1,
 			.cid_num = "",
 			.cid_name = "",
 			.cid_tag = "",
@@ -12868,6 +12869,7 @@ static struct dahdi_pvt *mkintf(int channel, const struct dahdi_chan_conf *conf,
 		}
 #endif
 		tmp->immediate = conf->chan.immediate;
+		tmp->immediatering = conf->chan.immediatering;
 		tmp->transfertobusy = conf->chan.transfertobusy;
 		tmp->dialmode = conf->chan.dialmode;
 		if (chan_sig & __DAHDI_SIG_FXS) {
@@ -13198,6 +13200,7 @@ static struct dahdi_pvt *mkintf(int channel, const struct dahdi_chan_conf *conf,
 				analog_p->canpark = conf->chan.canpark;
 				analog_p->dahditrcallerid = conf->chan.dahditrcallerid;
 				analog_p->immediate = conf->chan.immediate;
+				analog_p->immediatering = conf->chan.immediatering;
 				analog_p->permhidecallerid = conf->chan.hidecallerid; /* hidecallerid is the config setting, not permhidecallerid (~permcallwaiting above) */
 				/* It's not necessary to set analog_p->hidecallerid here, sig_analog will set hidecallerid=permhidecaller before each call */
 				analog_p->pulse = conf->chan.pulse;
@@ -18404,6 +18407,8 @@ static int process_dahdi(struct dahdi_chan_conf *confp, const char *cat, struct 
 			}
 		} else if (!strcasecmp(v->name, "immediate")) {
 			confp->chan.immediate = ast_true(v->value);
+		} else if (!strcasecmp(v->name, "immediatering")) {
+			confp->chan.immediatering = ast_true(v->value);
 		} else if (!strcasecmp(v->name, "transfertobusy")) {
 			confp->chan.transfertobusy = ast_true(v->value);
 		} else if (!strcasecmp(v->name, "dialmode")) {

--- a/channels/chan_dahdi.h
+++ b/channels/chan_dahdi.h
@@ -299,6 +299,12 @@ struct dahdi_pvt {
 	 * \note Set from the "immediate" value read in from chan_dahdi.conf
 	 */
 	unsigned int immediate:1;
+	/*!
+	 * \brief TRUE if audible ringback should be provided
+	 * when immediate = yes.
+	 * \note Set from the "immediatering" value read in from chan_dahdi.conf
+	 */
+	unsigned int immediatering:1;
 	/*! \brief TRUE if in an alarm condition. */
 	unsigned int inalarm:1;
 	/*! \brief TRUE if TDD in MATE mode */

--- a/channels/sig_analog.c
+++ b/channels/sig_analog.c
@@ -3815,7 +3815,10 @@ void *analog_handle_init_event(struct analog_pvt *i, int event)
 			if (i->immediate) {
 				analog_set_echocanceller(i, 1);
 				/* The channel is immediately up.  Start right away */
-				res = analog_play_tone(i, ANALOG_SUB_REAL, ANALOG_TONE_RINGTONE);
+				if (i->immediatering) {
+					/* Play fake ringing, if we've been told to... */
+					res = analog_play_tone(i, ANALOG_SUB_REAL, ANALOG_TONE_RINGTONE);
+				}
 				chan = analog_new_ast_channel(i, AST_STATE_RING, 1, ANALOG_SUB_REAL, NULL);
 				if (!chan) {
 					ast_log(LOG_WARNING, "Unable to start PBX on channel %d\n", i->channel);

--- a/channels/sig_analog.h
+++ b/channels/sig_analog.h
@@ -295,6 +295,7 @@ struct analog_pvt {
 	unsigned int dahditrcallerid:1;			/*!< should we use the callerid from incoming call on dahdi transfer or not */
 	unsigned int hanguponpolarityswitch:1;
 	unsigned int immediate:1;
+	unsigned int immediatering:1;			/*!< TRUE if ringing should be provided for immediate execution */
 	unsigned int permcallwaiting:1;			/*!< TRUE if call waiting is enabled. (Configured option) */
 	unsigned int permhidecallerid:1;		/*!< Whether to hide our outgoing caller ID or not */
 	unsigned int pulse:1;

--- a/configs/samples/chan_dahdi.conf.sample
+++ b/configs/samples/chan_dahdi.conf.sample
@@ -957,6 +957,13 @@ pickupgroup=1
 ;
 ;immediate=yes
 ;
+; On FXS channels (FXO signaled), specifies whether fake audible ringback should
+; be provided as soon as the channel goes off hook and immediate=yes.
+; If audio should come only from the dialplan, this option should be disabled.
+; Default is 'yes'
+;
+;immediatering=no
+;
 ; Specify whether flash-hook transfers to 'busy' channels should complete or
 ; return to the caller performing the transfer (default is yes).
 ;


### PR DESCRIPTION
When immediate=yes on an FXS channel, sig_analog will start fake audible ringback that continues until the channel is answered. Even if it answers immediately, the ringback is still audible for a brief moment.
This can be disruptive and unwanted behavior.

This adds an option to disable this behavior, though the default behavior remains unchanged.

Resolves: #118
ASTERISK-30003
Imported from: https://gerrit.asterisk.org/c/asterisk/+/19715

UserNote: The immediatering option can now be set to no to suppress the fake audible ringback provided
when immediate=yes on FXS channels.