### PR TITLE
res_musiconhold: Add option to loop last file.

### DIFF
--- a/configs/samples/musiconhold.conf.sample
+++ b/configs/samples/musiconhold.conf.sample
@@ -82,6 +82,14 @@ directory=moh
 ;               ; in alphabetical order. If 'randstart', the files are sorted
 ;               ; in alphabetical order as well, but the first file is chosen
 ;               ; at random. If unspecified, the sort order is undefined.
+;loop_last=no   ; If enabled, once the end of the directory is reached,
+                ; the last file played will be looped perpetually, rather than
+                ; starting over at the beginning again.
+                ; Can be used with sort=alpha or randstart so you can control
+                ; which file gets looped (the last one sorted alphabetically).
+                ; (If sort=alpha, all files will be played at least once, but
+                ; this may not be true with sort=randstart.)
+                ; Default is no.
 ;answeredonly=yes       ; Only allow answered channels to have music on hold.
                         ; Enabling this will prevent MOH on unanswered channels.
                         ; (default: "no")

--- a/contrib/ast-db-manage/config/versions/f5b0e7427449_add_loop_last_to_res_musiconhold.py
+++ b/contrib/ast-db-manage/config/versions/f5b0e7427449_add_loop_last_to_res_musiconhold.py
@@ -1,0 +1,27 @@
+"""Add loop_last to res_musiconhold
+
+Revision ID: f5b0e7427449
+Revises: f261363a857f
+Create Date: 2023-03-13 23:59:00.835055
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'f5b0e7427449'
+down_revision = 'f261363a857f'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import ENUM
+
+YESNO_NAME = 'yesno_values'
+YESNO_VALUES = ['yes', 'no']
+
+def upgrade():
+    yesno_values = ENUM(*YESNO_VALUES, name=YESNO_NAME, create_type=False)
+    op.add_column('musiconhold', sa.Column('loop_last', yesno_values))
+
+def downgrade():
+    if op.get_context().bind.dialect.name == 'mssql':
+        op.drop_constraint('musiconhold','loop_last')
+    op.drop_column('musiconhold', 'loop_last')


### PR DESCRIPTION
Adds the loop_last option to res_musiconhold,
which allows the last audio file in the directory
to be looped perpetually once reached, rather than circling back to the beginning again.

Resolves: #122
ASTERISK-30462

UserNote: The loop_last option in musiconhold.conf now allows the last file in the directory to be looped once reached.

Imported from Gerrit: https://gerrit.asterisk.org/c/asterisk/+/19968