### PR TITLE
configure: Makefile downloader enable follow redirects.

### DIFF
--- a/configure
+++ b/configure
@@ -7705,7 +7705,7 @@ if test "x${WGET}" != "x:"; then
   DOWNLOAD_TO_STDOUT="${WGET} -q -O-"
   DOWNLOAD_TIMEOUT='--timeout=$1'
 elif test "x${CURL}" != "x:"; then
-  DOWNLOAD="${CURL} -O --progress-bar -w \"%{url_effective}\n\""
+  DOWNLOAD="${CURL} -L -O --progress-bar -w \"%{url_effective}\n\""
   DOWNLOAD_TO_STDOUT="${CURL} -Ls"
   DOWNLOAD_TIMEOUT='--max-time $(or $2,$1)'
 else

--- a/configure.ac
+++ b/configure.ac
@@ -296,7 +296,7 @@ if test "x${WGET}" != "x:"; then
   DOWNLOAD_TO_STDOUT="${WGET} -q -O-"
   DOWNLOAD_TIMEOUT='--timeout=$1'
 elif test "x${CURL}" != "x:"; then
-  DOWNLOAD="${CURL} -O --progress-bar -w \"%{url_effective}\n\""
+  DOWNLOAD="${CURL} -L -O --progress-bar -w \"%{url_effective}\n\""
   DOWNLOAD_TO_STDOUT="${CURL} -Ls"
   DOWNLOAD_TIMEOUT='--max-time $(or $2,$1)'
 else


### PR DESCRIPTION
Makefile downloader enable follow redirects.
 
If curl is used for building, any download such as a sounds package
will fail to follow HTTP redirects and will download wrong data.
 
Resolves: #136