### PR TITLE
tcptls: when disabling a server port, we should set the accept_fd to -1.

### DIFF
--- a/main/tcptls.c
+++ b/main/tcptls.c
@@ -837,6 +837,7 @@ void ast_tcptls_server_start(struct ast_tcptls_session_args *desc)
 
 	if (desc->accept_fd != -1) {
 		close(desc->accept_fd);
+		desc->accept_fd = -1;
 	}
 
 	/* If there's no new server, stop here */


### PR DESCRIPTION
If we don't set this to -1 if the structure can be potentially re-used later then it's possible that we'll issue a close() on an unrelated file descriptor, breaking asterisk in other interesting ways.

I believe this to be an unlikely scenario, but it costs nothing to be safe.