### PR TITLE
ast-db-manage: Synchronize revisions between comments and code.

### DIFF
--- a/contrib/ast-db-manage/config/versions/189a235b3fd7_add_keep_alive_interval.py
+++ b/contrib/ast-db-manage/config/versions/189a235b3fd7_add_keep_alive_interval.py
@@ -1,7 +1,7 @@
 """add_keep_alive_interval
 
 Revision ID: 189a235b3fd7
-Revises: 28ce1e718f05
+Revises: 339a3bdf53fc
 Create Date: 2015-12-16 11:23:16.994523
 
 """

--- a/contrib/ast-db-manage/config/versions/2bb1a85135ad_pjsip_add_use_callerid_contact.py
+++ b/contrib/ast-db-manage/config/versions/2bb1a85135ad_pjsip_add_use_callerid_contact.py
@@ -1,7 +1,7 @@
 """pjsip add use_callerid_contact
 
 Revision ID: 2bb1a85135ad
-Revises: 7f85dd44c775
+Revises: 465f47f880be
 Create Date: 2018-10-18 15:13:40.462354
 
 """

--- a/contrib/ast-db-manage/config/versions/4042a0ff4d9f_add_reason_paused_to_queue_members.py
+++ b/contrib/ast-db-manage/config/versions/4042a0ff4d9f_add_reason_paused_to_queue_members.py
@@ -1,7 +1,7 @@
 """add reason_paused to queue_members
 
 Revision ID: 4042a0ff4d9f
-Revises: 5a2247c957d2
+Revises: f261363a857f
 Create Date: 2022-12-21 14:24:48.885750
 
 """

--- a/contrib/ast-db-manage/config/versions/61797b9fced6_add_stir_shaken.py
+++ b/contrib/ast-db-manage/config/versions/61797b9fced6_add_stir_shaken.py
@@ -1,7 +1,7 @@
 """add stir shaken
 
 Revision ID: 61797b9fced6
-Revises: fbb7766f17bc
+Revises: b80485ff4dd0
 Create Date: 2020-06-29 11:52:59.946929
 
 """

--- a/contrib/ast-db-manage/config/versions/6d8c104e6184_res_pjsip_add_contact_via_addr_and_.py
+++ b/contrib/ast-db-manage/config/versions/6d8c104e6184_res_pjsip_add_contact_via_addr_and_.py
@@ -1,7 +1,7 @@
 """res_pjsip: add contact via_addr and callid
 
 Revision ID: a845e4d8ade8
-Revises: bca7113d796f
+Revises: d7e3c73eb2bf
 Create Date: 2016-05-19 15:51:33.410852
 
 """

--- a/contrib/ast-db-manage/config/versions/b80485ff4dd0_add_pjsip_endpoint_acn_options.py
+++ b/contrib/ast-db-manage/config/versions/b80485ff4dd0_add_pjsip_endpoint_acn_options.py
@@ -1,7 +1,7 @@
 """Add pjsip endpoint ACN options
 
 Revision ID: b80485ff4dd0
-Revises: fbb7766f17bc
+Revises: 79290b511e4b
 Create Date: 2020-07-06 08:29:53.974820
 
 """

--- a/contrib/ast-db-manage/config/versions/ccf795ee535f_all_codecs_on_empty_reinvite.py
+++ b/contrib/ast-db-manage/config/versions/ccf795ee535f_all_codecs_on_empty_reinvite.py
@@ -1,7 +1,7 @@
 """all_codecs_on_empty_reinvite
 
 Revision ID: ccf795ee535f
-Revises: 539f68bede2c
+Revises: 417c0247fd7e
 Create Date: 2022-09-28 09:14:36.709781
 
 """

--- a/contrib/ast-db-manage/config/versions/fe6592859b85_fix_mwi_subscribe_replaces_.py
+++ b/contrib/ast-db-manage/config/versions/fe6592859b85_fix_mwi_subscribe_replaces_.py
@@ -1,7 +1,7 @@
 """Fix mwi_subscribe_replaces_unsolicited
 
 Revision ID: fe6592859b85
-Revises: 19b00bc19b7b
+Revises: 1d3ed26d9978
 Create Date: 2018-08-06 15:50:44.405534
 
 """

--- a/contrib/ast-db-manage/queue_log/versions/4105ee839f58_create_queue_log_table.py
+++ b/contrib/ast-db-manage/queue_log/versions/4105ee839f58_create_queue_log_table.py
@@ -1,7 +1,7 @@
 """create queue_log table
 
 Revision ID: 4105ee839f58
-Revises:
+Revises: None
 Create Date: 2016-09-30 22:32:45.918340
 
 """


### PR DESCRIPTION
In a handful of migrations, the comment header that indicates the current and previous revisions has drifted from the identifiers revision and down_revision variables. This updates the comment headers to match the code.