### PR TITLE
res_pjsip_session: Added new function calls to avoid ABI issues.

### DIFF
--- a/include/asterisk/res_pjsip_session.h
+++ b/include/asterisk/res_pjsip_session.h
@@ -795,6 +795,26 @@ void ast_sip_session_send_request_with_cb(struct ast_sip_session *session, pjsip
 struct ast_sip_session *ast_sip_dialog_get_session(pjsip_dialog *dlg);
 
 /*!
+ * \brief Retrieves a dialog from a session
+ *
+ * \param session The session to retrieve the dialog from
+ *
+ * \retval non-NULL if dialog exists
+ * \retval NULL if no dialog
+ */
+pjsip_dialog *ast_sip_session_get_dialog(const struct ast_sip_session *session);
+
+/*!
+ * \brief Retrieves the pjsip_inv_state from a session
+ *
+ * \param session The session to retrieve the state from
+ *
+ * \retval state if inv_session exists
+ * \retval PJSIP_INV_STATE_NULL if inv_session is NULL
+ */
+pjsip_inv_state ast_sip_session_get_pjsip_inv_state(const struct ast_sip_session *session);
+
+/*!
  * \brief Resumes processing of a deferred incoming re-invite
  *
  * \param session The session which has a pending incoming re-invite

--- a/res/res_pjsip_session.c
+++ b/res/res_pjsip_session.c
@@ -3641,6 +3641,28 @@ struct ast_sip_session *ast_sip_dialog_get_session(pjsip_dialog *dlg)
 	return session;
 }
 
+pjsip_dialog *ast_sip_session_get_dialog(const struct ast_sip_session *session)
+{
+	pjsip_inv_session *inv_session = session->inv_session;
+
+	if (!inv_session) {
+		return NULL;
+	}
+
+	return inv_session->dlg;
+}
+
+pjsip_inv_state ast_sip_session_get_pjsip_inv_state(const struct ast_sip_session *session)
+{
+	pjsip_inv_session *inv_session = session->inv_session;
+
+	if (!inv_session) {
+		return PJSIP_INV_STATE_NULL;
+	}
+
+	return inv_session->state;
+}
+
 enum sip_get_destination_result {
 	/*! The extension was successfully found */
 	SIP_GET_DEST_EXTEN_FOUND,


### PR DESCRIPTION
Added two new functions (ast_sip_session_get_dialog and
ast_sip_session_get_pjsip_inv_state) that retrieve the dialog and the
pjsip_inv_state respectively from the pjsip_inv_session on the
ast_sip_session struct. This is due to pjproject adding a new field to
the pjsip_inv_session struct that caused crashes when trying to access
fields that were no longer where they were expected to be if a module
was compiled against a different version of pjproject.

Resolves: #145
