### PR TITLE
build: Fix a few gcc 13 issues

### DIFF
--- a/include/asterisk/app.h
+++ b/include/asterisk/app.h
@@ -139,7 +139,7 @@ int ast_ivr_menu_run(struct ast_channel *c, struct ast_ivr_menu *menu, void *cbd
  *  is pressed during playback, it will immediately break out of the message and continue
  *  execution of your code.
  */
-int ast_app_getdata(struct ast_channel *c, const char *prompt, char *s, int maxlen, int timeout);
+enum ast_getdata_result ast_app_getdata(struct ast_channel *c, const char *prompt, char *s, int maxlen, int timeout);
 
 /*! \brief Plays a stream and gets DTMF data from a channel
  * \param c Which channel one is interacting with
@@ -156,7 +156,7 @@ int ast_app_getdata(struct ast_channel *c, const char *prompt, char *s, int maxl
  *  is pressed during playback, it will immediately break out of the message and continue
  *  execution of your code.
  */
-int ast_app_getdata_terminator(struct ast_channel *c, const char *prompt, char *s, int maxlen, int timeout, char *terminator);
+enum ast_getdata_result ast_app_getdata_terminator(struct ast_channel *c, const char *prompt, char *s, int maxlen, int timeout, char *terminator);
 
 /*! \brief Full version with audiofd and controlfd.  NOTE: returns '2' on ctrlfd available, not '1' like other full functions */
 int ast_app_getdata_full(struct ast_channel *c, const char *prompt, char *s, int maxlen, int timeout, int audiofd, int ctrlfd);

--- a/main/loader.c
+++ b/main/loader.c
@@ -1816,9 +1816,9 @@ prestart_error:
 	return res;
 }
 
-int ast_load_resource(const char *resource_name)
+enum ast_module_load_result ast_load_resource(const char *resource_name)
 {
-	int res;
+	enum ast_module_load_result res;
 	AST_DLLIST_LOCK(&module_list);
 	res = load_resource(resource_name, 0, NULL, 0, 0);
 	if (!res) {

--- a/main/stasis_message.c
+++ b/main/stasis_message.c
@@ -53,7 +53,7 @@ static void message_type_dtor(void *obj)
 	type->name = NULL;
 }
 
-int stasis_message_type_create(const char *name,
+enum stasis_message_type_result stasis_message_type_create(const char *name,
 	struct stasis_message_vtable *vtable,
 	struct stasis_message_type **result)
 {

--- a/tests/test_utils.c
+++ b/tests/test_utils.c
@@ -130,9 +130,9 @@ AST_TEST_DEFINE(quoted_escape_test)
 {
 	int res = AST_TEST_PASS;
 	const char *in = "a\"bcdefg\"hijkl\\mnopqrs tuv\twxyz";
-	char out[256] = { 0 };
-	char small[4] = { 0 };
 	int i;
+#define LONG_SIZE 256
+#define SHORT_SIZE 4
 
 	static struct {
 		char *buf;
@@ -140,14 +140,14 @@ AST_TEST_DEFINE(quoted_escape_test)
 
 		const char *output;
 	} tests[] = {
-		{0, sizeof(out),
+		{NULL, LONG_SIZE,
 			"a\\\"bcdefg\\\"hijkl\\\\mnopqrs tuv\twxyz"},
-		{0, sizeof(small),
+		{NULL, SHORT_SIZE,
 			"a\\\""},
 	};
 
-	tests[0].buf = out;
-	tests[1].buf = small;
+	tests[0].buf = ast_alloca(LONG_SIZE);
+	tests[1].buf = ast_alloca(SHORT_SIZE);
 
 	switch (cmd) {
 	case TEST_INIT:
@@ -171,6 +171,8 @@ AST_TEST_DEFINE(quoted_escape_test)
 		}
 	}
 
+#undef LONG_SIZE
+#undef SHORT_SIZE
 	return res;
 }
 


### PR DESCRIPTION
* gcc 13 is now catching when a function is declared as returning
  an enum but defined as returning an int or vice versa.  Fixed
  a few in app.h, loader.c, stasis_message.c.

* gcc 13 is also now (incorrectly) complaining of dangling pointers
  when assigning a pointer to a local char array to a char *. Had
  to change that to an ast_alloca.

Resolves: #155
