### PR TITLE
feat: [say.c] dded language support for pashto and dari languages 

### DIFF
--- a/main/say.c
+++ b/main/say.c
@@ -1374,8 +1374,8 @@ static int ast_say_number_full_ps(struct ast_channel *chan, int num, const char 
 		} else if (num < 1000) {
 			int hundreds = num / 100;
 			num = num % 100;
-			if (hundreds == 1) {
-				ast_copy_string(fn, "digits/1N", sizeof(fn));
+			if (hundreds == 2) {
+				ast_copy_string(fn, "digits/sawa", sizeof(fn));
 			} else {
 				snprintf(fn, sizeof(fn), "digits/%d", hundreds);
 			}
@@ -1387,9 +1387,9 @@ static int ast_say_number_full_ps(struct ast_channel *chan, int num, const char 
 			int thousands = num / 1000;
 			num = num % 1000;
 			t = 1;
-			if (thousands == 1) {
-				ast_copy_string(fn, "digits/1N", sizeof(fn));
-				ast_copy_string(fna, "digits/thousand", sizeof(fna));
+			if (thousands == 2) {
+				ast_copy_string(fn, "digits/zara", sizeof(fn));
+				//ast_copy_string(fna, "digits/thousand", sizeof(fna));
 			} else {
 				res = ast_say_number_full_de(chan, thousands, ints, language, options, audiofd, ctrlfd);
 				if (res)

--- a/main/say.c
+++ b/main/say.c
@@ -741,7 +741,7 @@ static int ast_say_number_full_cs(struct ast_channel *chan, int num, const char 
 static int ast_say_number_full_da(struct ast_channel *chan, int num, const char *ints, const char *language, const char *options, int audiofd, int ctrlfd);
 static int ast_say_number_full_de(struct ast_channel *chan, int num, const char *ints, const char *language, const char *options, int audiofd, int ctrlfd);
 static int ast_say_number_full_ps(struct ast_channel *chan, int num, const char *ints, const char *language, const char *options, int audiofd, int ctrlfd);
-//static int ast_say_number_full_dr(struct ast_channel *chan, int num, const char *ints, const char *language, const char *options, int audiofd, int ctrlfd);
+static int ast_say_number_full_dr(struct ast_channel *chan, int num, const char *ints, const char *language, const char *options, int audiofd, int ctrlfd);
 static int ast_say_number_full_en_GB(struct ast_channel *chan, int num, const char *ints, const char *language, int audiofd, int ctrlfd);
 static int ast_say_number_full_es(struct ast_channel *chan, int num, const char *ints, const char *language, const char *options, int audiofd, int ctrlfd);
 static int ast_say_number_full_fr(struct ast_channel *chan, int num, const char *ints, const char *language, const char *options, int audiofd, int ctrlfd);
@@ -902,8 +902,8 @@ static int say_number_full(struct ast_channel *chan, int num, const char *ints, 
 		return ast_say_number_full_ur(chan, num, ints, language, options, audiofd, ctrlfd);
 	} else if (!strncasecmp(language, "vi", 2)) { /* Vietnamese syntax */
 		return ast_say_number_full_vi(chan, num, ints, language, audiofd, ctrlfd);
-//	} else if (!strncasecmp(language, "dr", 2)) { /* Dari syntax */
-//		return ast_say_number_full_dr(chan, num, ints, language, options, audiofd, ctrlfd);
+	} else if (!strncasecmp(language, "dr", 2)) { /* Dari syntax */
+		return ast_say_number_full_dr(chan, num, ints, language, options, audiofd, ctrlfd);
 	} else if (!strncasecmp(language, "ps", 2)) { /* Pashto syntax */
 		return ast_say_number_full_ps(chan, num, ints, language, options, audiofd, ctrlfd);
 	}	
@@ -1303,11 +1303,8 @@ static int ast_say_number_full_de(struct ast_channel *chan, int num, const char 
  New files:
  In addition to English, the following sounds are required:
  - wesht
- - "millions"
- - "1-and" through "9-and"
- - "1F" (eine)
- - "1N" (ein)
- - NB "1" is recorded as 'eins'
+ - sawa
+ - zara
  */
 static int ast_say_number_full_ps(struct ast_channel *chan, int num, const char *ints, const char *language, const char *options, int audiofd, int ctrlfd)
 {
@@ -1328,15 +1325,9 @@ static int ast_say_number_full_ps(struct ast_channel *chan, int num, const char 
 		* - numbers 20 through 99 are said in reverse order, i.e. 21 is
 		*   "one-and twenty" and 68 is "eight-and sixty".
         * - 20 has unique pronounciation if there is a unit number after it
-        *   i.e. 21 is one.wav-wesht.wav while 20 is "shall" / 20.wav. 
-		* - "one" varies according to gender
-		* - 100 is 'hundert', however all other instances are 'ein hundert'
-		* - 1000 is 'tausend', however all other instances are 'ein tausend'
-		* - 1000000 is always 'eine million'
-		* - "million" is different in singular and plural form
-		* - 'and' should not go between a hundreds place value and any
-		*   tens/ones place values that follows it. i.e 136 is ein hundert
-		*   sechs und dreizig, not ein hundert und sechs und dreizig.
+        *   i.e. 21 is one wesht while 20 is just "twenty"
+        * - 200 is called sawa
+        * - 2000 is called zara
 		*/
 		if (num < 0) {
 			ast_copy_string(fn, "digits/minus", sizeof(fn));
@@ -1391,7 +1382,7 @@ static int ast_say_number_full_ps(struct ast_channel *chan, int num, const char 
 				ast_copy_string(fn, "digits/zara", sizeof(fn));
 				//ast_copy_string(fna, "digits/thousand", sizeof(fna));
 			} else {
-				res = ast_say_number_full_de(chan, thousands, ints, language, options, audiofd, ctrlfd);
+				res = ast_say_number_full_ps(chan, thousands, ints, language, options, audiofd, ctrlfd);
 				if (res)
 					return res;
 				ast_copy_string(fn, "digits/thousand", sizeof(fn));
@@ -1404,7 +1395,7 @@ static int ast_say_number_full_ps(struct ast_channel *chan, int num, const char 
 				ast_copy_string(fn, "digits/1F", sizeof(fn));
 				ast_copy_string(fna, "digits/million", sizeof(fna));
 			} else {
-				res = ast_say_number_full_de(chan, millions, ints, language, options, audiofd, ctrlfd);
+				res = ast_say_number_full_ps(chan, millions, ints, language, options, audiofd, ctrlfd);
 				if (res)
 					return res;
 				ast_copy_string(fn, "digits/millions", sizeof(fn));
@@ -1417,7 +1408,7 @@ static int ast_say_number_full_ps(struct ast_channel *chan, int num, const char 
 				ast_copy_string(fn, "digits/1F", sizeof(fn));
 				ast_copy_string(fna, "digits/milliard", sizeof(fna));
 			} else {
-				res = ast_say_number_full_de(chan, billions, ints, language, options, audiofd, ctrlfd);
+				res = ast_say_number_full_ps(chan, billions, ints, language, options, audiofd, ctrlfd);
 				if (res) {
 					return res;
 				}
@@ -1449,6 +1440,7 @@ static int ast_say_number_full_ps(struct ast_channel *chan, int num, const char 
 	}
 	return res;
 }
+
 /*! \brief  ast_say_number_full_en_GB: British syntax
  New files:
   - In addition to American English, the following sounds are required:  "vm-and"
@@ -1501,6 +1493,82 @@ static int ast_say_number_full_en_GB(struct ast_channel *chan, int num, const ch
 		} else if (num < 1000000000) {
 				int millions = num / 1000000;
 				res = ast_say_number_full_en_GB(chan, millions, ints, language, audiofd, ctrlfd);
+				if (res)
+					return res;
+				ast_copy_string(fn, "digits/million", sizeof(fn));
+				num %= 1000000;
+				if (num && num < 100)
+					playa++;
+		} else {
+				ast_debug(1, "Number '%d' is too big for me\n", num);
+				res = -1;
+		}
+
+		if (!res) {
+			if (!ast_streamfile(chan, fn, language)) {
+				if ((audiofd > -1) && (ctrlfd > -1))
+					res = ast_waitstream_full(chan, ints, audiofd, ctrlfd);
+				else
+					res = ast_waitstream(chan, ints);
+			}
+			ast_stopstream(chan);
+		}
+	}
+	return res;
+}
+
+/*! \brief  ast_say_number_full_en_dr: Dari syntax
+ New files:
+  - In addition to American English, the following sounds are required:  "vm-and"
+ */
+static int ast_say_number_full_dr(struct ast_channel *chan, int num, const char *ints, const char *language, int audiofd, int ctrlfd)
+{
+	int res = 0;
+	int playh = 0;
+	int playa = 0;
+	char fn[256] = "";
+	if (!num)
+		return ast_say_digits_full(chan, 0, ints, language, audiofd, ctrlfd);
+
+	while (!res && (num || playh || playa )) {
+		if (num < 0) {
+			ast_copy_string(fn, "digits/minus", sizeof(fn));
+			if ( num > INT_MIN ) {
+				num = -num;
+			} else {
+				num = 0;
+			}
+		} else if (playh) {
+			ast_copy_string(fn, "digits/hundred", sizeof(fn));
+			playh = 0;
+		} else if (playa) {
+			ast_copy_string(fn, "vm-and", sizeof(fn));
+			playa = 0;
+		} else if (num < 20) {
+			snprintf(fn, sizeof(fn), "digits/%d", num);
+			num = 0;
+		} else if (num < 100) {
+			snprintf(fn, sizeof(fn), "digits/%d", (num /10) * 10);
+			num %= 10;
+		} else if (num < 1000) {
+			int hundreds = num / 100;
+			snprintf(fn, sizeof(fn), "digits/%d", (num / 100));
+
+			playh++;
+			num -= 100 * hundreds;
+			if (num)
+				playa++;
+		} else if (num < 1000000) {
+			res = ast_say_number_full_dr(chan, num / 1000, ints, language, audiofd, ctrlfd);
+			if (res)
+				return res;
+			ast_copy_string(fn, "digits/thousand", sizeof(fn));
+			num %= 1000;
+			if (num && num < 100)
+				playa++;
+		} else if (num < 1000000000) {
+				int millions = num / 1000000;
+				res = ast_say_number_full_dr(chan, millions, ints, language, audiofd, ctrlfd);
 				if (res)
 					return res;
 				ast_copy_string(fn, "digits/million", sizeof(fn));

--- a/main/say.c
+++ b/main/say.c
@@ -1298,10 +1298,11 @@ static int ast_say_number_full_de(struct ast_channel *chan, int num, const char 
 	return res;
 }
 
-/*! \brief  ast_say_number_full_de: German syntax
+/*! \brief  ast_say_number_full_ps: Pashto syntax
 
  New files:
  In addition to English, the following sounds are required:
+ - wesht
  - "millions"
  - "1-and" through "9-and"
  - "1F" (eine)
@@ -1320,11 +1321,14 @@ static int ast_say_number_full_ps(struct ast_channel *chan, int num, const char 
 	if (options && (!strncasecmp(options, "f", 1)))
 		mf = -1;
 
+    int playWesht = 0;
 	while (!res && num) {
-		/* The grammar for German numbers is the same as for English except
+		/* The grammar for Pashto numbers is the same as for English except
 		* for the following:
 		* - numbers 20 through 99 are said in reverse order, i.e. 21 is
 		*   "one-and twenty" and 68 is "eight-and sixty".
+        * - 20 has unique pronounciation if there is a unit number after it
+        *   i.e. 21 is one.wav-wesht.wav while 20 is "shall" / 20.wav. 
 		* - "one" varies according to gender
 		* - 100 is 'hundert', however all other instances are 'ein hundert'
 		* - 1000 is 'tausend', however all other instances are 'ein tausend'
@@ -1342,7 +1346,7 @@ static int ast_say_number_full_ps(struct ast_channel *chan, int num, const char 
 				num = 0;
 			}
 		} else if (num == 1 && mf == -1) {
-			snprintf(fn, sizeof(fn), "digits/%dF", num);
+			snprintf(fn, sizeof(fn), "digits/%dF", num); // idk why this works for ps as we don't have any "digits/1F" file in ps sounds dir
 			num = 0;
 		} else if (num < 20) {
 			snprintf(fn, sizeof(fn), "digits/%d", num);
@@ -1350,10 +1354,18 @@ static int ast_say_number_full_ps(struct ast_channel *chan, int num, const char 
 		} else if (num < 100) {
 			int ones = num % 10;
 			if (ones) {
-				snprintf(fn, sizeof(fn), "digits/%d-and", ones);
+				snprintf(fn, sizeof(fn), "digits/%d", ones);
 				num -= ones;
+                if (num == 20){
+                    playWesht = 1;
+                }
 			} else {
-				snprintf(fn, sizeof(fn), "digits/%d", num);
+                if (num == 20 && playWesht == 1){
+				    snprintf(fn, sizeof(fn), "digits/wesht");
+                    playWesht = 0;
+                } else{
+				    snprintf(fn, sizeof(fn), "digits/%d", num);
+                }
 				num = 0;
 			}
 		} else if (num == 100 && t == 0) {

--- a/main/say.c
+++ b/main/say.c
@@ -741,7 +741,7 @@ static int ast_say_number_full_cs(struct ast_channel *chan, int num, const char 
 static int ast_say_number_full_da(struct ast_channel *chan, int num, const char *ints, const char *language, const char *options, int audiofd, int ctrlfd);
 static int ast_say_number_full_de(struct ast_channel *chan, int num, const char *ints, const char *language, const char *options, int audiofd, int ctrlfd);
 static int ast_say_number_full_ps(struct ast_channel *chan, int num, const char *ints, const char *language, const char *options, int audiofd, int ctrlfd);
-static int ast_say_number_full_dr(struct ast_channel *chan, int num, const char *ints, const char *language, const char *options, int audiofd, int ctrlfd);
+static int ast_say_number_full_dr(struct ast_channel *chan, int num, const char *ints, const char *language, int audiofd, int ctrlfd);
 static int ast_say_number_full_en_GB(struct ast_channel *chan, int num, const char *ints, const char *language, int audiofd, int ctrlfd);
 static int ast_say_number_full_es(struct ast_channel *chan, int num, const char *ints, const char *language, const char *options, int audiofd, int ctrlfd);
 static int ast_say_number_full_fr(struct ast_channel *chan, int num, const char *ints, const char *language, const char *options, int audiofd, int ctrlfd);
@@ -903,8 +903,8 @@ static int say_number_full(struct ast_channel *chan, int num, const char *ints, 
 	} else if (!strncasecmp(language, "vi", 2)) { /* Vietnamese syntax */
 		return ast_say_number_full_vi(chan, num, ints, language, audiofd, ctrlfd);
 	} else if (!strncasecmp(language, "dr", 2)) { /* Dari syntax */
-		return ast_say_number_full_dr(chan, num, ints, language, options, audiofd, ctrlfd);
-	} else if (!strncasecmp(language, "ps", 2)) { /* Pashto syntax */
+		return ast_say_number_full_dr(chan, num, ints, language, audiofd, ctrlfd);
+    } else if (!strncasecmp(language, "ps", 2)) { /* Pashto syntax */
 		return ast_say_number_full_ps(chan, num, ints, language, options, audiofd, ctrlfd);
 	}	
     /* Default to english */
@@ -1519,7 +1519,7 @@ static int ast_say_number_full_en_GB(struct ast_channel *chan, int num, const ch
 
 /*! \brief  ast_say_number_full_en_dr: Dari syntax
  New files:
-  - In addition to American English, the following sounds are required:  "vm-and"
+  - In addition to American English, the following sounds are required:  "o"
  */
 static int ast_say_number_full_dr(struct ast_channel *chan, int num, const char *ints, const char *language, int audiofd, int ctrlfd)
 {
@@ -1542,7 +1542,7 @@ static int ast_say_number_full_dr(struct ast_channel *chan, int num, const char 
 			ast_copy_string(fn, "digits/hundred", sizeof(fn));
 			playh = 0;
 		} else if (playa) {
-			ast_copy_string(fn, "vm-and", sizeof(fn));
+			ast_copy_string(fn, "digits/o", sizeof(fn));
 			playa = 0;
 		} else if (num < 20) {
 			snprintf(fn, sizeof(fn), "digits/%d", num);


### PR DESCRIPTION
This pull request to add language support for Pashto and Dari in the mod_say module in asterisk is a great addition to the project. With this new feature, users who speak these languages can now benefit from the text-to-speech functionality provided by asterisk. This will make the platform more accessible and useful to a wider range of users, particularly those in regions where Pashto and Dari are spoken. This contribution will help to improve the overall usability and inclusivity of the asterisk platform.