### PR TITLE
users.conf: Deprecate users.conf configuration.

### DIFF
--- a/configs/samples/users.conf.sample
+++ b/configs/samples/users.conf.sample
@@ -1,6 +1,11 @@
 ;
 ; User configuration
 ;
+; WARNING: This configuration file is deprecated and will be removed in
+; a future version of Asterisk. It is recommended that you make configurations
+; in the appropriate module-specific configuration file for more flexibility.
+; Many Asterisk modules already no longer support users.conf.
+;
 ; Creating entries in users.conf is a "shorthand" for creating individual
 ; entries in each configuration file.  Using users.conf is not intended to
 ; provide you with as much flexibility as using the separate configuration

--- a/pbx/pbx_config.c
+++ b/pbx/pbx_config.c
@@ -1974,6 +1974,27 @@ static void append_interface(char *iface, int maxlen, char *add)
 	}
 }
 
+static void startup_event_cb(void *data, struct stasis_subscription *sub, struct stasis_message *message)
+{
+	struct ast_json_payload *payload;
+	const char *type;
+
+	if (stasis_message_type(message) != ast_manager_get_generic_type()) {
+		return;
+	}
+
+	payload = stasis_message_data(message);
+	type = ast_json_string_get(ast_json_object_get(payload->json, "type"));
+
+	if (strcmp(type, "FullyBooted")) {
+		return;
+	}
+
+	ast_log(LOG_WARNING, "users.conf is deprecated and will be removed in a future version of Asterisk\n");
+
+	stasis_unsubscribe(sub);
+}
+
 static void pbx_load_users(void)
 {
 	struct ast_config *cfg;
@@ -1993,6 +2014,9 @@ static void pbx_load_users(void)
 	cfg = ast_config_load("users.conf", config_flags);
 	if (!cfg)
 		return;
+
+	/*! \todo Remove users.conf support in Asterisk 23 */
+	stasis_subscribe_pool(ast_manager_get_topic(), startup_event_cb, NULL);
 
 	for (cat = ast_category_browse(cfg, NULL); cat ; cat = ast_category_browse(cfg, cat)) {
 		if (!strcasecmp(cat, "general"))


### PR DESCRIPTION
This deprecates the users.conf config file, which
is no longer as widely supported but still integrated with a number of different modules.

Because there is no real mechanism for marking a
configuration file as "deprecated", and users.conf is not just used in a single place, this now emits a warning to the user when the PBX loads to notify about the deprecation.

This configuration mechanism has been widely criticized and discouraged since its inception, and is no longer relevant to the configuration that most users are doing today. Removing it will allow for some simplification and cleanup in the codebase.

Resolves: #183

UpgradeNote: The users.conf config is now deprecated and will be removed in a future version of Asterisk.