### PR TITLE
chan_iax2.c: Avoid crash with IAX2 switch support.

### DIFF
--- a/channels/chan_iax2.c
+++ b/channels/chan_iax2.c
@@ -14323,7 +14323,7 @@ static struct iax2_dpcache *find_cache(struct ast_channel *chan, const char *dat
 			ast_log(LOG_WARNING, "Timeout waiting for %s exten %s\n", data, exten);
 		}
 
-		if (ast_check_hangup(chan)) {
+		if (chan && ast_check_hangup(chan)) {
 			doabort = 1;
 		}
 


### PR DESCRIPTION
A change made in 82cebaa0 did not properly handle the case when a channel was not provided, triggering a crash. ast_check_hangup(...) does not protect against NULL pointers.

Fixes #180