### PR TITLE
app.h: Move declaration of ast_getdata_result before its first use

### DIFF
--- a/include/asterisk/app.h
+++ b/include/asterisk/app.h
@@ -123,6 +123,16 @@ enum ast_timelen {
 */
 int ast_ivr_menu_run(struct ast_channel *c, struct ast_ivr_menu *menu, void *cbdata);
 
+enum ast_getdata_result {
+	AST_GETDATA_FAILED = -1,
+	AST_GETDATA_COMPLETE = 0,
+	AST_GETDATA_TIMEOUT = 1,
+	AST_GETDATA_INTERRUPTED = 2,
+	/*! indicates a user terminated empty string rather than an empty string resulting
+	 * from a timeout or other factors */
+	AST_GETDATA_EMPTY_END_TERMINATED = 3,
+};
+
 /*! \brief Plays a stream and gets DTMF data from a channel
  * \param c Which channel one is interacting with
  * \param prompt File to pass to ast_streamfile (the one that you wish to play).
@@ -1148,16 +1158,6 @@ int ast_play_and_record(struct ast_channel *chan, const char *playfile, const ch
  * \retval 't' Recording either exceeded maximum duration or the call was ended via DTMF
  */
 int ast_play_and_prepend(struct ast_channel *chan, char *playfile, char *recordfile, int maxtime_sec, char *fmt, int *duration, int *sound_duration, int beep, int silencethreshold, int maxsilence_ms);
-
-enum ast_getdata_result {
-	AST_GETDATA_FAILED = -1,
-	AST_GETDATA_COMPLETE = 0,
-	AST_GETDATA_TIMEOUT = 1,
-	AST_GETDATA_INTERRUPTED = 2,
-	/*! indicates a user terminated empty string rather than an empty string resulting
-	 * from a timeout or other factors */
-	AST_GETDATA_EMPTY_END_TERMINATED = 3,
-};
 
 enum AST_LOCK_RESULT {
 	AST_LOCK_SUCCESS = 0,


### PR DESCRIPTION
The ast_app_getdata() and ast_app_getdata_terminator() declarations
in app.h were changed recently to return enum ast_getdata_result
(which is how they were defined in app.c).  The existing
declaration of ast_getdata_result in app.h was about 1000 lines
after those functions however so under certain circumstances,
a "use before declaration" error was thrown by the compiler.
The declaration of the enum was therefore moved to before those
functions.

Resolves: #200
