### PR TITLE
sig_analog: Allow three-way flash to time out to silence.

### DIFF
--- a/channels/chan_dahdi.c
+++ b/channels/chan_dahdi.c
@@ -12898,6 +12898,7 @@ static struct dahdi_pvt *mkintf(int channel, const struct dahdi_chan_conf *conf,
 		tmp->usedistinctiveringdetection = usedistinctiveringdetection;
 		tmp->callwaitingcallerid = conf->chan.callwaitingcallerid;
 		tmp->threewaycalling = conf->chan.threewaycalling;
+		tmp->threewaysilenthold = conf->chan.threewaysilenthold;
 		tmp->adsi = conf->chan.adsi;
 		tmp->use_smdi = conf->chan.use_smdi;
 		tmp->permhidecallerid = conf->chan.hidecallerid;
@@ -18245,6 +18246,8 @@ static int process_dahdi(struct dahdi_chan_conf *confp, const char *cat, struct 
 				confp->chan.cid_start = CID_START_RING;
 		} else if (!strcasecmp(v->name, "threewaycalling")) {
 			confp->chan.threewaycalling = ast_true(v->value);
+		} else if (!strcasecmp(v->name, "threewaysilenthold")) {
+			confp->chan.threewaysilenthold = ast_true(v->value);
 		} else if (!strcasecmp(v->name, "cancallforward")) {
 			confp->chan.cancallforward = ast_true(v->value);
 		} else if (!strcasecmp(v->name, "relaxdtmf")) {

--- a/channels/chan_dahdi.h
+++ b/channels/chan_dahdi.h
@@ -352,6 +352,11 @@ struct dahdi_pvt {
 	 */
 	unsigned int threewaycalling:1;
 	/*!
+	 * \brief TRUE if a three way dial tone should time out to silence
+	 * \note Set from the "threewaysilenthold" value read in from chan_dahdi.conf
+	 */
+	unsigned int threewaysilenthold:1;
+	/*!
 	 * \brief TRUE if call transfer is enabled
 	 * \note For FXS ports (either direct analog or over T1/E1):
 	 *   Support flash-hook call transfer

--- a/channels/sig_analog.h
+++ b/channels/sig_analog.h
@@ -300,6 +300,7 @@ struct analog_pvt {
 	unsigned int permhidecallerid:1;		/*!< Whether to hide our outgoing caller ID or not */
 	unsigned int pulse:1;
 	unsigned int threewaycalling:1;
+	unsigned int threewaysilenthold:1;		/*!< Whether to time out a three-way dial tone to silence */
 	unsigned int transfer:1;
 	unsigned int transfertobusy:1;			/*!< allow flash-transfers to busy channels */
 	unsigned int use_callerid:1;			/*!< Whether or not to use caller id on this channel */

--- a/configs/samples/chan_dahdi.conf.sample
+++ b/configs/samples/chan_dahdi.conf.sample
@@ -759,6 +759,14 @@ callwaitingcallerid=yes
 ;
 threewaycalling=yes
 ;
+; By default, the three-way dial tone never times out, allowing it to be
+; used as a primitive "hold" mechanism. However, if you'd prefer
+; to have the dial tone time out to silence, you can use this option
+; to time out after the normal first digit timeout to silence.
+; Default is 'no'.
+;
+;threewaysilenthold=no
+;
 ; For FXS ports (either direct analog or over T1/E1):
 ;   Support flash-hook call transfer (requires three way calling)
 ;   Also enables call parking (overrides the 'canpark' parameter)


### PR DESCRIPTION
sig_analog allows users to flash and use the three-way dial tone as a primitive hold function, simply by never timing it out.

Some systems allow this dial tone to time out to silence, so the user is not annoyed by a persistent dial tone. This option allows the dial tone to time out normally to silence.

Resolves: #205
ASTERISK-30004 #close
Imported from Gerrit: https://gerrit.asterisk.org/c/asterisk/+/19716

UserNote: The threewaysilenthold option now allows the three-way dial tone to time out to silence, rather than continuing forever.