### PR TITLE
func_export: Use correct function argument as variable name.

### DIFF
--- a/funcs/func_export.c
+++ b/funcs/func_export.c
@@ -84,7 +84,7 @@ static int func_export_write(struct ast_channel *chan, const char *function, cha
 		return -1;
 	}
 
-	pbx_builtin_setvar_helper(ochan, data, value);
+	pbx_builtin_setvar_helper(ochan, args.var, value);
 	ast_channel_unref(ochan);
 	return 0;
 }


### PR DESCRIPTION
Fixes #208