### PR TITLE
Update func_cut.c

### DIFF
--- a/.github/workflows/PROpenedOrUpdated.yml
+++ b/.github/workflows/PROpenedOrUpdated.yml
@@ -18,13 +18,6 @@ jobs:
   PROpenUpdateUnitTests:
     runs-on: ubuntu-latest
     steps:
-      - name: Job Start Delay
-        env:
-          JOB_START_DELAY_SEC:       ${{vars.PR_JOB_START_DELAY_SEC}}
-        run: |
-          # Give the user a chance to add their "cherry-pick-to" comments
-          sleep ${JOB_START_DELAY_SEC:-60}
-
       - name: Get Token needed to add reviewers
         if: github.event.action == 'opened'
         id: get_workflow_token
@@ -44,17 +37,12 @@ jobs:
           github_token:            ${{secrets.GITHUB_TOKEN}}
 
       - name: Add cherry-pick reminder
+        if: ${{ steps.getbranches.outputs.branch_count == 0 || steps.getbranches.outputs.forced_none != 'true' }}
         env:
           GITHUB_TOKEN: ${{steps.get_workflow_token.outputs.token}}
           GH_TOKEN: ${{steps.get_workflow_token.outputs.token}}
           CHERRY_PICK_REMINDER: ${{vars.CHERRY_PICK_REMINDER}}
-          BRANCHES_OUTPUT: ${{toJSON(steps.getbranches.outputs)}}
-          BRANCH_COUNT: ${{steps.getbranches.outputs.branch_count}}
-          FORCED_NONE:  ${{steps.getbranches.outputs.forced_none}}
         run: |
-          # If the user already added "cherry-pick-to" comments
-          # we don't need to remind them.
-          ( $FORCED_NONE || [ $BRANCH_COUNT -gt 0 ] ) && { echo "No reminder needed." ; exit 0 ; }
           IFS=$'; \n'
           # If there's already a reminder comment, don't add another one.
           ADD_COMMENT=true

--- a/funcs/func_cut.c
+++ b/funcs/func_cut.c
@@ -72,14 +72,15 @@
 				<para>Number of the field you want (1-based offset), may also be specified as a range (with <literal>-</literal>)
 				or group of ranges and fields (with <literal>&amp;</literal>)</para>
 			</parameter>
+ 					<example title="The varname parameter must be a variable name, not a string value. This is unusual syntax. So:">
+				exten => s,1,Set(foo=${CUT(bar,,2)}) ; This is correct syntax
+				exten => s,1,Set(foo=${CUT(${bar},,2)}) ; This is invalid syntax (unless bar contains the name of another variable)		
+					</example>
 		</syntax>
 		<description>
 			<para>Cut out information from a string (<replaceable>varname</replaceable>), based upon a named delimiter.</para>
 		</description>
-			<example title="The varname parameter must be a variable name, not a string value. This is unusual syntax. So:">
-				exten => s,1,Set(foo=${CUT(bar,,2)}) ; This is correct syntax
-				exten => s,1,Set(foo=${CUT(${bar},,2)}) ; This is invalid syntax (unless bar contains the name of another variable)		
-			</example>	
+				
 	</function>
  ***/
 

--- a/funcs/func_cut.c
+++ b/funcs/func_cut.c
@@ -76,6 +76,10 @@
 		<description>
 			<para>Cut out information from a string (<replaceable>varname</replaceable>), based upon a named delimiter.</para>
 		</description>
+			<example title="The varname parameter must be a variable name, not a string value. This is unusual syntax. So:">
+				exten => s,1,Set(foo=${CUT(bar,,2)}) ; This is correct syntax
+				exten => s,1,Set(foo=${CUT(${bar},,2)}) ; This is invalid syntax (unless bar contains the name of another variable)		
+			</example>	
 	</function>
  ***/
 

--- a/funcs/func_cut.c
+++ b/funcs/func_cut.c
@@ -71,15 +71,15 @@
 			<parameter name="range-spec" required="true">
 				<para>Number of the field you want (1-based offset), may also be specified as a range (with <literal>-</literal>)
 				or group of ranges and fields (with <literal>&amp;</literal>)</para>
-			</parameter>
- 					<example title="The varname parameter must be a variable name, not a string value. This is unusual syntax. So:">
-				exten => s,1,Set(foo=${CUT(bar,,2)}) ; This is correct syntax
-				exten => s,1,Set(foo=${CUT(${bar},,2)}) ; This is invalid syntax (unless bar contains the name of another variable)		
-					</example>
+    			</parameter>
 		</syntax>
 		<description>
 			<para>Cut out information from a string (<replaceable>varname</replaceable>), based upon a named delimiter.</para>
-		</description>		
+  					 <example title="The varname parameter must be a variable name, not a variable expression">
+				exten => s,1,Set(foo=${CUT(bar,,2)}) ; This is correct syntax
+				exten => s,1,Set(foo=${CUT(${bar},,2)}) ; This is invalid syntax (unless bar contains the name of another variable)
+   					</example>
+		</description>
 	</function>
  ***/
 

--- a/funcs/func_cut.c
+++ b/funcs/func_cut.c
@@ -79,8 +79,7 @@
 		</syntax>
 		<description>
 			<para>Cut out information from a string (<replaceable>varname</replaceable>), based upon a named delimiter.</para>
-		</description>
-				
+		</description>		
 	</function>
  ***/
 


### PR DESCRIPTION
Func. CUT add note of unusual syntax for func. 

want to update the WIKI
The **varname**  parameter must be a variable name, not a variable expression
`exten => s,1,Set(foo=${CUT(bar,,2)}) ; This is correct syntax`
`exten => s,1,Set(foo=${CUT(${bar},,2)}) ; This is invalid syntax (unless bar contains the name of another variable)`

