### PR TITLE
extensions.conf.sample: Remove reference to missing context.

### DIFF
--- a/configs/samples/extensions.ael.sample
+++ b/configs/samples/extensions.ael.sample
@@ -30,8 +30,6 @@ globals {
 	CONSOLE-AEL="Console/dsp"; 		// Console interface for demo
 	//CONSOLE-AEL=Zap/1;
 	//CONSOLE-AEL=Phone/phone0;
-	IAXINFO-AEL=guest;				// IAXtel username/password
-	//IAXINFO-AEL="myuser:mypass";
 	OUTBOUND-TRUNK="Zap/g2";		// Trunk interface
 	//
 	// Note the 'g2' in the OUTBOUND-TRUNK variable above. It specifies which group (defined
@@ -188,16 +186,6 @@ macro ael-dundi-e164(exten) {
 };
 
 //
-// Here are the entries you need to participate in the IAXTEL
-// call routing system.  Most IAXTEL numbers begin with 1-700, but
-// there are exceptions.  For more information, and to sign
-// up, please go to www.gnophone.com or www.iaxtel.com
-//
-context ael-iaxtel700 {
-	_91700XXXXXXX => Dial(IAX2/${IAXINFO-AEL}@iaxtel.com/${EXTEN:1}@iaxtel);
-};
-
-//
 // The SWITCH statement permits a server to share the dialplan with
 // another server. Use with care: Reciprocal switch statements are not
 // allowed (e.g. both A -> B and B -> A), and the switched server needs
@@ -279,13 +267,12 @@ context ael-longdistance {
 
 context ael-local {
 	//
-	// Master context for local, toll-free, and iaxtel calls only
+	// Master context for local and toll-free calls only
 	//
 	ignorepat => 9;
 	includes {
 		ael-default;
 		ael-trunklocal;
-		ael-iaxtel700;
 		ael-trunktollfree;
 		ael-iaxprovider;
 	};

--- a/configs/samples/extensions.conf.sample
+++ b/configs/samples/extensions.conf.sample
@@ -124,8 +124,6 @@ clearglobalvars=no
 CONSOLE=Console/dsp				; Console interface for demo
 ;CONSOLE=DAHDI/1
 ;CONSOLE=Phone/phone0
-IAXINFO=guest					; IAXtel username/password
-;IAXINFO=myuser:mypass
 TRUNK=DAHDI/G2					; Trunk interface
 ;
 ; Note the 'G2' in the TRUNK variable above. It specifies which group (defined
@@ -366,12 +364,12 @@ include => trunkld
 
 [local]
 ;
-; Master context for local, toll-free, and iaxtel calls only
+; Master context for local and toll-free calls only
 ;
 ignorepat => 9
 include => default
 include => trunklocal
-include => iaxtel700
+include => iax2-trunk
 include => trunktollfree
 include => iaxprovider
 

--- a/configs/samples/extensions.lua.sample
+++ b/configs/samples/extensions.lua.sample
@@ -4,9 +4,6 @@ CONSOLE = "Console/dsp" -- Console interface for demo
 --CONSOLE = "DAHDI/1"
 --CONSOLE = "Phone/phone0"
 
-IAXINFO = "guest"       -- IAXtel username/password
---IAXINFO = "myuser:mypass"
-
 TRUNK = "DAHDI/G2"
 TRUNKMSD = 1
 -- TRUNK = "IAX2/user:pass@provider"

--- a/configs/samples/iax.conf.sample
+++ b/configs/samples/iax.conf.sample
@@ -65,7 +65,7 @@
 ;
 
 ;
-; You may specify a global default AMA flag for iaxtel calls.  These flags are
+; You may specify a global default AMA flag for iax calls.  These flags are
 ; used in the generation of call detail records.
 ;
 ; Accepted values: default, omit, billing, documentation
@@ -308,25 +308,6 @@ encryption=yes
 ;
 ;register => marko:[torkey]@tormenta.linux-support.net
 ;
-; Sample Registration for iaxtel
-;
-; Visit http://www.iaxtel.com to register with iaxtel.  Replace "user"
-; and "pass" with your username and password for iaxtel.  Incoming
-; calls arrive at the "s" extension of "default" context.
-;
-;register => user:pass@iaxtel.com
-;
-; Sample Registration for IAX2 + FWD
-;
-; To register using IAX2 with FWD, it must be enabled by visiting the URL
-; http://www.fwdnet.net/index.php?section_id=112
-;
-; Note that you need an extension in you default context which matches
-; your free world dialup number.  Please replace "FWDNumber" with your
-; FWD number and "passwd" with your password.
-;
-;register => FWDNumber:passwd@iax.fwdnet.net
-;
 ; Through the use of the res_stun_monitor module, Asterisk has the ability to detect when the
 ; perceived external network address has changed.  When the stun_monitor is installed and
 ; configured, chan_iax will renew all outbound registrations when the monitor detects any sort
@@ -497,24 +478,6 @@ autokill=yes
 type=user
 context=public
 callerid="Guest IAX User"
-
-;
-; Trust Caller*ID Coming from iaxtel.com
-;
-[iaxtel]
-type=user
-context=default
-auth=rsa
-inkeys=iaxtel
-
-;
-; Trust Caller*ID Coming from iax.fwdnet.net
-;
-[iaxfwd]
-type=user
-context=default
-auth=rsa
-inkeys=freeworlddialup
 
 ;
 ; Trust Caller*ID delivered over DUNDi/e164


### PR DESCRIPTION
c3ff4648 removed the `[iaxtel700]` context but neglected to remove references to it.

This commit addresses that and also removes iaxtel and freeworlddialup references from other config files.