### PR TITLE
chan_dahdi: Allow autoreoriginating after hangup.

### DIFF
--- a/channels/chan_dahdi.h
+++ b/channels/chan_dahdi.h
@@ -276,6 +276,14 @@ struct dahdi_pvt {
 	 * \note Set from the "hanguponpolarityswitch" value read in from chan_dahdi.conf
 	 */
 	unsigned int hanguponpolarityswitch:1;
+	/*!
+	 * \brief TRUE if FXS (FXO-signalled) channel should reoriginate for user to make a new call.
+	 */
+	unsigned int reoriginate:1;
+	/*!
+	 * \brief Internal flag for if we should actually process a reorigination.
+	 */
+	unsigned int doreoriginate:1;
 	/*! \brief TRUE if DTMF detection needs to be done by hardware. */
 	unsigned int hardwaredtmf:1;
 	/*!

--- a/configs/samples/chan_dahdi.conf.sample
+++ b/configs/samples/chan_dahdi.conf.sample
@@ -1097,6 +1097,15 @@ pickupgroup=1
 ;                        polarity switch and hangup polarity switch.
 ;                        (default: 600ms)
 ;
+; For kewlstart FXS (FXO signalled) ports only:
+; When all calls towards a DAHDI channel have cleared, automatically
+; reoriginate and provide dial tone to the user again, so s/he can
+; make another call without having to cycle the hookswitch manually.
+; This only works for kewlstart (fxo_ks) lines!
+; Dial tone will be provided only after the loop disconnect has finished.
+;
+;autoreoriginate=yes
+;
 ; On trunk interfaces (FXS) it can be useful to attempt to follow the progress
 ; of a call through RINGING, BUSY, and ANSWERING.   If turned on, call
 ; progress attempts to determine answer, busy, and ringing on phone lines.


### PR DESCRIPTION
Currently, if an FXS channel is still off hook when all calls on the line have hung up, the user is provided reorder tone until going back on hook again.

In addition to not reflecting what most commercial switches actually do, it's very common for switches to automatically reoriginate for the user so that dial tone is provided without the user having to depress and release the hookswitch manually. This can increase convenience for users.

This behavior is now supported for kewlstart FXS channels. It's supported only for kewlstart (FXOKS) mainly because the behavior doesn't make any sense for ground start channels, and loop start signalling doesn't provide the necessary DAHDI event that makes this easy to implement. Likely almost everyone is using FXOKS over FXOLS anyways since FXOLS is pretty useless these days.

Imported from Gerrit: https://gerrit.asterisk.org/c/asterisk/+/19714

ASTERISK-30357 #close

Resolves: #224

UserNote: The autoreoriginate setting now allows for kewlstart FXS channels to automatically reoriginate and provide dial tone to the user again after all calls on the line have cleared. This saves users from having to manually hang up and pick up the receiver again before making another call.