### PR TITLE
During an incoming call from my provider, when the call is answer on …

### DIFF
--- a/res/res_pjsip.c
+++ b/res/res_pjsip.c
@@ -1000,9 +1000,11 @@ static pjsip_dialog *create_dialog_uas(const struct ast_sip_endpoint *endpoint,
 
 	contact.ptr = pj_pool_alloc(rdata->tp_info.pool, PJSIP_MAX_URL_SIZE);
 	contact.slen = pj_ansi_snprintf(contact.ptr, PJSIP_MAX_URL_SIZE,
-			"<%s:%s%.*s%s:%d%s%s>",
+			"<%s:%s%s%s%.*s%s:%d%s%s>",
 			uas_use_sips_contact(rdata) ? "sips" : "sip",
 			(type & PJSIP_TRANSPORT_IPV6) ? "[" : "",
+			(!ast_strlen_zero(endpoint->contact_user))?endpoint->contact_user:"",
+			(!ast_strlen_zero(endpoint->contact_user))?"@":"",
 			(int)transport->local_name.host.slen,
 			transport->local_name.host.ptr,
 			(type & PJSIP_TRANSPORT_IPV6) ? "]" : "",


### PR DESCRIPTION
My provider required a contact_user to be sent in a 200 OK (after the 180 ringing) for the incoming calls, asterisk don't include it since it is optional in RFC. Therefore, I included if present in the configuration