### PR TITLE
res_pjsip.c: Add the contact_user to the Contact header

### DIFF
--- a/res/res_pjsip.c
+++ b/res/res_pjsip.c
@@ -1000,9 +1000,11 @@ static pjsip_dialog *create_dialog_uas(const struct ast_sip_endpoint *endpoint,
 
 	contact.ptr = pj_pool_alloc(rdata->tp_info.pool, PJSIP_MAX_URL_SIZE);
 	contact.slen = pj_ansi_snprintf(contact.ptr, PJSIP_MAX_URL_SIZE,
-			"<%s:%s%.*s%s:%d%s%s>",
+			"<%s:%s%s%s%.*s%s:%d%s%s>",
 			uas_use_sips_contact(rdata) ? "sips" : "sip",
 			(type & PJSIP_TRANSPORT_IPV6) ? "[" : "",
+			S_OR(endpoint->contact_user, ""),
+                        (!ast_strlen_zero(endpoint->contact_user)) ? "@" : "",
 			(int)transport->local_name.host.slen,
 			transport->local_name.host.ptr,
 			(type & PJSIP_TRANSPORT_IPV6) ? "]" : "",


### PR DESCRIPTION
If the contact_user in declared in the endpoint, the contact_user will be inserted in the message for the incoming calls which it was not the case before. The contact_user is already used in the outgoing calls. 

Resolves: #226