### PR TITLE
audiohook: Unlock channel in mute if no audiohooks present.

### DIFF
--- a/main/audiohook.c
+++ b/main/audiohook.c
@@ -1385,6 +1385,7 @@ int ast_audiohook_set_mute_all(struct ast_channel *chan, const char *source, enu
 	ast_channel_lock(chan);
 
 	if (!ast_channel_audiohooks(chan)) {
+		ast_channel_unlock(chan);
 		return -1;
 	}
 


### PR DESCRIPTION
In the case where mute was called on a channel that had no audiohooks the code was not unlocking the channel, resulting in a deadlock.

Resolves: #233