### PR TITLE
manager: Tolerate stasis messages with no channel snapshot.

### DIFF
--- a/main/manager_channels.c
+++ b/main/manager_channels.c
@@ -467,7 +467,7 @@ struct ast_str *ast_manager_build_channel_state_string_prefix(
 	char *connected_name;
 	int res;
 
-	if (snapshot->base->tech_properties & AST_CHAN_TP_INTERNAL) {
+	if (!snapshot || (snapshot->base->tech_properties & AST_CHAN_TP_INTERNAL)) {
 		return NULL;
 	}
 


### PR DESCRIPTION
In some cases I have yet to determine some stasis messages may be created without a channel snapshot. This change adds some tolerance to this scenario, preventing a crash from occurring.