### PR TITLE
pjproject_bundled: Increase PJSIP_MAX_MODULE to 38

### DIFF
--- a/third-party/pjproject/patches/config_site.h
+++ b/third-party/pjproject/patches/config_site.h
@@ -91,3 +91,11 @@
 #define PJSIP_TSX_UAS_CONTINUE_ON_TP_ERROR 0
 #define PJ_SSL_SOCK_OSSL_USE_THREAD_CB 0
 #define PJSIP_AUTH_ALLOW_MULTIPLE_AUTH_HEADER 1
+
+/*
+ * The default is 32 with 8 being used by pjproject itself.
+ * Since this value is used in invites, dialogs, transports
+ * and subscriptions as well as the global pjproject endpoint,
+ * we don't want to increase it too much.
+ */
+#define PJSIP_MAX_MODULE 38


### PR DESCRIPTION
The default is 32 with 8 being used by pjproject itself.  Recent
commits have put us over the limit resulting in assertions in
pjproject.  Since this value is used in invites, dialogs,
transports and subscriptions as well as the global pjproject
endpoint, we don't want to increase it too much.

Resolves: #255
