### PR TITLE
res_pjsip_diversion: Add debugging to aid testsuite failures

### DIFF
--- a/include/asterisk/res_pjsip.h
+++ b/include/asterisk/res_pjsip.h
@@ -70,6 +70,8 @@
 
 #define PJSTR_PRINTF_SPEC "%.*s"
 #define PJSTR_PRINTF_VAR(_v) ((int)(_v).slen), ((_v).ptr)
+#define PJ_SIP_URI_SPEC PJSTR_PRINTF_SPEC "@" PJSTR_PRINTF_SPEC ":%d"
+#define PJ_SIP_URI_VAR(_v) (int)(_v)->user.slen, (_v)->user.ptr, (int)(_v)->host.slen, (_v)->host.ptr, (_v)->port
 
 /* Response codes from RFC8224 */
 #define AST_STIR_SHAKEN_RESPONSE_CODE_STALE_DATE 403


### PR DESCRIPTION
Added many ast_debug statements to the Diversion path.  Not
so much to the HistoryInfo path.

Also added two new macros in res_pjsip.h to assist printing
URI user and host without having to allocate memory from the
pool and doing a "sprintf" on the uri to it.
