### PR TITLE
variables: Add additional variable dialplan functions.

### DIFF
--- a/funcs/func_global.c
+++ b/funcs/func_global.c
@@ -53,6 +53,40 @@
 			<para>Set or get the value of a global variable specified in <replaceable>varname</replaceable></para>
 		</description>
 	</function>
+	<function name="GLOBAL_DELETE" language="en_US">
+		<synopsis>
+			Deletes a specified global variable.
+		</synopsis>
+		<syntax>
+			<parameter name="varname" required="true">
+				<para>Global variable name</para>
+			</parameter>
+		</syntax>
+		<description>
+			<para>Delete the global variable specified in <replaceable>varname</replaceable>.
+			Will succeed if the global variable exists or not.</para>
+		</description>
+		<see-also>
+			<ref type="function">GLOBAL</ref>
+			<ref type="function">DELETE</ref>
+		</see-also>
+	</function>
+	<function name="GLOBAL_EXISTS" language="en_US">
+		<synopsis>
+			Check if a global variable exists or not.
+		</synopsis>
+		<syntax>
+			<parameter name="varname" required="true">
+				<para>Global variable name</para>
+			</parameter>
+		</syntax>
+		<description>
+			<para>Returns <literal>1</literal> if global variable exists or <literal>0</literal> otherwise.</para>
+		</description>
+		<see-also>
+			<ref type="function">VARIABLE_EXISTS</ref>
+		</see-also>
+	</function>
 	<function name="SHARED" language="en_US">
 		<synopsis>
 			Gets or sets the shared variable specified.
@@ -143,6 +177,33 @@ static struct ast_custom_function global_function = {
 	.name = "GLOBAL",
 	.read = global_read,
 	.write = global_write,
+};
+
+static int global_delete_write(struct ast_channel *chan, const char *cmd, char *data, const char *value)
+{
+	pbx_builtin_setvar_helper(NULL, data, NULL);
+
+	return 0;
+}
+
+static struct ast_custom_function global_delete_function = {
+	.name = "GLOBAL_DELETE",
+	.write = global_delete_write,
+};
+
+static int global_exists_read(struct ast_channel *chan, const char *cmd, char *data,
+		  char *buf, size_t len)
+{
+	const char *var = pbx_builtin_getvar_helper(NULL, data);
+
+	strcpy(buf, var ? "1" : "0");
+
+	return 0;
+}
+
+static struct ast_custom_function global_exists_function = {
+	.name = "GLOBAL_EXISTS",
+	.read = global_exists_read,
 };
 
 static int shared_read(struct ast_channel *chan, const char *cmd, char *data, char *buf, size_t len)
@@ -313,6 +374,8 @@ static int unload_module(void)
 	int res = 0;
 
 	res |= ast_custom_function_unregister(&global_function);
+	res |= ast_custom_function_unregister(&global_delete_function);
+	res |= ast_custom_function_unregister(&global_exists_function);
 	res |= ast_custom_function_unregister(&shared_function);
 
 	return res;
@@ -323,6 +386,8 @@ static int load_module(void)
 	int res = 0;
 
 	res |= ast_custom_function_register(&global_function);
+	res |= ast_custom_function_register(&global_delete_function);
+	res |= ast_custom_function_register(&global_exists_function);
 	res |= ast_custom_function_register(&shared_function);
 
 	return res;

--- a/funcs/func_logic.c
+++ b/funcs/func_logic.c
@@ -111,6 +111,39 @@
 		<description>
 		</description>
 	</function>
+	<function name="DELETE" language="en_US">
+		<synopsis>
+			Deletes a specified channel variable.
+		</synopsis>
+		<syntax>
+			<parameter name="varname" required="true">
+				<para>Channel variable name</para>
+			</parameter>
+		</syntax>
+		<description>
+			<para>Delete the channel variable specified in <replaceable>varname</replaceable>.
+			Will succeed if the channel variable exists or not.</para>
+		</description>
+		<see-also>
+			<ref type="function">GLOBAL_DELETE</ref>
+		</see-also>
+	</function>
+	<function name="VARIABLE_EXISTS" language="en_US">
+		<synopsis>
+			Check if a dialplan variable exists or not.
+		</synopsis>
+		<syntax>
+			<parameter name="varname" required="true">
+				<para>Channel variable name</para>
+			</parameter>
+		</syntax>
+		<description>
+			<para>Returns <literal>1</literal> if channel variable exists or <literal>0</literal> otherwise.</para>
+		</description>
+		<see-also>
+			<ref type="function">GLOBAL_EXISTS</ref>
+		</see-also>
+	</function>
  ***/
 
 static int isnull(struct ast_channel *chan, const char *cmd, char *data,
@@ -273,6 +306,23 @@ static int import_read2(struct ast_channel *chan, const char *cmd, char *data, s
 	return import_helper(chan, cmd, data, NULL, str, len);
 }
 
+static int delete_write(struct ast_channel *chan, const char *cmd, char *data, const char *value)
+{
+	pbx_builtin_setvar_helper(chan, data, NULL);
+
+	return 0;
+}
+
+static int variable_exists_read(struct ast_channel *chan, const char *cmd, char *data,
+		  char *buf, size_t len)
+{
+	const char *var = pbx_builtin_getvar_helper(chan, data);
+
+	strcpy(buf, var ? "1" : "0");
+
+	return 0;
+}
+
 static struct ast_custom_function isnull_function = {
 	.name = "ISNULL",
 	.read = isnull,
@@ -307,6 +357,16 @@ static struct ast_custom_function import_function = {
 	.read2 = import_read2,
 };
 
+static struct ast_custom_function delete_function = {
+	.name = "DELETE",
+	.write = delete_write,
+};
+
+static struct ast_custom_function variable_exists_function = {
+	.name = "VARIABLE_EXISTS",
+	.read = variable_exists_read,
+};
+
 static int unload_module(void)
 {
 	int res = 0;
@@ -317,6 +377,8 @@ static int unload_module(void)
 	res |= ast_custom_function_unregister(&if_function);
 	res |= ast_custom_function_unregister(&if_time_function);
 	res |= ast_custom_function_unregister(&import_function);
+	res |= ast_custom_function_unregister(&delete_function);
+	res |= ast_custom_function_unregister(&variable_exists_function);
 
 	return res;
 }
@@ -331,6 +393,8 @@ static int load_module(void)
 	res |= ast_custom_function_register(&if_function);
 	res |= ast_custom_function_register(&if_time_function);
 	res |= ast_custom_function_register(&import_function);
+	res |= ast_custom_function_register(&delete_function);
+	res |= ast_custom_function_register(&variable_exists_function);
 
 	return res;
 }


### PR DESCRIPTION
   Using the Set dialplan application does not actually
    delete channel or global variables. Instead the
    variables are set to an empty value.
    
    This change adds two dialplan functions,
    GLOBAL_DELETE and DELETE which can be used to
    delete global and channel variables instead
    of just setting them to empty.
    
    There is also no ability within the dialplan to
    determine if a global or channel variable has
    actually been set or not.
    
    This change also adds two dialplan functions,
    GLOBAL_EXISTS and VARIABLE_EXISTS which can be
    used to determine if a global or channel variable
    has been set or not.
    
    Resolves: #289
    
    UserNote: Four new dialplan functions have been added.
    GLOBAL_DELETE and DELETE have been added which allows
    the deletion of global and channel variables.
    GLOBAL_EXISTS and VARIABLE_EXISTS have been added
    which checks whether a global or channel variable has
    been set.