### PR TITLE
func_groupcount.c: Adding Group Variables + additional Group functions

### DIFF
--- a/funcs/func_groupcount.c
+++ b/funcs/func_groupcount.c
@@ -27,11 +27,16 @@
 
 #include "asterisk.h"
 
+#include <regex.h>
+
 #include "asterisk/module.h"
 #include "asterisk/channel.h"
 #include "asterisk/pbx.h"
 #include "asterisk/utils.h"
 #include "asterisk/app.h"
+#include "asterisk/manager.h"
+#include "asterisk/strings.h"
+#include "asterisk/cli.h"
 
 /*** DOCUMENTATION
 	<function name="GROUP_COUNT" language="en_US">
@@ -54,6 +59,233 @@
 			channel's current group if not specified (and non-empty).</para>
 		</description>
 	</function>
+	<function name="GROUP_MATCH_LIST" language="en_US">
+		<synopsis>Find groups by regular expression</synopsis>
+		<syntax argsep="@">
+			<parameter name="group_regex"/>
+			<parameter name="category_regex"/>
+		</syntax>
+		<description>
+			<para>Search for groups matching group@category. This search will look at all known groups and filter by the regex(s) provided.</para>
+			<para>If only the group_regex is specified, then return group@category results that only match the group name against the group_regex</para>
+			<para>If only the category_regex is specified, then return group@category results that only match the category name against the category_regex.</para>
+			<para>If the search regex parameters are entirely empty, all group@category will be returned.</para>
+			<para>Uses standard regular expression matching (see regex(7)).</para>
+			<example title="Find groups containing the string 'foo'">
+				On Channel 1:
+					Set(GROUP()=groupName)
+				On Channel 2:
+					Set(GROUP()=foobarbaz)
+				On Channel 3:
+					Set(GROUP()=foobarbill)
+				On Channel 4:
+					Set(GROUP()=somethingelse)
+				On any Channel:
+					Assuming that channels still exist that have the above associated GROUP() assignents
+					Set(groups_found=${GROUP_LIST(.*foo.*)})
+				Given the above:
+					This will find the groups 'foobarbaz' and 'foobarbill' since they both match .*foo.* regex against the group name
+                                        Variable groups_found will be set to: foobarbaz,foobarbill
+			</example>
+			<example title="Find groups containing category name of 'bar'">
+				On Channel 1:
+					Set(GROUP()=groupName@categoryName)
+				On Channel 2:
+					Set(GROUP()=foo@barbaz)
+				On Channel 3:
+					Set(GROUP()=foo@barbill)
+				On Channel 4:
+					Set(GROUP()=anything@somethingelse)
+				On any Channel:
+					Assuming that channels still exist that have the above associated GROUP() assignents
+					Set(groups_found=${GROUP_LIST(@.*bar.*)})
+
+				Given the above:
+					This will find the groups 'foo@barbaz' and 'foo@barbill' since they both match .*bar.* regex against the category name
+                                        Variable groups_found will be set to: foo@barbaz,foo@barbill
+			</example>
+			<example title="Find groups containing 'foo' and category name of 'bar'">
+				On Channel 1:
+					Set(GROUP()=groupName@categoryName)
+				On Channel 2:
+					Set(GROUP()=foo@barbaz)
+				On Channel 3:
+					Set(GROUP()=foo@barbill)
+				On Channel 4:
+					Set(GROUP()=anything@somethingelse)
+				On any Channel:
+					Assuming that channels still exist that have the above associated GROUP() assignents
+					Set(groups_found=${GROUP_LIST(.*foo.*@.*bar.*)})
+
+				Given the above:
+					This will find the groups 'foo@barbaz' and 'foo@barbill' since they both match .*foo*. against the group name and .*bar.* regex against the category name
+                                        Variable groups_found will be set to: foo@barbaz,foo@barbill
+			</example>
+		</description>
+		<see-also>
+			<ref type="function">GROUP</ref>
+			<ref type="function">GROUP_CHANNEL_LIST</ref>
+		</see-also>
+	</function>
+	<function name="GROUP_CHANNEL_LIST" language="en_US">
+		<synopsis>
+			Find channels that are members of groups/categories by exact match
+		</synopsis>
+		<syntax argsep="@">
+			<parameter name="group"/>
+			<parameter name="category"/>
+		</syntax>
+		<description>
+			<para>Search for groups matching group@category and return the channels that are members of those groups, the group/category must match exactly</para>
+			<para>If only the group is specified, then return group@category results that only match against the group name</para>
+			<para>If only the category is specified, then return group@category results that only match the against the category name</para>
+			<para>If the search parameters are entirely empty, all channels having any kind of group membership will be returned.</para>
+			<para>After GROUP_CHANNEL_LIST is complete.  Channel variables may be set with information related to the function call.</para>
+			<variablelist>
+				<variable name="GROUP_CHANNEL_LIST_ERROR">
+					<value name="TRUNCATED">
+						The full result is not complete and was truncated
+					</value>
+				</variable>
+			</variablelist>
+			<example>
+				Find channels that are members of the group 'foobarbaz':
+
+				On Channel PJSIP/1234-0000001:
+					Set(GROUP()=groupName)
+				On Channel PJSIP/1234-0000003:
+					Set(GROUP()=foobarbaz)
+				On Channel PJSIP/1234-0000004:
+					Set(GROUP()=foobarbill)
+				On Channel PJSIP/1234-0000005:
+					Set(GROUP()=somethingelse)
+				On any Channel:
+					Assuming that channels still exist that have the above associated GROUP() assignents
+					Set(channels_found=${GROUP_CHANNEL_LIST(foobarbaz)}
+				Given the above:
+					This will find the channels that are in the group 'foobarbaz'
+                                        Variable channels_found will be set to: PJSIP/1234-0000003
+			</example>
+			<example>
+				Find channels that have the category name of 'barbaz'
+
+				On Channel PJSIP/1234-0000001:
+					Set(GROUP()=groupName@categoryName)
+				On Channel PJSIP/1234-0000002:
+					Set(GROUP()=foo@barbaz)
+                                On Channel PJSIP/1234-0000003:
+					Set(GROUP()=oof@barbaz)
+                                On Channel PJSIP/1234-0000004:
+					Set(GROUP()=anything@somethingelse)
+				On any Channel:
+					Assuming that channels still exist that have the above associated GROUP() assignents
+					Set(channels_found=${GROUP_CHANNEL_LIST(@barbaz)})
+
+				Given the above:
+					This will find the channels that are in group 'foo@foobarbaz' and 'oof@barbaz' since they both have the category barbaz
+                                        Variable channels_found will be set to: PJSIP/1234-0000002,PJSIP/1234-0000003
+			</example>
+			<example>
+				Find groups containing 'foo' and category name of 'bar'
+
+                                On Channel PJSIP/1234-0000001:
+					Set(GROUP()=groupName@categoryName)
+                                On Channel PJSIP/1234-0000002:
+					Set(GROUP()=foo@bar)
+                                On Channel PJSIP/1234-0000003:
+					Set(GROUP()=foo@bar)
+                                On Channel PJSIP/1234-0000004:
+					Set(GROUP()=anything@somethingelse)
+				On any Channel:
+					Assuming that channels still exist that have the above associated GROUP() assignents
+					Set(channels_found=${GROUP_MATCH_CHANNEL_LIST(.*foo.*@.*bar.*)})
+
+				Given the above:
+					This will find the channels that are in the group@category assignment of foo@bar
+                                        Variable channels_found will be set to: PJSIP/1234-0000002,PJSIP/1234-0000003
+			</example>
+		</description>
+		<see-also>
+			<ref type="function">GROUP</ref>
+			<ref type="function">GROUP_MATCH_CHANNEL_LIST</ref>
+		</see-also>
+	</function>
+	<function name="GROUP_MATCH_CHANNEL_LIST" language="en_US">
+		<synopsis>
+			Find channels that are members of groups by regular expression
+		</synopsis>
+		<syntax argsep="@">
+			<parameter name="group_regex"/>
+			<parameter name="category_regex"/>
+		</syntax>
+		<description>
+			<para>Search for groups matching group@category and return the channels that are members of those groups, filtering known groups by the regex(s) provided.</para>
+			<para>If only the group_regex is specified, then return group@category results that only match the group name against the group_regex</para>
+			<para>If only the category_regex is specified, then return group@category results that only match the category name against the category_regex.</para>
+			<para>If the search regex parameters are entirely empty, all channels having any kind of group membership will be returned.</para>
+			<para>Uses standard regular expression matching (see regex(7)).</para>
+			<example>
+				Find channels containing the string 'foo'
+
+				On Channel PJSIP/1234-0000001:
+					Set(GROUP()=groupName)
+				On Channel PJSIP/1234-0000003:
+					Set(GROUP()=foobarbaz)
+				On Channel PJSIP/1234-0000004:
+					Set(GROUP()=foobarbill)
+				On Channel PJSIP/1234-0000005:
+					Set(GROUP()=somethingelse)
+				On any Channel:
+					Assuming that channels still exist that have the above associated GROUP() assignents
+					Set(channels_found=${GROUP_MATCH_CHANNEL_LIST(.*foo.*)})
+				Given the above:
+					This will find the channels that are in groups 'foobarbaz' and 'foobarbill' since they both match .*foo.* regex against the group name
+                                        Variable channels_found will be set to: PJSIP/1234-0000003,PJSIP/1234-0000004
+			</example>
+			<example>
+				Find channels in groups containing category name of 'bar'
+
+				On Channel PJSIP/1234-0000001:
+					Set(GROUP()=groupName@categoryName)
+				On Channel PJSIP/1234-0000002:
+					Set(GROUP()=foo@barbaz)
+                                On Channel PJSIP/1234-0000003:
+					Set(GROUP()=foo@barbill)
+                                On Channel PJSIP/1234-0000004:
+					Set(GROUP()=anything@somethingelse)
+				On any Channel:
+					Assuming that channels still exist that have the above associated GROUP() assignents
+					Set(channels_found=${GROUP_MATCH_CHANNEL_LIST(@.*bar.*)})
+
+				Given the above:
+					This will find the channels that are in groups 'foo@barbaz' and 'foo@barbill' since they both match .*bar.* regex against the category name
+                                        Variable channels_found will be set to: PJSIP/1234-0000002,PJSIP/1234-0000003
+			</example>
+			<example>
+				Find channels in groups where they contain 'foo' and have the matching category contain the name of 'bar'
+
+                                On Channel PJSIP/1234-0000001:
+					Set(GROUP()=groupName@categoryName)
+                                On Channel PJSIP/1234-0000002:
+					Set(GROUP()=foo@bar)
+                                On Channel PJSIP/1234-0000003:
+					Set(GROUP()=foo@barbill)
+                                On Channel PJSIP/1234-0000004:
+					Set(GROUP()=anything@somethingelse)
+				On any Channel:
+					Assuming that channels still exist that have the above associated GROUP() assignents
+					Set(channels_found=${GROUP_MATCH_CHANNEL_LIST(.*foo.*@.*bar.*)}
+
+				Given the above:
+					This will find the channels that are in groups 'foo@barbaz' and 'foo@barbill' since they both match .*foo*. against the group name and .*bar.* regex against the category name
+                                        Variable channels_found will be set to: PJSIP/1234-0000002,PJSIP/1234-0000003
+			</example>
+		</description>
+		<see-also>
+			<ref type="function">GROUP</ref>
+			<ref type="function">GROUP_CHANNEL_LIST</ref>
+		</see-also>
+	</function>
 	<function name="GROUP_MATCH_COUNT" language="en_US">
 		<since>
 			<version>1.2.0</version>
@@ -62,17 +294,17 @@
 			Counts the number of channels in the groups matching the specified pattern.
 		</synopsis>
 		<syntax argsep="@">
-			<parameter name="groupmatch" required="true">
+			<parameter name="group_match">
 				<para>A standard regular expression used to match a group name.</para>
 			</parameter>
-			<parameter name="category">
+			<parameter name="category_match">
 				<para>A standard regular expression used to match a category name.</para>
 			</parameter>
 		</syntax>
 		<description>
 			<para>Calculates the group count for all groups that match the specified pattern.
 			Note: category matching is applied after matching based on group.
-			Uses standard regular expression matching on both (see regex(7)).</para>
+			Uses standard regular expression matching on both parameters (see regex(7)).</para>
 		</description>
 	</function>
 	<function name="GROUP" language="en_US">
@@ -82,15 +314,61 @@
 		<synopsis>
 			Gets or sets the channel group.
 		</synopsis>
-		<syntax>
+		<syntax argsep="@">
+			<parameter name="group">
+				<para>Group name.</para>
+			</parameter>
 			<parameter name="category">
 				<para>Category name.</para>
 			</parameter>
 		</syntax>
 		<description>
 			<para><replaceable>category</replaceable> can be employed for more fine grained group management. Each channel
-			can only be member of exactly one group per <replaceable>category</replaceable>.</para>
+			can only be member of exactly one group per <replaceable>category</replaceable>.  Once a group is assigned to
+			a channel, per-group variables can then be assigned via GROUP_VAR()</para>
 		</description>
+		<see-also>
+			<ref type="function">GROUP_VAR</ref>
+		</see-also>
+	</function>
+	<function name="GROUP_VAR" language="en_US">
+		<synopsis>
+			Gets or sets a variable on a channel group.
+		</synopsis>
+		<syntax>
+			<parameter name="category">
+				<para>Category name.</para>
+			</parameter>
+		</syntax>
+		<description>
+			<para>
+				Once a GROUP() is assinged to a channel, variables can then be attached to that group.	As long as the
+				group exists, these variables will exist. When the group no longer exists, the variables will be cleaned up
+				automatically.
+			</para>
+			<para>
+				These variables can be considered 'globals for a group of channels'.  These variables are
+				like a SHARED() variable but for a collection of channels.
+			</para>
+			<example>
+				On Channel 1
+				Set(GROUP()=foo)
+				Set(GROUP_VAR(foo,savethis)=123)
+
+				On Channel 2 -- Assuming Channel1 is still up and Channel1 is still a member of GROUP(foo)
+                                We can now join the same Group and read a Group Variable
+				Set(GROUP()=foo)
+				NoOp(${GROUP_VAR(foo,savethis) &lt;-- This prints '123'
+
+			        On Channel 3 -- Assuming Channel1 is still up and Channel1 is still a member of GROUP(foo)
+                                We do not need to join the group in order to read a Group Variable
+				NoOp(${GROUP_VAR(foo,savethis) &lt;-- This prints '123'
+			</example>
+		</description>
+		<see-also>
+			<ref type="function">GROUP</ref>
+			<ref type="function">SHARED</ref>
+		</see-also>
 	</function>
 	<function name="GROUP_LIST" language="en_US">
 		<since>
@@ -104,15 +382,179 @@
 			<para>Gets a list of the groups set on a channel.</para>
 		</description>
 	</function>
+	<manager name="GroupSet" language="en_US">
+		<synopsis>
+			Add channel group assignments
+		</synopsis>
+		<syntax>
+			<xi:include xpointer="xpointer(/docs/manager[@name='Login']/syntax/parameter[@name='ActionID'])" />
+			<parameter name="channel">
+				<para>Channel to operate on.</para>
+			</parameter>
+			<parameter name="group">
+				<para>Group name to set.</para>
+			</parameter>
+			<parameter name="category">
+				<para>Category name to set.</para>
+			</parameter>
+		</syntax>
+		<description>
+			<para>For more information, see the dialplan function GROUP()</para>
+		</description>
+	</manager>
+	<manager name="GroupRemove" language="en_US">
+		<synopsis>
+			Remove channel group assignments
+		</synopsis>
+		<syntax>
+			<xi:include xpointer="xpointer(/docs/manager[@name='Login']/syntax/parameter[@name='ActionID'])" />
+			<parameter name="channel">
+				<para>Channel to operate on.</para>
+			</parameter>
+			<parameter name="group">
+				<para>Group name to remove.</para>
+			</parameter>
+			<parameter name="category">
+				<para>Category name to remove.</para>
+			</parameter>
+		</syntax>
+		<description>
+			<para>For more information, see the dialplan function GROUP()</para>
+		</description>
+	</manager>
+	<application name="DumpGroups" language="en_US">
+		<synopsis>
+			Dump all group information to the console
+		</synopsis>
+		<description>
+			<para>When executed, this will show all group assignments and group variables
+			in the console</para>
+		</description>
+	</application>
+	<manager name="GroupVarGet" language="en_US">
+		<synopsis>
+			Get channel group variables.
+		</synopsis>
+		<syntax>
+			<xi:include xpointer="xpointer(/docs/manager[@name='Login']/syntax/parameter[@name='ActionID'])" />
+			<parameter name="Group" required="false" />
+			<parameter name="Category" required="false" />
+			<parameter name="Variable" required="true" />
+		</syntax>
+		<description>
+			<para>
+				At a minimum, either group or category must be provided.
+				For more information, see the dialplan function GROUP_VAR().
+			</para>
+		</description>
+	</manager>
+	<manager name="GroupVarSet" language="en_US">
+		<synopsis>
+			Set channel group variables.
+		</synopsis>
+		<syntax>
+			<xi:include xpointer="xpointer(/docs/manager[@name='Login']/syntax/parameter[@name='ActionID'])" />
+			<parameter name="Group" required="false" />
+			<parameter name="Category" required="false" />
+			<parameter name="Variable" required="true" />
+			<parameter name="Value" required="false" />
+		</syntax>
+		<description>
+			<para>
+				At a minimum, either group or category must be provided.
+				For more information, see the dialplan function GROUP_VAR().
+			</para>
+		</description>
+	</manager>
+	<manager name="GroupsShow" language="en_US">
+		<synopsis>
+			Show channel groups.  With optional filtering
+		</synopsis>
+		<syntax>
+			<xi:include xpointer="xpointer(/docs/manager[@name='Login']/syntax/parameter[@name='ActionID'])" />
+			<parameter name="Group" required="false">
+				<para>The exact group name to find, or to use a regular expression: set this parameter to: /regex/</para>
+			</parameter>
+			<parameter name="Category" required="false">
+				<para>The exact category to find, or to use a regular expression: set this parameter to: /regex/</para>
+			</parameter>
+		</syntax>
+		<description>
+			<para>
+				This will return a list of channel groups that are in use.
+				For more information, see the dialplan function GROUP().
+			</para>
+		</description>
+	</manager>
+	<manager name="GroupsShowChannels" language="en_US">
+		<synopsis>
+			Show group channel assignments. With optional filtering
+		</synopsis>
+		<syntax>
+			<xi:include xpointer="xpointer(/docs/manager[@name='Login']/syntax/parameter[@name='ActionID'])" />
+			<parameter name="Group" required="false">
+				<para>The exact group name to find, or to use a regular expression: set this parameter to: /regex/</para>
+			</parameter>
+			<parameter name="Category" required="false">
+				<para>The exact category to find, or to use a regular expression: set this parameter to: /regex/</para>
+			</parameter>
+		</syntax>
+		<description>
+			<para>
+				This will return a list the channels that are within each group.
+				For more information, see the dialplan function GROUP().
+			</para>
+		</description>
+	</manager>
+	<manager name="GroupsShowVariables" language="en_US">
+		<synopsis>
+			Show group channel variable assignments.
+		</synopsis>
+		<syntax>
+			<xi:include xpointer="xpointer(/docs/manager[@name='Login']/syntax/parameter[@name='ActionID'])" />
+		</syntax>
+		<description>
+			<para>
+				This will return a list of groups and the variables assigned in each group.
+				For more information, see the dialplan function GROUP_VAR().
+			</para>
+		</description>
+	</manager>
+	<managerEvent language="en_US" name="GroupVarGetResponse">
+		<managerEventInstance class="EVENT_FLAG_REPORTING">
+			<synopsis>
+				Raised in response to a a GroupVarGet command
+			</synopsis>
+			<syntax>
+				<parameter name="ActionID">
+					<para>ActionID (if any) that was passed into the GroupVarGet request</para>
+				</parameter>
+				<parameter name="Group">
+					<para>Name of the group that the variable is a part of</para>
+				</parameter>
+				<parameter name="Category">
+					<para>Name of the category that the variable is a part of</para>
+				</parameter>
+				<parameter name="Variable">
+					<para>The variable that was requested</para>
+				</parameter>
+				<parameter name="Value">
+					<para>The value of the variable</para>
+				</parameter>
+			</syntax>
+		</managerEventInstance>
+	</managerEvent>
 
  ***/
+
+static const char *dumpgroups_app = "DumpGroups";
 
 static int group_count_function_read(struct ast_channel *chan, const char *cmd,
 				     char *data, char *buf, size_t len)
 {
 	int ret = -1;
 	int count = -1;
-	char group[80] = "", category[80] = "";
+	char group[MAX_GROUP_LEN] = "", category[MAX_CATEGORY_LEN] = "";
 
 	if (!chan) {
 		ast_log(LOG_WARNING, "No channel was provided to %s function.\n", cmd);
@@ -128,15 +570,18 @@ static int group_count_function_read(struct ast_channel *chan, const char *cmd,
 
 		ast_app_group_list_rdlock();
 		for (gi = ast_app_group_list_head(); gi; gi = AST_LIST_NEXT(gi, group_list)) {
-			if (gi->chan != chan)
+			if (gi->chan != chan) {
 				continue;
-			if (ast_strlen_zero(category) || (!ast_strlen_zero(gi->category) && !strcasecmp(gi->category, category)))
+			}
+			if (ast_strlen_zero(category) || (!ast_strlen_zero(gi->category) && !strcasecmp(gi->category, category))) {
 				break;
+			}
 		}
 		if (gi) {
 			ast_copy_string(group, gi->group, sizeof(group));
-			if (!ast_strlen_zero(gi->category))
+			if (!ast_strlen_zero(gi->category)) {
 				ast_copy_string(category, gi->category, sizeof(category));
+			}
 		}
 		ast_app_group_list_unlock();
 	}
@@ -161,8 +606,8 @@ static int group_match_count_function_read(struct ast_channel *chan,
 					   const char *cmd, char *data, char *buf,
 					   size_t len)
 {
-	char group[80] = "";
-	char category[80] = "";
+	char group[MAX_GROUP_LEN] = "";
+	char category[MAX_CATEGORY_LEN] = "";
 
 	ast_app_group_split_group(data, group, sizeof(group), category,
 				  sizeof(category));
@@ -198,12 +643,15 @@ static int group_function_read(struct ast_channel *chan, const char *cmd,
 	ast_app_group_list_rdlock();
 
 	for (gi = ast_app_group_list_head(); gi; gi = AST_LIST_NEXT(gi, group_list)) {
-		if (gi->chan != chan)
+		if (gi->chan != chan) {
 			continue;
-		if (ast_strlen_zero(data))
+		}
+		if (ast_strlen_zero(data)) {
 			break;
-		if (!ast_strlen_zero(gi->category) && !strcasecmp(gi->category, data))
+		}
+		if (!ast_strlen_zero(gi->category) && !strcasecmp(gi->category, data)) {
 			break;
+		}
 	}
 
 	if (gi) {
@@ -249,6 +697,553 @@ static struct ast_custom_function group_function = {
 	.write = group_function_write,
 };
 
+
+/* GROUP_VAR and related */
+
+static int group_var_function_read(struct ast_channel *chan, const char *cmd,
+			       char *data, char *buf, size_t len)
+{
+	char group[MAX_GROUP_LEN] = "";
+	char category[MAX_CATEGORY_LEN] = "";
+	char *variable_value;
+	AST_DECLARE_APP_ARGS(args,
+		AST_APP_ARG(groupcategory);
+		AST_APP_ARG(varname);
+	);
+	AST_STANDARD_APP_ARGS(args, data);
+
+	buf[0] = '\0';
+
+	if (ast_strlen_zero(args.groupcategory) || ast_strlen_zero(args.varname)) {
+		ast_log(LOG_WARNING, "Syntax GROUP_VAR(group[@category],<varname>)\n");
+		return -1;
+	}
+
+	if (ast_app_group_split_group(args.groupcategory, group, sizeof(group), category, sizeof(category))) {
+		return -1;
+	}
+
+	variable_value = ast_app_group_get_var(group, category, args.varname);
+
+	if (variable_value) {
+		ast_copy_string(buf, variable_value, len);
+		ast_free(variable_value);
+	}
+
+	return 0;
+}
+
+static int group_var_function_write(struct ast_channel *chan, const char *cmd,
+				char *data, const char *value)
+{
+	char group[MAX_GROUP_LEN] = "";
+	char category[MAX_CATEGORY_LEN] = "";
+	int result;
+	AST_DECLARE_APP_ARGS(args,
+		AST_APP_ARG(groupcategory);
+		AST_APP_ARG(varname);
+	);
+	AST_STANDARD_APP_ARGS(args, data);
+
+	if (!value) {
+		value = "";
+	}
+
+	if (ast_strlen_zero(args.groupcategory) || ast_strlen_zero(args.varname)) {
+		ast_log(LOG_WARNING, "Syntax GROUP_VAR(group[@category],<varname>)=<value>)\n");
+		return -1;
+	}
+
+	ast_app_group_split_group(args.groupcategory, group, sizeof(group), category, sizeof(category));
+	result = ast_app_group_set_var(chan, group, category, args.varname, value);
+
+	if (result != 0) {
+		/* We know we're not passing any NULL values, so our error has to be 'non-exist' */
+		ast_log(LOG_WARNING, "GROUP_VAR() Variable set failed (group doesn't exist)");
+		return -1;
+	}
+
+	return 0;
+}
+
+static int manager_group_set(struct mansession *s, const struct message *m)
+{
+	const char *channel = astman_get_header(m, "Channel");
+	const char *group = astman_get_header(m, "Group");
+	const char *category = astman_get_header(m, "Category");
+
+	struct ast_channel *chan = NULL;
+	struct ast_str *group_category = ast_str_create(MAX_GROUP_LEN);
+
+	if (!group_category) {
+		astman_send_error(s, m, "Unable to allocate new variable.  Cannot proceed with GroupSet\n");
+		return AMI_SUCCESS;
+	}
+
+	if (ast_strlen_zero(channel)) {
+		astman_send_error(s, m, "Channel not specified.");
+		return AMI_SUCCESS;
+	}
+
+	chan = ast_channel_get_by_name(channel);
+	if (!chan) {
+		astman_send_error(s, m, "Channel not found.");
+		return AMI_SUCCESS;
+	}
+
+	if (!group) {
+		group = "";
+	}
+
+	if (!category) {
+		category = "";
+	}
+
+	if (ast_str_set(&group_category, 0, "%s@%s", group, category) == AST_DYNSTR_BUILD_FAILED) {
+		astman_send_error(s, m, "Unable to allocate new variable.  Cannot proceed with GroupSet\n");
+		goto done;
+        }
+
+	if (ast_app_group_set_channel(chan, ast_str_buffer(group_category)) == 0) {
+		astman_send_ack(s, m, "Group Set");
+		ast_channel_unref(chan);
+		return AMI_SUCCESS;
+	}
+
+	astman_send_error(s, m, "Group set failed.");
+
+       done:
+	ast_channel_unref(chan);
+        ast_free(group_category);
+
+	return AMI_SUCCESS;
+}
+
+static int manager_group_remove(struct mansession *s, const struct message *m)
+{
+	const char *group    = astman_get_header(m, "Group");
+	const char *category = astman_get_header(m, "Category");
+
+	if (ast_app_group_remove_all_channels(group, category) == 0) {
+		astman_send_ack(s, m, "Group Removed");
+		return AMI_SUCCESS;
+	}
+
+	astman_send_error(s, m, "Group remove failed.");
+
+	return AMI_SUCCESS;
+}
+
+static int manager_group_var_get(struct mansession *s, const struct message *m)
+{
+	const char *id = astman_get_header(m, "ActionID");
+	const char *group = astman_get_header(m, "Group");
+	const char *category = astman_get_header(m, "Category");
+	const char *variable = astman_get_header(m, "Variable");
+	char *variable_value;
+	char idText[256] = "";
+
+	if (ast_strlen_zero(group)) {
+		astman_send_error(s, m, "No group specified.");
+		return 0;
+	}
+
+	if (ast_strlen_zero(variable)) {
+		astman_send_error(s, m, "No variable specified.");
+		return 0;
+	}
+
+	if (!ast_strlen_zero(id)) {
+		snprintf(idText, sizeof(idText), "ActionID: %s\r\n", id);
+	}
+
+	if (!category) {
+		category = "";
+	}
+
+	variable_value = ast_app_group_get_var(group, category, variable);
+
+	if (!variable_value) {
+		astman_send_error(s, m, "Group variable not found");
+		return 0;
+	}
+
+	astman_send_ack(s, m, "Result will follow");
+	astman_append(s, "Event: GroupVarGetResponse\r\n"
+			"Group: %s\r\n"
+			"Category: %s\r\n"
+			"Variable: %s\r\n"
+			"Value: %s\r\n"
+			"%s"
+			"\r\n",
+			group, category, variable, variable_value, idText);
+
+        ast_free(variable_value);
+
+	return AMI_SUCCESS;
+}
+
+static int manager_group_var_set(struct mansession *s, const struct message *m)
+{
+	const char *group = astman_get_header(m, "Group");
+	const char *category = astman_get_header(m, "Category");
+	const char *variable = astman_get_header(m, "Variable");
+	const char *value = astman_get_header(m, "Value");
+	int result = 0;
+
+	if (ast_strlen_zero(group)) {
+		astman_send_error(s, m, "No group specified.");
+		return AMI_SUCCESS;
+	}
+
+	if (ast_strlen_zero(variable)) {
+		astman_send_error(s, m, "No variable specified.");
+		return AMI_SUCCESS;
+	}
+
+	if (!category) {
+		category = "";
+	}
+
+	if (!value) {
+		value = "";
+	}
+
+	result = ast_app_group_set_var(NULL, group, category, variable, value);
+
+	if (result != 0) {
+		/* We know we're not passing any NULL values, so our error has to be 'non-exist' */
+		astman_send_error(s, m, "Variable set failed (group doesn't exist)");
+		return 0;
+	}
+
+	astman_send_ack(s, m, "Variable Set");
+
+	return 0;
+}
+
+static int manager_groups_show(struct mansession *s, const struct message *m)
+{
+	const char *id			= astman_get_header(m, "ActionID");
+	const char *group_or_regex	= astman_get_header(m, "Group");    /* could be a regex, if starting with '/' */
+	const char *category_or_regex	= astman_get_header(m, "Category"); /* could be a regex, if starting with '/' */
+
+	const char *group_match		= NULL;
+	const char *category_match	= NULL;
+
+	struct ast_str *group_regex_string	= NULL;
+	struct ast_str *category_regex_string	= NULL;
+
+	regex_t regexbuf_group;
+	regex_t regexbuf_category;
+
+	struct ast_group_meta *gmi = NULL;
+	char idText[256] = "";
+	int groups = 0;
+
+	if (!ast_strlen_zero(group_or_regex)) {
+		if (group_or_regex[0] == '/') {
+			group_regex_string = ast_str_create(strlen(group_or_regex));
+			if (!group_regex_string) {
+				astman_send_error(s, m, "Memory Allocation Failure");
+				return 0; /* Nothing to clean up */
+			}
+
+			/* Make "/regex/" into "regex" */
+			if (ast_regex_string_to_regex_pattern(group_or_regex, &group_regex_string) != 0) {
+				astman_send_error(s, m, "Regex format invalid, Group param should be /regex/");
+				ast_free(group_regex_string);
+				return AMI_SUCCESS; /* Nothing else to clean up */
+			}
+
+			/* if regex compilation fails, whole command fails */
+			if (regcomp(&regexbuf_group, ast_str_buffer(group_regex_string), REG_EXTENDED | REG_NOSUB)) {
+				astman_send_error_va(s, m, "Regex compile failed on: %s", group_or_regex);
+				ast_free(group_regex_string);
+				return AMI_SUCCESS; /* Nothing else to clean up */
+			}
+		} else {
+			group_match = group_or_regex;
+		}
+	}
+
+	if (!ast_strlen_zero(category_or_regex)) {
+		if (category_or_regex[0] == '/') {
+			category_regex_string = ast_str_create(strlen(category_or_regex));
+			if (!category_regex_string) {
+				astman_send_error(s, m, "Memory Allocation Failure");
+				goto done;
+			}
+
+			/* Make "/regex/" into "regex" */
+			if (ast_regex_string_to_regex_pattern(category_or_regex, &category_regex_string) != 0) {
+				astman_send_error(s, m, "Regex format invalid, Category param should be /regex/");
+				ast_free(category_regex_string);
+				category_regex_string = NULL;
+				goto done;
+			}
+
+			/* if regex compilation fails, whole command fails */
+			if (regcomp(&regexbuf_category, ast_str_buffer(category_regex_string), REG_EXTENDED | REG_NOSUB)) {
+				astman_send_error_va(s, m, "Regex compile failed on: %s", category_or_regex);
+				ast_free(category_regex_string);
+				category_regex_string = NULL;
+				goto done;
+			}
+		} else {
+			category_match = category_or_regex;
+		}
+	}
+
+	if (!ast_strlen_zero(id)) {
+		snprintf(idText, sizeof(idText), "ActionID: %s\r\n", id);
+	}
+
+	astman_send_listack(s, m, "Groups will follow", "start");
+
+	ast_app_group_meta_rdlock();
+	for (gmi = ast_app_group_meta_head(); gmi; gmi = AST_LIST_NEXT(gmi, group_meta_list)) {
+		if (group_regex_string && regexec(&regexbuf_group, gmi->group, 0, NULL, 0)) {
+			continue;
+		}
+
+		if (category_regex_string && regexec(&regexbuf_category, gmi->category, 0, NULL, 0)) {
+			continue;
+		}
+
+		if (group_match && strcmp(group_match, gmi->group)) {
+			continue;
+		}
+
+		if (category_match && strcmp(category_match, gmi->category)) {
+			continue;
+		}
+
+		astman_append(s,
+			"Event: GroupsShow\r\n"
+			"Group: %s\r\n"
+			"Category: %s\r\n"
+			"%s"
+			"\r\n", gmi->group, gmi->category, idText);
+
+		groups++;
+	}
+	ast_app_group_meta_unlock();
+
+	astman_append(s,
+		"Event: GroupsShowComplete\r\n"
+		"EventList: Complete\r\n"
+		"ListItems: %d\r\n"
+		"%s"
+		"\r\n", groups, idText);
+
+done:
+	if (group_regex_string) {
+		regfree(&regexbuf_group);
+		ast_free(group_regex_string);
+	}
+
+	if (category_regex_string) {
+		regfree(&regexbuf_category);
+		ast_free(category_regex_string);
+	}
+
+	return AMI_SUCCESS;
+}
+
+static int manager_groups_show_channels(struct mansession *s, const struct message *m)
+{
+	const char *id = astman_get_header(m, "ActionID");
+	const char *group_or_regex    = astman_get_header(m, "Group");	  /* could be a regex, if starting with '/' */
+	const char *category_or_regex = astman_get_header(m, "Category"); /* could be a regex, if starting with '/' */
+
+	const char *group_match	   = NULL;
+	const char *category_match = NULL;
+
+	struct ast_str *group_regex_string    = NULL;
+	struct ast_str *category_regex_string = NULL;
+
+	regex_t regexbuf_group;
+	regex_t regexbuf_category;
+
+	struct ast_group_info *gi = NULL;
+	char idText[256] = "";
+	int channels = 0;
+
+	if (!ast_strlen_zero(group_or_regex)) {
+		if (group_or_regex[0] == '/') {
+			group_regex_string = ast_str_create(strlen(group_or_regex));
+			if (!group_regex_string) {
+				astman_send_error(s, m, "Memory Allocation Failure");
+				return 0; /* Nothing to clean up */
+			}
+
+			/* Make "/regex/" into "regex" */
+			if (ast_regex_string_to_regex_pattern(group_or_regex, &group_regex_string) != 0) {
+				astman_send_error(s, m, "Regex format invalid, Group param should be /regex/");
+				ast_free(group_regex_string);
+				return AMI_SUCCESS; /* Nothing else to clean up */
+			}
+
+			/* if regex compilation fails, whole command fails */
+			if (regcomp(&regexbuf_group, ast_str_buffer(group_regex_string), REG_EXTENDED | REG_NOSUB)) {
+				astman_send_error_va(s, m, "Regex compile failed on: %s", group_or_regex);
+				ast_free(group_regex_string);
+				return AMI_SUCCESS; /* Nothing else to clean up */
+			}
+		} else {
+			group_match = group_or_regex;
+		}
+	}
+
+	if (!ast_strlen_zero(category_or_regex)) {
+		if (category_or_regex[0] == '/') {
+			category_regex_string = ast_str_create(strlen(category_or_regex));
+			if (!category_regex_string) {
+				astman_send_error(s, m, "Memory Allocation Failure");
+				goto done;
+			}
+
+			/* Make "/regex/" into "regex" */
+			if (ast_regex_string_to_regex_pattern(category_or_regex, &category_regex_string) != 0) {
+				astman_send_error(s, m, "Regex format invalid, Category param should be /regex/");
+				ast_free(category_regex_string);
+				category_regex_string = NULL;
+				goto done;
+			}
+
+			/* if regex compilation fails, whole command fails */
+			if (regcomp(&regexbuf_category, ast_str_buffer(category_regex_string), REG_EXTENDED | REG_NOSUB)) {
+				astman_send_error_va(s, m, "Regex compile failed on: %s", category_or_regex);
+				ast_free(category_regex_string);
+				category_regex_string = NULL;
+				goto done;
+			}
+		} else {
+			category_match = category_or_regex;
+		}
+	}
+
+	if (!ast_strlen_zero(id)) {
+		snprintf(idText, sizeof(idText), "ActionID: %s\r\n", id);
+	}
+
+	astman_send_listack(s, m, "Group channels will follow", "start");
+
+	ast_app_group_list_rdlock();
+	for (gi = ast_app_group_list_head(); gi; gi = AST_LIST_NEXT(gi, group_list)) {
+		if (group_regex_string && regexec(&regexbuf_group, gi->group, 0, NULL, 0)) {
+			continue;
+		}
+
+		if (category_regex_string && regexec(&regexbuf_category, gi->category, 0, NULL, 0)) {
+			continue;
+		}
+
+		if (group_match && strcmp(group_match, gi->group)) {
+			continue;
+		}
+
+		if (category_match && strcmp(category_match, gi->category)) {
+			continue;
+		}
+
+		astman_append(s,
+			"Event: GroupsShowChannels\r\n"
+			"Group: %s\r\n"
+			"Category: %s\r\n"
+			"Channel: %s\r\n"
+			"%s"
+			"\r\n", gi->group, gi->category, ast_channel_name(gi->chan), idText);
+
+		channels++;
+	}
+	ast_app_group_list_unlock();
+
+	astman_append(s,
+		"Event: GroupsShowChannelsComplete\r\n"
+		"EventList: Complete\r\n"
+		"ListItems: %d\r\n"
+		"%s"
+		"\r\n", channels, idText);
+
+done:
+	if (group_regex_string) {
+		regfree(&regexbuf_group);
+		ast_free(group_regex_string);
+	}
+
+	if (category_regex_string) {
+		regfree(&regexbuf_category);
+		ast_free(category_regex_string);
+	}
+
+	return AMI_SUCCESS;
+}
+
+static int manager_groups_show_variables(struct mansession *s, const struct message *m)
+{
+	const char *id = astman_get_header(m, "ActionID");
+	struct ast_group_meta *gmi = NULL;
+	char action_id[256] = "";
+	int groups = 0;
+
+	struct varshead *headp;
+	struct ast_var_t *vardata;
+	struct ast_str *variables = ast_str_create(100);
+
+	if (!variables) {
+		ast_log(LOG_ERROR, "Unable to allocate new variable.  Cannot proceed with GroupsShowVariables().\n");
+		return AMI_SUCCESS;
+	}
+
+	if (!ast_strlen_zero(id)) {
+		snprintf(action_id, sizeof(action_id), "ActionID: %s\r\n", id);
+	}
+
+	astman_send_listack(s, m, "Group variables will follow", "start");
+
+	ast_app_group_meta_rdlock();
+	for (gmi = ast_app_group_meta_head(); gmi; gmi = AST_LIST_NEXT(gmi, group_meta_list)) {
+		headp = &gmi->varshead;
+		ast_str_reset(variables);
+
+		AST_LIST_TRAVERSE(headp, vardata, entries) {
+			ast_str_append(&variables, 0, "Variable(%s): %s\r\n", ast_var_name(vardata), ast_var_value(vardata));
+		}
+
+		astman_append(s,
+			"Event: GroupsShowVariables\r\n"
+			"Group: %s\r\n"
+			"Category: %s\r\n"
+			"%s"
+			"%s"
+			"\r\n", gmi->group, gmi->category, action_id, ast_str_buffer((variables)));
+
+		groups++;
+	}
+	ast_app_group_meta_unlock();
+
+	astman_append(s,
+		"Event: GroupsShowVariablesComplete\r\n"
+		"EventList: Complete\r\n"
+		"ListItems: %d\r\n"
+		"%s"
+		"\r\n", groups, action_id);
+
+	ast_free(variables);
+
+	return AMI_SUCCESS;
+}
+
+static struct ast_custom_function group_var_function = {
+	.name = "GROUP_VAR",
+	.syntax = "GROUP_VAR(groupname[@category],var)",
+	.synopsis = "Gets or sets a channel group variable.",
+	.read = group_var_function_read,
+	.write = group_var_function_write,
+};
+
 static int group_list_function_read(struct ast_channel *chan, const char *cmd,
 				    char *data, char *buf, size_t len)
 {
@@ -262,19 +1257,23 @@ static int group_list_function_read(struct ast_channel *chan, const char *cmd,
 	ast_app_group_list_rdlock();
 
 	for (gi = ast_app_group_list_head(); gi; gi = AST_LIST_NEXT(gi, group_list)) {
-		if (gi->chan != chan)
+		if (gi->chan != chan) {
 			continue;
+		}
+
 		if (!ast_strlen_zero(tmp1)) {
 			ast_copy_string(tmp2, tmp1, sizeof(tmp2));
-			if (!ast_strlen_zero(gi->category))
+			if (!ast_strlen_zero(gi->category)) {
 				snprintf(tmp1, sizeof(tmp1), "%s %s@%s", tmp2, gi->group, gi->category);
-			else
+			} else {
 				snprintf(tmp1, sizeof(tmp1), "%s %s", tmp2, gi->group);
+			}
 		} else {
-			if (!ast_strlen_zero(gi->category))
+			if (!ast_strlen_zero(gi->category)) {
 				snprintf(tmp1, sizeof(tmp1), "%s@%s", gi->group, gi->category);
-			else
+			} else {
 				snprintf(tmp1, sizeof(tmp1), "%s", gi->group);
+			}
 		}
 	}
 
@@ -285,10 +1284,270 @@ static int group_list_function_read(struct ast_channel *chan, const char *cmd,
 	return 0;
 }
 
+static int group_match_list_function_read(struct ast_channel *chan, const char *cmd,
+				    char *data, char *buf, size_t len)
+{
+	struct ast_group_meta *gmi = NULL;
+	struct ast_str *foundgroup_str = ast_str_create(MAX_GROUP_LEN + MAX_CATEGORY_LEN);
+
+	char groupmatch[MAX_GROUP_LEN] = "";
+	char categorymatch[MAX_CATEGORY_LEN] = "";
+	int groups_found = 0;
+	regex_t regexbuf_group;
+	regex_t regexbuf_category;
+
+	buf[0] = '\0';
+
+	if (!foundgroup_str) {
+		ast_log(LOG_ERROR, "Unable to allocate new variable.  Cannot proceed with GROUP_MATCH_LIST()\n");
+		return -1;
+	}
+
+	ast_app_group_split_group(data, groupmatch, sizeof(groupmatch), categorymatch, sizeof(categorymatch));
+
+	/* if regex compilation fails, return zero matches */
+	if (regcomp(&regexbuf_group, groupmatch, REG_EXTENDED | REG_NOSUB)) {
+		ast_log(LOG_ERROR, "Regex compile failed on: %s\n", groupmatch);
+		return -1;
+	}
+
+	if (regcomp(&regexbuf_category, categorymatch, REG_EXTENDED | REG_NOSUB)) {
+		ast_log(LOG_ERROR, "Regex compile failed on: %s\n", categorymatch);
+		regfree(&regexbuf_group);
+		return -1;
+	}
+
+	/* Traverse all groups, and keep track of what we find */
+	ast_app_group_meta_rdlock();
+	for (gmi = ast_app_group_meta_head(); gmi; gmi = AST_LIST_NEXT(gmi, group_meta_list)) {
+		if (!regexec(&regexbuf_group, gmi->group, 0, NULL, 0) && (ast_strlen_zero(categorymatch) || (!ast_strlen_zero(gmi->category) && !regexec(&regexbuf_category, gmi->category, 0, NULL, 0)))) {
+			if (groups_found > 1) {
+				ast_str_append(&foundgroup_str, 0, ",");
+			}
+
+			ast_str_append(&foundgroup_str, 0, "%s@%s", gmi->group, gmi->category);
+
+			groups_found++;
+		}
+	}
+	ast_app_group_meta_unlock();
+
+	snprintf(buf, len, "%s", ast_str_buffer(foundgroup_str));
+
+	regfree(&regexbuf_group);
+	regfree(&regexbuf_category);
+
+	return 0;
+}
+
+static int dumpgroups_exec(struct ast_channel *chan, const char *data)
+{
+#define FORMAT_STRING_CHANNELS	"%-25s	%-20s  %-20s\n"
+#define FORMAT_STRING_GROUPS	 "%-20s	 %-20s\n"
+#define FORMAT_STRING_VAR "	%s=%s\n"
+
+	static char *line     = "================================================================================";
+	static char *thinline = "-----------------------------------";
+
+	struct ast_group_info *gi = NULL;
+	struct ast_group_meta *gmi = NULL;
+	struct varshead *headp;
+	struct ast_var_t *variable = NULL;
+	int numgroups = 0;
+	int numchans = 0;
+	struct ast_str *out = ast_str_create(4096);
+
+	if (!out) {
+		ast_log(LOG_ERROR, "Unable to allocate new variable.  Cannot proceed with DumpGroups().\n");
+		return -1;
+	}
+
+	ast_verbose("%s\n", line);
+	ast_verbose(FORMAT_STRING_CHANNELS, "Channel", "Group", "Category\n");
+
+	ast_app_group_list_rdlock();
+	gi = ast_app_group_list_head();
+	while (gi) {
+		ast_str_append(&out, 0, FORMAT_STRING_CHANNELS, ast_channel_name(gi->chan), gi->group, (ast_strlen_zero(gi->category) ? "(default)" : gi->category));
+		numchans++;
+		gi = AST_LIST_NEXT(gi, group_list);
+	}
+
+	ast_app_group_list_unlock();
+
+	ast_str_append(&out, 0, "%d active group assignment%s\n", numchans, ESS(numchans));
+
+	ast_str_append(&out, 0, "%s\n", thinline);
+	/****************** Group Variables ******************/
+
+	ast_str_append(&out, 0, "Group	  Variables    Category\n");
+
+	/* Print group variables */
+	ast_app_group_meta_rdlock();
+	gmi = ast_app_group_meta_head();
+	while (gmi) {
+		ast_str_append(&out, 0, FORMAT_STRING_GROUPS, gmi->group, (strcmp(gmi->category, "") ? gmi->category : "(Default)"));
+		numgroups++;
+		headp = &gmi->varshead;
+
+		AST_LIST_TRAVERSE(headp, variable, entries) {
+			ast_str_append(&out, 0, FORMAT_STRING_VAR, ast_var_name(variable), ast_var_value(variable));
+		}
+
+		gmi = AST_LIST_NEXT(gmi, group_meta_list);
+	}
+	ast_app_group_meta_unlock();
+
+	ast_str_append(&out, 0, "%s\n", line);
+
+	ast_verbose("%s\n", ast_str_buffer(out));
+
+	ast_free(out);
+
+	return 0;
+
+#undef FORMAT_STRING_CHANNELS
+#undef FORMAT_STRING_GROUPS
+#undef FORMAT_STRING_VAR
+}
+
+static struct ast_custom_function group_match_list_function = {
+	.name = "GROUP_MATCH_LIST",
+	.read = group_match_list_function_read,
+	.write = NULL,
+};
+
 static struct ast_custom_function group_list_function = {
 	.name = "GROUP_LIST",
 	.read = group_list_function_read,
 	.write = NULL,
+};
+
+static int group_channel_list_function_read(struct ast_channel *chan, const char *cmd, char *data, char *buf, size_t len)
+{
+	char group[MAX_GROUP_LEN] = "";
+	char category[MAX_CATEGORY_LEN] = "";
+	struct ast_group_info *gi = NULL;
+	int out_len = 0;
+        int remaining_buf = len;
+        char *buf_pos = buf;
+
+	AST_DECLARE_APP_ARGS(args,
+		AST_APP_ARG(groupcategory);
+	);
+	AST_STANDARD_APP_ARGS(args, data);
+
+	pbx_builtin_setvar_helper(chan, "GROUP_CHANNEL_LIST_ERROR", NULL);
+
+	buf[0] = '\0';
+
+	if (ast_strlen_zero(args.groupcategory)) {
+		ast_log(LOG_WARNING, "Syntax GROUP_CHANNEL_LIST(group[@category])\n");
+		return -1;
+	}
+
+	if (ast_app_group_split_group(args.groupcategory, group, sizeof(group), category, sizeof(category))) {
+		return -1;
+	}
+
+	ast_app_group_list_rdlock();
+	gi = ast_app_group_list_head();
+	while (gi) {
+		if (!strcasecmp(gi->group, group) && (ast_strlen_zero(category) || (!ast_strlen_zero(gi->category) && !strcasecmp(gi->category, category)))) {
+			int write_len;
+
+			/* In the odd event we go over the buffer length, don't include a partial channel name */
+			int channel_name_len = strlen(ast_channel_name(gi->chan));
+
+			if ((out_len + channel_name_len + 1) > len) { /* +1 for null */
+				ast_log(LOG_WARNING, "GROUP_CHANNEL_LIST(%s) Channel membership list too large for buffer, truncating.\n", args.groupcategory);
+				pbx_builtin_setvar_helper(chan, "GROUP_CHANNEL_LIST_ERROR", "TRUNCATED");
+				break;
+			}
+
+			write_len = snprintf(buf_pos, remaining_buf, "%s,", ast_channel_name(gi->chan));
+                        /* Note we already prevent buffer overrun above, write_len will always be characters written */
+			out_len += write_len;
+			buf_pos += write_len;
+			remaining_buf -= write_len;
+		}
+
+		gi = AST_LIST_NEXT(gi, group_list);
+	}
+	ast_app_group_list_unlock();
+
+	/* delete the last comma.  We'll always have a final comma, because we already do overlength check above, so we'll never have a partial write */
+	if (out_len) {
+		buf_pos--;
+		*buf_pos = '\0';
+	}
+
+	return 0;
+}
+
+static struct ast_custom_function group_channel_list_function = {
+	.name = "GROUP_CHANNEL_LIST",
+	.read = group_channel_list_function_read,
+};
+
+static int group_match_channel_list_function_read(struct ast_channel *chan, const char *cmd, char *data, char *buf, size_t len)
+{
+	char group[MAX_GROUP_LEN] = "";
+	char category[MAX_CATEGORY_LEN] = "";
+	struct ast_group_info *gi = NULL;
+	struct ast_str *out = ast_str_create(1024);
+	int out_len = 0;
+
+	AST_DECLARE_APP_ARGS(args,
+		AST_APP_ARG(groupcategory);
+	);
+	AST_STANDARD_APP_ARGS(args, data);
+
+	if (!out) {
+		ast_log(LOG_ERROR, "Unable to allocate new variable.  Cannot proceed with GROUP_MATCH_CHANNEL_LIST().\n");
+		return -1;
+	}
+
+	buf[0] = 0;
+
+	if (ast_strlen_zero(args.groupcategory)) {
+		ast_log(LOG_WARNING, "Syntax GROUP_MATCH_CHANNEL_LIST(group[@category])\n");
+		return -1;
+	}
+
+	if (ast_app_group_split_group(args.groupcategory, group, sizeof(group), category, sizeof(category))) {
+		return -1;
+	}
+
+	ast_app_group_list_rdlock();
+	gi = ast_app_group_list_head();
+	while (gi) {
+		if (!strcasecmp(gi->group, group) && (ast_strlen_zero(category) || (!ast_strlen_zero(gi->category) && !strcasecmp(gi->category, category)))) {
+			ast_str_append(&out, 0, "%s,", ast_channel_name(gi->chan));
+		}
+
+		gi = AST_LIST_NEXT(gi, group_list);
+	}
+	ast_app_group_list_unlock();
+
+	out_len = strlen(ast_str_buffer(out));
+
+	if (out_len) {
+		if (out_len <= len) {
+			len -= 1; /* rid , only if we didn't go over the buffer limit */
+		}
+
+		ast_copy_string(buf, ast_str_buffer(out), len);
+	}
+
+	ast_free(out);
+
+	return 0;
+}
+
+static struct ast_custom_function group_match_channel_list_function = {
+	.name = "GROUP_MATCH_CHANNEL_LIST",
+	.read = group_match_channel_list_function_read,
 };
 
 static int unload_module(void)
@@ -297,8 +1556,20 @@ static int unload_module(void)
 
 	res |= ast_custom_function_unregister(&group_count_function);
 	res |= ast_custom_function_unregister(&group_match_count_function);
+	res |= ast_custom_function_unregister(&group_match_list_function);
+	res |= ast_custom_function_unregister(&group_match_channel_list_function);
 	res |= ast_custom_function_unregister(&group_list_function);
+	res |= ast_custom_function_unregister(&group_channel_list_function);
+	res |= ast_custom_function_unregister(&group_var_function);
 	res |= ast_custom_function_unregister(&group_function);
+
+	res |= ast_unregister_application(dumpgroups_app);
+
+	res |= ast_manager_unregister("GroupVarGet");
+	res |= ast_manager_unregister("GroupVarSet");
+	res |= ast_manager_unregister("GroupsShow");
+	res |= ast_manager_unregister("GroupsShowChannels");
+	res |= ast_manager_unregister("GroupsShowVariables");
 
 	return res;
 }
@@ -309,8 +1580,22 @@ static int load_module(void)
 
 	res |= ast_custom_function_register(&group_count_function);
 	res |= ast_custom_function_register(&group_match_count_function);
+	res |= ast_custom_function_register(&group_match_list_function);
+	res |= ast_custom_function_register(&group_match_channel_list_function);
 	res |= ast_custom_function_register(&group_list_function);
+	res |= ast_custom_function_register(&group_channel_list_function);
+	res |= ast_custom_function_register(&group_var_function);
 	res |= ast_custom_function_register(&group_function);
+
+	res |= ast_register_application_xml(dumpgroups_app, dumpgroups_exec);
+
+	res |= ast_manager_register_xml("GroupSet",    EVENT_FLAG_CALL, manager_group_set);
+	res |= ast_manager_register_xml("GroupRemove", EVENT_FLAG_CALL, manager_group_remove);
+	res |= ast_manager_register_xml("GroupVarGet", EVENT_FLAG_CALL, manager_group_var_get);
+	res |= ast_manager_register_xml("GroupVarSet", EVENT_FLAG_CALL, manager_group_var_set);
+	res |= ast_manager_register_xml("GroupsShow",  EVENT_FLAG_REPORTING, manager_groups_show);
+	res |= ast_manager_register_xml("GroupsShowChannels",  EVENT_FLAG_REPORTING, manager_groups_show_channels);
+	res |= ast_manager_register_xml("GroupsShowVariables", EVENT_FLAG_REPORTING, manager_groups_show_variables);
 
 	return res;
 }

--- a/include/asterisk/app.h
+++ b/include/asterisk/app.h
@@ -1196,8 +1196,47 @@ struct ast_group_info;
 /*! \brief Split a group string into group and category, returning a default category if none is provided. */
 int ast_app_group_split_group(const char *data, char *group, int group_max, char *category, int category_max);
 
+/*! \brief Remove channel assignments for the specified group  */
+int ast_app_group_remove_all_channels(const char *group, const char *category);
+
+/*! \brief Rename a group@category while retaining all the channel memberships
+ * \return Number of rename operations performed
+ * \retval -1 on Error
+ * \retval 0 group@category was not found
+ */
+int ast_app_group_rename(const char *old_group, const char *old_category, const char *new_group, const char *new_category);
+
 /*! \brief Set the group for a channel, splitting the provided data into group and category, if specified. */
 int ast_app_group_set_channel(struct ast_channel *chan, const char *data);
+
+/*!
+ * \brief Set a group variable for a group@category
+ *
+ * \param chan      channel (if any) that is setting the group variable (can be NULL)
+ * \param group     group to set the variable on (cannot be null)
+ * \param category  category to set the variable on (cannot be null)
+ * \param name      name of the variable to set (cannot be null)
+ * \param value     value of the variable to set (cannot be null)
+ *
+ * \retval 0 On success
+ * \retval -1 On failure (group@category not found)
+ * \retval -2 On failure (input validation error)
+ */
+int ast_app_group_set_var(struct ast_channel *chan, const char *group, const char *category, const char *name, const char *value);
+
+/*!
+ * \brief Get a group variable for a group@category
+ *
+ * \param group     group to get the variable from
+ * \param category  category to get the variable from
+ * \param name      name of the variable to get
+ *
+ * \return Allocated string containing variable contents
+ * \retval NULL On failure (variable in group@category not found)
+ *
+ * \post caller must ast_free() the returned value
+ */
+char *ast_app_group_get_var(const char *group, const char *category, const char *name);
 
 /*! \brief Get the current channel count of the specified group and category. */
 int ast_app_group_get_count(const char *group, const char *category);
@@ -1222,6 +1261,15 @@ struct ast_group_info *ast_app_group_list_head(void);
 
 /*! \brief Unlock the group count list */
 int ast_app_group_list_unlock(void);
+
+/*! \brief Read Lock the group meta list */
+int ast_app_group_meta_rdlock(void);
+
+/*! \brief Get the head of the group meta list */
+struct ast_group_meta *ast_app_group_meta_head(void);
+
+/*! \brief Unlock the group meta list */
+int ast_app_group_meta_unlock(void);
 
 /*!
   \brief Define an application argument

--- a/include/asterisk/channel.h
+++ b/include/asterisk/channel.h
@@ -122,6 +122,8 @@ References:
 #ifndef _ASTERISK_CHANNEL_H
 #define _ASTERISK_CHANNEL_H
 
+#include <regex.h>
+
 #include "asterisk/alertpipe.h"
 #include "asterisk/abstract_jb.h"
 #include "asterisk/astobj2.h"
@@ -174,6 +176,9 @@ extern "C" {
 #define MAX_LANGUAGE            40  /*!< Max length of the language setting */
 #define MAX_MUSICCLASS          80  /*!< Max length of the music class setting */
 #define AST_MAX_USER_FIELD      256 /*!< Max length of the channel user field */
+
+#define MAX_GROUP_LEN		80	/*!< Max length of a channel group */
+#define MAX_CATEGORY_LEN	80	/*!< Max length of a channel group category */
 
 #include "asterisk/frame.h"
 #include "asterisk/chanvars.h"
@@ -2980,6 +2985,18 @@ struct ast_group_info {
 	AST_LIST_ENTRY(ast_group_info) group_list;
 };
 
+/*! \brief list of groups currently in use, with a pointer to a list of channels within the groups */
+struct ast_group_meta {
+	int num_channels;				/*!< number of channels in this group */
+	struct varshead varshead;			/*!< A linked list for group variables. See \ref AstGroupVar */
+
+	AST_LIST_ENTRY(ast_group_info) channels_list;	/*!< List of channels in this group */
+	AST_LIST_ENTRY(ast_group_meta) group_meta_list;	/*!< Next group */
+
+	char category[MAX_CATEGORY_LEN];
+	char group[MAX_GROUP_LEN];
+};
+
 #define ast_channel_lock(chan) ao2_lock(chan)
 #define ast_channel_unlock(chan) ao2_unlock(chan)
 #define ast_channel_trylock(chan) ao2_trylock(chan)
@@ -3211,6 +3228,7 @@ struct ast_channel *ast_channel_get_by_name_prefix(const char *name, size_t name
 struct ast_channel *ast_channel_get_by_exten(const char *exten, const char *context);
 
 /*!
+
  * \brief Find a channel by a uniqueid
  *
  * \param uniqueid The uniqueid to search for
@@ -3219,6 +3237,34 @@ struct ast_channel *ast_channel_get_by_exten(const char *exten, const char *cont
  * \retval NULL if no channel was found
  */
 struct ast_channel *ast_channel_get_by_uniqueid(const char *uniqueid);
+
+/*
+ * \brief Find a channel by a regex string
+ *
+ * \arg regex_string the regex pattern to search for
+ *
+ * Return a channel that where the regex pattern matches the channel name
+ *
+ * \retval a channel that matches the regex pattern
+ * \retval NULL if no channel was found or pattern is bad
+ *
+ * \since 23
+ */
+struct ast_channel *ast_channel_get_by_regex(const char *regex_string);
+
+/*!
+ * \brief Find a channel by a regex pattern
+ *
+ * \arg regex the compiled regex pattern to search for
+ *
+ * Return a channel that where the regex pattern matches the channel name
+ *
+ * \retval a channel that matches the regex pattern
+ * \retval NULL if no channel was found
+ *
+ * \since 23
+ */
+struct ast_channel *ast_channel_get_by_regex_compiled(regex_t *regex);
 
 /*! @} End channel search functions. */
 

--- a/include/asterisk/chanvars.h
+++ b/include/asterisk/chanvars.h
@@ -33,27 +33,143 @@ struct ast_var_t {
 
 AST_LIST_HEAD_NOLOCK(varshead, ast_var_t);
 
+
+/*!
+ * \brief Create a new variables list and initalize to empty
+ *
+ * \retval NULL on error
+ * \retval returns the pointer to the newly created list on success
+ */
 struct varshead *ast_var_list_create(void);
+
+/*!
+ * \brief Remove all variables from the list, free them and also free the list
+ *
+ * \param head pointer to the list
+ *
+ */
 void ast_var_list_destroy(struct varshead *head);
 
 struct ast_var_t *_ast_var_assign(const char *name, const char *value, const char *file, int lineno, const char *function);
+
+/*!
+ * \brief Insert a new variable into the variables list and store the value
+ *
+ * \param name      name of the variable to set
+ * \param value     value of the variable to set
+ *
+ * \retval NULL on error
+ * \retval returns a populated struct ast_var_t
+ */
 #define ast_var_assign(name, value) _ast_var_assign(name, value, __FILE__, __LINE__, __PRETTY_FUNCTION__)
 
+/*!
+ * \brief Free a variable.  This does not remove the variable from the list that it might be a part of
+ * \see linkedlists.h
+ *
+ * \see ast_var_find
+ * \see ast_var_assign
+ *
+ * \param var           must be a struct ast_var_t* that's been set up with ast_var_assign
+ *
+ */
 void ast_var_delete(struct ast_var_t *var);
+
+/*!
+ * \brief Return the name component of an existing struct ast_var_t, stripping any _ or __ inheritance modifiers
+ *
+ * \param var must be a struct ast_var_t * (Allowed to be empty/uninitalized)
+ *
+ * \retval NULL on error
+ * \retval variable name on success
+ */
 const char *ast_var_name(const struct ast_var_t *var);
+
+/*!
+ * \brief Return the full name component of an existing struct ast_var_t, including any _ or __ inheritance modifiers
+ *
+ * \param var must be a struct ast_var_t * (Allowed to be empty/uninitalized)
+ *
+ * \retval NULL on error
+ * \retval variable name on success
+ */
 const char *ast_var_full_name(const struct ast_var_t *var);
+
+/*!
+ * \brief Return the value component of an existing struct ast_var_t
+ *
+ * \param var must be a struct ast_var_t * (Allowed to be empty/uninitalized)
+ *
+ * \retval NULL on error
+ * \retval variable value on success
+ */
 const char *ast_var_value(const struct ast_var_t *var);
+
+/*!
+ * \brief Find a variable by full name
+ *
+ * \note If the original variable was set with a _ or __ prefix, the name param for this search will have to match exactly
+ *
+ * \see ast_var_full_name
+ *
+ * \param varshead      pointer to an existing and fully set up variables list
+ * \param name          name of the variable to find
+ *
+ * \retval variable value on success
+ * \retval NULL on not found
+ */
 char *ast_var_find(const struct varshead *head, const char *name);
+
+/*!
+ * \brief Create a brand new variables list with the same variables as the source list
+ *
+ * \param head an existing varshead
+ *
+ * \retval NULL on error
+ * \retval pointer to new list on success
+ */
 struct varshead *ast_var_list_clone(struct varshead *head);
 
+/*!
+ * \brief Traverse the variable list in the same style as AST_LIST_TRAVERSE
+ *
+ * * \param head This is a pointer to the list head structure
+ * \param var This is the name of the variable that will hold a pointer to the
+ * current list entry on each iteration. It must be declared before calling
+ * this macro.
+ * \param field This is the name of the field (declared using AST_LIST_ENTRY())
+ * used to link entries of this list together.
+ *
+ *
+ * \see AST_LIST_TRAVERSE
+ */
 #define AST_VAR_LIST_TRAVERSE(head, var) AST_LIST_TRAVERSE(head, var, entries)
 
+/*!
+ * \brief Insert into the end of the variables list in the same style as AST_LIST_INSERT_TAIL
+ *
+ * \see AST_LIST_INSERT_TAIL
+ *
+ * \param head          list to insert into
+ * \param var           must be a struct ast_var_t * (Allowed to be empty/uninitalized)
+ *
+ */
 static inline void AST_VAR_LIST_INSERT_TAIL(struct varshead *head, struct ast_var_t *var) {
 	if (var) {
 		AST_LIST_INSERT_TAIL(head, var, entries);
 	}
 }
 
+
+/*!
+ * \brief Insert into the beginning of the variables list in the same style as AST_LIST_INSERT_HEAD
+ *
+ * \see AST_LIST_INSERT_HEAD
+ *
+ * \param head          list to insert into
+ * \param var           must be a struct ast_var_t * (Allowed to be empty/uninitalized)
+ *
+ */
 static inline void AST_VAR_LIST_INSERT_HEAD(struct varshead *head, struct ast_var_t *var) {
 	if (var) {
 		AST_LIST_INSERT_HEAD(head, var, entries);

--- a/main/app.c
+++ b/main/app.c
@@ -61,6 +61,7 @@
 #include "asterisk/indications.h"
 #include "asterisk/linkedlists.h"
 #include "asterisk/threadstorage.h"
+#include "asterisk/manager.h"
 #include "asterisk/test.h"
 #include "asterisk/module.h"
 #include "asterisk/astobj2.h"
@@ -68,6 +69,95 @@
 #include "asterisk/stasis_channels.h"
 #include "asterisk/json.h"
 #include "asterisk/format_cache.h"
+
+/*** DOCUMENTATION
+	<managerEvent language="en_US" name="GroupCreate">
+		<managerEventInstance class="EVENT_FLAG_REPORTING">
+			<synopsis>Raised when a group has been created. Note: GroupChannelAdd events will show which channels have been assigned this group@category</synopsis>
+			<syntax>
+				<parameter name="Category">
+					<para>The category portion of the group@category that has been created</para>
+				</parameter>
+				<parameter name="Group">
+					<para>The group portion of the group@category that has been created</para>
+				</parameter>
+			</syntax>
+		</managerEventInstance>
+	</managerEvent>
+	<managerEvent language="en_US" name="GroupChannelAdd">
+		<managerEventInstance class="EVENT_FLAG_REPORTING">
+			<synopsis>Raised when a channel is now a part of a group@category GROUP() assignment</synopsis>
+			<syntax>
+				<parameter name="Channel">
+					<para>Channel that is now part of this group@category</para>
+				</parameter>
+				<parameter name="Uniqueid">
+					<para>Uniqueid of the channel that is now part of this group@category</para>
+				</parameter>
+				<parameter name="Category">
+					<para>The category portion of the group@category of the GROUP() that the channel is now a part of</para>
+				</parameter>
+				<parameter name="Group">
+					<para>The group portion of the group@category of the GROUP() that the channel is now a part of</para>
+				</parameter>
+			</syntax>
+		</managerEventInstance>
+	</managerEvent>
+	<managerEvent language="en_US" name="GroupVarSet">
+		<managerEventInstance class="EVENT_FLAG_REPORTING">
+			<synopsis>Raised in response to when a Group Variable is set using GROUP_VAR() on a group@category GROUP()</synopsis>
+			<syntax>
+				<parameter name="Group">
+					<para>Name of the group that the variable was set on</para>
+				</parameter>
+				<parameter name="Category">
+					<para>Name of the category that the variable was set on</para>
+				</parameter>
+				<parameter name="Channel">
+					<para>Channel (if any) that caused the variable to be set</para>
+				</parameter>
+				<parameter name="Variable">
+					<para>The variable that was set</para>
+				</parameter>
+				<parameter name="Value">
+					<para>The value of the variable</para>
+				</parameter>
+			</syntax>
+		</managerEventInstance>
+	</managerEvent>
+	<managerEvent language="en_US" name="GroupChannelRemove">
+		<managerEventInstance class="EVENT_FLAG_REPORTING">
+			<synopsis>Raised when a channel is no longer part of a group@category GROUP() assignment</synopsis>
+			<syntax>
+				<parameter name="Channel">
+					<para>Channel that no longer is part of this group@category</para>
+				</parameter>
+				<parameter name="Uniqueid">
+					<para>Uniqueid of the channel that is no longer is part of this group</para>
+				</parameter>
+				<parameter name="Category">
+					<para>The category portion of the group@category of the GROUP() that the channel was a part of</para>
+				</parameter>
+				<parameter name="Group">
+					<para>The group portion of the group@category of the GROUP() that the channel was a part of</para>
+				</parameter>
+			</syntax>
+		</managerEventInstance>
+	</managerEvent>
+	<managerEvent language="en_US" name="GroupDestroy">
+		<managerEventInstance class="EVENT_FLAG_REPORTING">
+			<synopsis>Raised when a group has been completely removed. Note: GroupChannelRemove events will show which channels no longer are assigned to this group@category</synopsis>
+			<syntax>
+				<parameter name="Category">
+					<para>The category portion of the group@category that is no longer present</para>
+				</parameter>
+				<parameter name="Group">
+					<para>The group portion of the group@category that is no longer present</para>
+				</parameter>
+			</syntax>
+		</managerEventInstance>
+	</managerEvent>
+ ***/
 
 AST_THREADSTORAGE_PUBLIC(ast_str_thread_global_buf);
 
@@ -118,10 +208,36 @@ static void *shaun_of_the_dead(void *data)
 	return NULL;
 }
 
+struct group_data_store;
+
+/* \brief a single group assignment entry */
+struct group_list_entry {
+	struct ast_str *group;                         /*!< A group assignment is group@category, this is the group part  */
+	struct ast_str *category;                      /*!< This is the category part */
+
+	struct group_data_store *group_store;          /*!< The group_data_store we live on */
+
+	AST_LIST_ENTRY(group_list_entry) entries;    /*!< Next group */
+};
+
+AST_LIST_HEAD_NOLOCK(group_list, group_list_entry);  /*!< All GROUP assignments */
+
+/* Datastore for GROUP() entry storage */
+struct group_data_store {
+	void *datastore;                             /*!< Pointer to the datastore that was allocated in */
+	struct ast_channel *chan;                    /*!< Channel this datastore is on */
+
+	struct group_list group_list_head;           /*!< All the GROUPs that this channel is in */
+
+	AST_LIST_ENTRY(group_data_store) entries;  /*!< Next GROUP datastore  */
+};
+
+AST_RWLIST_HEAD_STATIC(group_stores_list, group_data_store);
 
 #define AST_MAX_FORMATS 10
 
-static AST_RWLIST_HEAD_STATIC(groups, ast_group_info);
+static AST_RWLIST_HEAD_STATIC(groups, ast_group_info);      /*!< List of channels that are in groups */
+static AST_RWLIST_HEAD_STATIC(groups_meta, ast_group_meta); /*!< List of groups and their metadata */
 
 /*!
  * \brief This function presents a dialtone and reads an extension into 'collect'
@@ -2191,51 +2307,273 @@ int ast_app_group_split_group(const char *data, char *group, int group_max, char
 	return res;
 }
 
-int ast_app_group_set_channel(struct ast_channel *chan, const char *data)
+static int ast_app_group_add_meta_ifneeded(const char *group, const char *category)
 {
-	int res = 0;
-	char group[80] = "", category[80] = "";
-	struct ast_group_info *gi = NULL;
-	size_t len = 0;
+	struct ast_group_meta *gmi = NULL; /*!< Group metadatas */
 
-	if (ast_app_group_split_group(data, group, sizeof(group), category, sizeof(category))) {
-		return -1;
-	}
-
-	/* Calculate memory we will need if this is new */
-	len = sizeof(*gi) + strlen(group) + 1;
-	if (!ast_strlen_zero(category)) {
-		len += strlen(category) + 1;
-	}
-
-	AST_RWLIST_WRLOCK(&groups);
-	AST_RWLIST_TRAVERSE_SAFE_BEGIN(&groups, gi, group_list) {
-		if ((gi->chan == chan) && ((ast_strlen_zero(category) && ast_strlen_zero(gi->category)) || (!ast_strlen_zero(gi->category) && !strcasecmp(gi->category, category)))) {
-			AST_RWLIST_REMOVE_CURRENT(group_list);
-			ast_free(gi);
-			break;
+	AST_RWLIST_WRLOCK(&groups_meta);
+	AST_RWLIST_TRAVERSE_SAFE_BEGIN(&groups_meta, gmi, group_meta_list) {
+		if (!strcasecmp(gmi->group, group) && !strcasecmp(gmi->category, category)) {
+			break; /* We only have one list item per group@category */
 		}
 	}
 	AST_RWLIST_TRAVERSE_SAFE_END;
 
-	if (ast_strlen_zero(group)) {
-		/* Enable unsetting the group */
-	} else if ((gi = ast_calloc(1, len))) {
-		gi->chan = chan;
-		gi->group = (char *) gi + sizeof(*gi);
-		strcpy(gi->group, group);
-		if (!ast_strlen_zero(category)) {
-			gi->category = (char *) gi + sizeof(*gi) + strlen(group) + 1;
-			strcpy(gi->category, category);
+	if (!gmi) {
+		if (!(gmi = ast_calloc(1, sizeof(struct ast_group_meta)))) {
+		    AST_RWLIST_UNLOCK(&groups_meta);
+		    return -1;
 		}
-		AST_RWLIST_INSERT_TAIL(&groups, gi, group_list);
-	} else {
-		res = -1;
+
+		ast_copy_string(gmi->group, group, MAX_GROUP_LEN);
+
+		if (!ast_strlen_zero(category)) {
+			ast_copy_string(gmi->category, category, MAX_CATEGORY_LEN);
+		}
+
+		AST_RWLIST_INSERT_TAIL(&groups_meta, gmi, group_meta_list);
+
+		manager_event(EVENT_FLAG_DIALPLAN, "GroupCreate",
+			"Category: %s\r\n"
+			"Group: %s\r\n",
+			category, group);
 	}
 
-	AST_RWLIST_UNLOCK(&groups);
+	gmi->num_channels++;
 
-	return res;
+	AST_RWLIST_UNLOCK(&groups_meta);
+
+	return 1;
+}
+
+/* NOTE: Ideally we would also be able to use direct pointers to the group meta, so we don't have to search */
+static int ast_app_group_remove_meta_ifneeded(const char *group, const char *category)
+{
+	struct ast_group_meta *gmi = NULL; /*!< Group metadatas	  */
+
+	struct varshead *headp;
+	struct ast_var_t *vardata;
+
+	if (!category) {
+		category = "";
+	}
+
+	AST_RWLIST_WRLOCK(&groups_meta);
+	AST_RWLIST_TRAVERSE_SAFE_BEGIN(&groups_meta, gmi, group_meta_list) {
+		if (!strcasecmp(gmi->group, group) && !strcasecmp(gmi->category, category) && (--gmi->num_channels <= 0)) {
+			/* Remove all group variables */
+			headp = &gmi->varshead;
+
+			while ((vardata = AST_LIST_REMOVE_HEAD(headp, entries))) {
+				ast_var_delete(vardata);
+			}
+
+			AST_RWLIST_REMOVE_CURRENT(group_meta_list);
+			ast_free(gmi);
+
+			break; /* We only have one list item per group@category */
+		}
+	}
+	AST_RWLIST_TRAVERSE_SAFE_END;
+	AST_RWLIST_UNLOCK(&groups_meta);
+
+	if (gmi) {
+		manager_event(EVENT_FLAG_DIALPLAN, "GroupDestroy",
+			"Category: %s\r\n"
+			"Group: %s\r\n",
+			category, group);
+	}
+
+	return (gmi != NULL);
+}
+
+int ast_app_group_set_channel(struct ast_channel *chan, const char *data)
+{
+        int res = 0;
+        char group[MAX_GROUP_LEN] = "", category[MAX_CATEGORY_LEN] = "";
+        struct ast_group_info *gi = NULL;
+        size_t len = 0;
+
+        if (ast_app_group_split_group(data, group, sizeof(group), category, sizeof(category))) {
+                return -1;
+        }
+
+        /* Calculate memory we will need if this is new */
+        len = sizeof(*gi) + strlen(group) + 1;
+        if (!ast_strlen_zero(category)) {
+                len += strlen(category) + 1;
+        }
+
+        /* Remove previous group assignment within this category if there is one */
+        AST_RWLIST_WRLOCK(&groups);
+        AST_RWLIST_TRAVERSE_SAFE_BEGIN(&groups, gi, group_list) {
+                if ((gi->chan == chan) && ((ast_strlen_zero(category) && ast_strlen_zero(gi->category)) || (!ast_strlen_zero(gi->category) && !strcasecmp(gi->category, category)))) {
+                        /* Find our group meta data, remove the entire group metadata if we're the last channel */
+                        ast_app_group_remove_meta_ifneeded(gi->group, gi->category);
+
+                        manager_event(EVENT_FLAG_DIALPLAN, "GroupChannelRemove",
+                                "Channel: %s\r\n"
+                                "Category: %s\r\n"
+                                "Group: %s\r\n"
+                                "Uniqueid: %s\r\n",
+                                ast_channel_name(chan),
+                                gi->category, gi->group,
+                                ast_channel_uniqueid(chan));
+
+                        AST_RWLIST_REMOVE_CURRENT(group_list);
+                        ast_free(gi);
+                        break;
+                }
+        }
+        AST_RWLIST_TRAVERSE_SAFE_END;
+
+        if (ast_strlen_zero(group)) {
+                /* Enable unsetting the group */
+        } else if ((gi = ast_calloc(1, len))) {
+                gi->chan = chan;
+                gi->group = (char *) gi + sizeof(*gi);
+                strcpy(gi->group, group);
+                if (!ast_strlen_zero(category)) {
+                        gi->category = (char *) gi + sizeof(*gi) + strlen(group) + 1;
+                        strcpy(gi->category, category);
+                }
+                AST_RWLIST_INSERT_TAIL(&groups, gi, group_list);
+
+                ast_app_group_add_meta_ifneeded(group, category);
+
+                manager_event(EVENT_FLAG_DIALPLAN, "GroupChannelAdd",
+                        "Channel: %s\r\n"
+                        "Category: %s\r\n"
+                        "Group: %s\r\n"
+                        "Uniqueid: %s\r\n",
+                        ast_channel_name(chan),
+                        category, group,
+                        ast_channel_uniqueid(chan));
+
+        } else {
+                res = -1;
+        }
+
+        AST_RWLIST_UNLOCK(&groups);
+
+        return res;
+}
+
+int ast_app_group_set_var(struct ast_channel *chan, const char *group, const char *category, const char *name, const char *value)
+{
+	struct ast_group_meta *gmi = NULL;
+
+	struct varshead *headp;
+	struct ast_var_t *variable = NULL;
+
+	if (!group || !name) {
+		ast_log(LOG_WARNING, "<%s> GROUP variable assignment failed for %s@%s, group/name cannot be NULL, group variable '%s' not set\n", ast_channel_name(chan), group, category, name);
+		return -2;
+	}
+
+	if (!category) {
+		category = "";
+	}
+
+	if (!value) {
+		value = "";
+	}
+
+	/* Find our group meta data */
+	AST_RWLIST_WRLOCK(&groups_meta);
+	AST_RWLIST_TRAVERSE_SAFE_BEGIN(&groups_meta, gmi, group_meta_list) {
+		if ((strcasecmp(gmi->group, group) != 0) || (strcasecmp(gmi->category, category) != 0)) {
+			continue;
+		}
+
+		headp = &gmi->varshead;
+
+		AST_LIST_TRAVERSE(headp, variable, entries) {
+			if (strcasecmp(ast_var_name(variable), name) == 0) {
+				/* there is already such a variable, nuke it so we can replace it */
+				ast_var_delete(variable);
+				break;
+			}
+		}
+
+		variable = ast_var_assign(name, value);
+
+		AST_LIST_INSERT_HEAD(headp, variable, entries);
+		manager_event(EVENT_FLAG_DIALPLAN, "GroupVarSet",
+			"Channel: %s\r\n"
+			"Category: %s\r\n"
+			"Group: %s\r\n"
+			"Variable: %s\r\n"
+			"Value: %s\r\n"
+			"Uniqueid: %s\r\n",
+			chan ? ast_channel_name(chan) : "none",
+			category, group, name, value,
+			chan ? ast_channel_uniqueid(chan) : "none");
+
+		break; /* We only have one list item per group@category */
+	}
+	AST_RWLIST_TRAVERSE_SAFE_END;
+	AST_RWLIST_UNLOCK(&groups_meta);
+
+	if (!variable) {
+		ast_log(LOG_WARNING, "<%s> GROUP assignment %s@%s doesn't exist, group variable '%s' not set\n", ast_channel_name(chan), group, category, name);
+		return -1;
+	}
+
+	return 0;
+}
+
+char *ast_app_group_get_var(const char *group, const char *category, const char *name)
+{
+	struct ast_group_meta *gmi = NULL;
+	struct varshead *headp;
+	const char *variable;
+        char *return_value;
+	struct ast_var_t *ast_var;
+	int len;
+
+	if (!group || !name) {
+		return NULL;
+	}
+
+	if (!category) {
+		category = "";
+	}
+
+	/* Find our group meta data */
+	AST_RWLIST_RDLOCK(&groups_meta);
+	AST_RWLIST_TRAVERSE(&groups_meta, gmi, group_meta_list) {
+		if ((strcasecmp(gmi->group, group) != 0) || (strcasecmp(gmi->category, category) != 0)) {
+			continue;
+		}
+
+		headp = &gmi->varshead;
+
+		AST_LIST_TRAVERSE(headp, ast_var, entries) {
+			variable = ast_var_name(ast_var);
+
+			if (!strcasecmp(variable, name)) {
+				/* found it */
+				variable = ast_var_value(ast_var); /* Already found it, we can safely re-use */
+                                len = strlen(variable);
+
+				return_value = ast_malloc(len + 1);
+                                if (!return_value) {
+					ast_log(LOG_ERROR, "Group Variable Get Failed to allocate memory for return value\n");
+					AST_RWLIST_UNLOCK(&groups_meta);
+					return NULL;
+                                }
+
+				ast_copy_string(return_value, variable, len);
+				AST_RWLIST_UNLOCK(&groups_meta);
+
+				return return_value;
+			}
+		}
+	}
+	AST_RWLIST_UNLOCK(&groups_meta);
+
+	return NULL;
 }
 
 int ast_app_group_get_count(const char *group, const char *category)
@@ -2276,6 +2614,7 @@ int ast_app_group_match_get_count(const char *groupmatch, const char *category)
 		return 0;
 	}
 
+	/* if regex compilation fails, return zero matches */
 	if (!ast_strlen_zero(category) && regcomp(&regexbuf_category, category, REG_EXTENDED | REG_NOSUB)) {
 		ast_log(LOG_ERROR, "Regex compile failed on: %s\n", category);
 		regfree(&regexbuf_group);
@@ -2301,14 +2640,21 @@ int ast_app_group_match_get_count(const char *groupmatch, const char *category)
 int ast_app_group_update(struct ast_channel *old, struct ast_channel *new)
 {
 	struct ast_group_info *gi = NULL;
+	struct ast_group_info *gi_new = NULL;
 
 	AST_RWLIST_WRLOCK(&groups);
 	AST_RWLIST_TRAVERSE_SAFE_BEGIN(&groups, gi, group_list) {
+		/* keep channel groups on transfer */
 		if (gi->chan == old) {
+			/* only move group if it doesn't already exist on new */
+			AST_RWLIST_TRAVERSE_SAFE_BEGIN(&groups, gi_new, group_list) {
+				if (gi_new->chan == old && !strcasecmp(gi_new->group, gi->group) && !strcasecmp(gi_new->category, gi->category)) {
+					break;
+				}
+			}
+			AST_RWLIST_TRAVERSE_SAFE_END;
+
 			gi->chan = new;
-		} else if (gi->chan == new) {
-			AST_RWLIST_REMOVE_CURRENT(group_list);
-			ast_free(gi);
 		}
 	}
 	AST_RWLIST_TRAVERSE_SAFE_END;
@@ -2317,16 +2663,153 @@ int ast_app_group_update(struct ast_channel *old, struct ast_channel *new)
 	return 0;
 }
 
+/* Remove all channels from the given group */
+int ast_app_group_remove_all_channels(const char *group, const char *category)
+{
+	struct ast_group_info *gi = NULL;
+	int group_meta_found = 0;
+
+	if (!group) {
+		ast_log(LOG_WARNING, "Group Remove: At the minimum, group must be non-NULL\n");
+		return 0;
+	}
+
+	if (!category) {
+		category = "";
+	}
+
+	/* Traverse group@category channel assignments */
+	AST_RWLIST_WRLOCK(&groups);
+	AST_RWLIST_TRAVERSE_SAFE_BEGIN(&groups, gi, group_list) {
+		if (strcasecmp(gi->group, group) || strcasecmp(gi->category, category)) {
+			/* Need to match group@category exactly */
+			continue;
+		}
+
+		manager_event(EVENT_FLAG_DIALPLAN, "GroupChannelRemove",
+			"Channel: %s\r\n"
+			"Category: %s\r\n"
+			"Group: %s\r\n"
+			"Uniqueid: %s\r\n",
+			ast_channel_name(gi->chan),
+			gi->category, gi->group,
+			ast_channel_uniqueid(gi->chan));
+
+		ast_app_group_remove_meta_ifneeded(gi->group, gi->category);
+
+		AST_RWLIST_REMOVE_CURRENT(group_list);
+		ast_free(gi);
+
+		group_meta_found++;
+	}
+	AST_RWLIST_TRAVERSE_SAFE_END;
+	AST_RWLIST_UNLOCK(&groups);
+
+	return group_meta_found;
+}
+
+int ast_app_group_rename(const char *old_group, const char *old_category, const char *new_group, const char *new_category)
+{
+	struct ast_group_info *gi = NULL;
+	struct ast_group_meta *gmi = NULL; /*!< Group metadatas	*/
+
+	int groups_found = 0;
+
+	if (!old_group) {
+		ast_log(LOG_WARNING, "Old Group name is required for group rename\n");
+		return -1;
+	}
+
+	if (!new_group) {
+		ast_log(LOG_WARNING, "New Group name is required for group rename\n");
+		return -1;
+	}
+
+	if (!old_category) {
+		old_category = "";
+	}
+
+	if (!new_category) {
+		new_category = "";
+	}
+
+	/* Traverse group@category channel assignments */
+	AST_RWLIST_WRLOCK(&groups);
+	AST_RWLIST_TRAVERSE_SAFE_BEGIN(&groups, gi, group_list) {
+		if (strcasecmp(gi->group, old_group) || strcasecmp(gi->category, old_category)) {
+			/* Need to match group@category exactly */
+			continue;
+		}
+
+		ast_copy_string(gi->group,    new_group,    MAX_GROUP_LEN);
+		ast_copy_string(gi->category, new_category, MAX_CATEGORY_LEN);
+		groups_found++;
+	}
+	AST_RWLIST_TRAVERSE_SAFE_END;
+	AST_RWLIST_UNLOCK(&groups);
+
+	/* Group Variables */
+	AST_RWLIST_WRLOCK(&groups_meta);
+	AST_RWLIST_TRAVERSE_SAFE_BEGIN(&groups_meta, gmi, group_meta_list) {
+		if (strcasecmp(gmi->group, old_group) || strcasecmp(gmi->category, old_category)) {
+			/* Need to match group@category exactly */
+			continue;
+		}
+
+		strncpy(gmi->group,    new_group,    MAX_GROUP_LEN    - 1);
+		strncpy(gmi->category, new_category, MAX_CATEGORY_LEN - 1);
+
+                /*
+                  No groups_found++ here, since we already found it earlier.
+                  If everyone plays by the rules, we'll never have a groups_meta
+                    entry for a group@category without first already having
+                    a group@category itself
+                */
+	}
+	AST_RWLIST_TRAVERSE_SAFE_END;
+	AST_RWLIST_UNLOCK(&groups_meta);
+
+	if (groups_found) {
+		manager_event(EVENT_FLAG_DIALPLAN, "GroupRename",
+			"OldGroup: %s\r\n"
+			"OldCategory: %s\r\n"
+			"NewGroup: %s\r\n"
+			"NewCategory: %s\r\n",
+			old_group,
+			old_category,
+			new_group,
+			new_category);
+	}
+
+	return groups_found;
+}
+
 int ast_app_group_discard(struct ast_channel *chan)
 {
 	struct ast_group_info *gi = NULL;
 
+        /* Find and remove all groups associated to this channel */
 	AST_RWLIST_WRLOCK(&groups);
 	AST_RWLIST_TRAVERSE_SAFE_BEGIN(&groups, gi, group_list) {
-		if (gi->chan == chan) {
-			AST_RWLIST_REMOVE_CURRENT(group_list);
-			ast_free(gi);
+		if (gi->chan != chan) {
+			continue;
 		}
+
+		manager_event(EVENT_FLAG_DIALPLAN, "GroupChannelRemove",
+			"Channel: %s\r\n"
+			"Category: %s\r\n"
+			"Group: %s\r\n"
+			"Uniqueid: %s\r\n",
+			ast_channel_name(gi->chan),
+			gi->category, gi->group,
+			ast_channel_uniqueid(chan));
+
+		/* Find our group meta data, remove the entire group metadata if we're the last channel */
+		ast_app_group_remove_meta_ifneeded(gi->group, gi->category);
+
+		/* Remove this group assignment for this channel */
+		AST_RWLIST_REMOVE_CURRENT(group_list);
+		ast_free(gi);
 	}
 	AST_RWLIST_TRAVERSE_SAFE_END;
 	AST_RWLIST_UNLOCK(&groups);
@@ -2352,6 +2835,21 @@ struct ast_group_info *ast_app_group_list_head(void)
 int ast_app_group_list_unlock(void)
 {
 	return AST_RWLIST_UNLOCK(&groups);
+}
+
+int ast_app_group_meta_rdlock(void)
+{
+	return AST_RWLIST_RDLOCK(&groups_meta);
+}
+
+struct ast_group_meta *ast_app_group_meta_head(void)
+{
+	return AST_RWLIST_FIRST(&groups_meta);
+}
+
+int ast_app_group_meta_unlock(void)
+{
+	return AST_RWLIST_UNLOCK(&groups_meta);
 }
 
 unsigned int __ast_app_separate_args(char *buf, char delim, int remove_chars, char **array, int arraylen)

--- a/main/app.c
+++ b/main/app.c
@@ -2491,6 +2491,7 @@ int ast_app_group_set_var(struct ast_channel *chan, const char *group, const cha
 		AST_LIST_TRAVERSE(headp, variable, entries) {
 			if (strcasecmp(ast_var_name(variable), name) == 0) {
 				/* there is already such a variable, nuke it so we can replace it */
+				AST_LIST_REMOVE(headp, variable, entries);
 				ast_var_delete(variable);
 				break;
 			}


### PR DESCRIPTION
DumpGroups
-------------------
* New application.  This will dump all channel group membership and associated
  variables

Groups and Group Variables
------------------
 * Group variables can be set on a group once the group is created
   When a group is destroyed, all variables on that group are also destroyed

   A group variable is somewhat like a global variable, but it's on a per-group
   basis.

   GroupSet - Adds functionality to the manager to be able to set a GROUP()
	      on a channel.
   GroupsShowChannels - Show each channel and it's associated groups
                        (a channel will be repeated for each group@category
                         it's a member of)
   GroupsShowVariables - Show variables in each group@category, one event per
                         group, all variables are contained in each
                         group@category event
   GroupVarSet - Set a group variable (the group must already exist)
   GroupVarGet - Get a group variable

 * New Manager events:
   ------------------
   GroupCreate - Event is fired any time a group is made,
                 ie: Set(GROUP=x) or Set(GROUP()=x@y).
                 This event is only sent on when a channel is added to a group
                 that did not exist previously.
   GroupChannelAdd - Event is fired any time a channel is added to a group
   GroupChannelRemove - Event is fired any time a channel is removed from a
                        group
   GroupDestroy - Event is fired when there are no longer any channels assigned
                  to the group
   GroupVarSet - Event is fired when any group variable is changed

 * New CLI Command
   ---------------
   group show variables

 * New Application
   ---------------
   DumpGroups() - Show groups and group assigments (similar to DumpChan)

Resolves: #291
