### PR TITLE
chan_dahdi: Clarify scope of callgroup/pickupgroup.

### DIFF
--- a/channels/chan_dahdi.c
+++ b/channels/chan_dahdi.c
@@ -18434,18 +18434,30 @@ static int process_dahdi(struct dahdi_chan_conf *confp, const char *cat, struct 
 		} else if (!strcasecmp(v->name, "group")) {
 			confp->chan.group = ast_get_group(v->value);
 		} else if (!strcasecmp(v->name, "callgroup")) {
+			if (!((confp->chan.sig == SIG_FXOKS) || (confp->chan.sig == SIG_FXOGS) || (confp->chan.sig == SIG_FXOLS))) {
+				ast_log(LOG_WARNING, "Only FXO signalled channels may belong to a call group\n");
+			}
 			if (!strcasecmp(v->value, "none"))
 				confp->chan.callgroup = 0;
 			else
 				confp->chan.callgroup = ast_get_group(v->value);
 		} else if (!strcasecmp(v->name, "pickupgroup")) {
+			if (!((confp->chan.sig == SIG_FXOKS) || (confp->chan.sig == SIG_FXOGS) || (confp->chan.sig == SIG_FXOLS))) {
+				ast_log(LOG_WARNING, "Only FXO signalled channels may belong to a pickup group\n");
+			}
 			if (!strcasecmp(v->value, "none"))
 				confp->chan.pickupgroup = 0;
 			else
 				confp->chan.pickupgroup = ast_get_group(v->value);
 		} else if (!strcasecmp(v->name, "namedcallgroup")) {
+			if (!((confp->chan.sig == SIG_FXOKS) || (confp->chan.sig == SIG_FXOGS) || (confp->chan.sig == SIG_FXOLS))) {
+				ast_log(LOG_WARNING, "Only FXO signalled channels may belong to a named call group\n");
+			}
 			confp->chan.named_callgroups = ast_get_namedgroups(v->value);
 		} else if (!strcasecmp(v->name, "namedpickupgroup")) {
+			if (!((confp->chan.sig == SIG_FXOKS) || (confp->chan.sig == SIG_FXOGS) || (confp->chan.sig == SIG_FXOLS))) {
+				ast_log(LOG_WARNING, "Only FXO signalled channels may belong to a named pickup group\n");
+			}
 			confp->chan.named_pickupgroups = ast_get_namedgroups(v->value);
 		} else if (!strcasecmp(v->name, "setvar")) {
 			if (v->value) {

--- a/configs/samples/chan_dahdi.conf.sample
+++ b/configs/samples/chan_dahdi.conf.sample
@@ -944,6 +944,10 @@ group=1
 ; you can answer it by picking up and dialing *8#.  For simple offices, just
 ; make these both the same.  Groups range from 0 to 63.
 ;
+; Call groups and pickup groups may only be specified for FXO signalled channels.
+; If you need to pick up an FXS signalled channel directly, you can have it
+; dial a Local channel and pick up the ;1 side of the Local channel instead.
+;
 callgroup=1
 pickupgroup=1
 ;


### PR DESCRIPTION
Internally, chan_dahdi only applies callgroup and
pickupgroup to FXO signalled channels, but this is not documented anywhere. This is now documented in the sample config, and a warning is emitted if a
user tries configuring these settings for channel
types that do not support these settings, since they will not have any effect.

Resolves: #294