### PR TITLE
res_rtp_asterisk: fix wrong counter management in ioqueue objects

### DIFF
--- a/res/res_rtp_asterisk.c
+++ b/res/res_rtp_asterisk.c
@@ -1552,7 +1552,7 @@ static void rtp_ioqueue_thread_remove(struct ast_rtp_ioqueue_thread *ioqueue)
 
 	/* If nothing is using this ioqueue thread destroy it */
 	AST_LIST_LOCK(&ioqueues);
-	if ((ioqueue->count - 2) == 0) {
+	if ((ioqueue->count -= 2) == 0) {
 		destroy = 1;
 		AST_LIST_REMOVE(&ioqueues, ioqueue, next);
 	}


### PR DESCRIPTION
In function  rtp_ioqueue_thread_remove counter in ioqueue object is not decreased
which prevents unused ICE TURN threads from being removed.

Resolves: #301
