### PR TITLE
res_speech_aeap: check for null format on response

### DIFF
--- a/res/res_speech_aeap.c
+++ b/res/res_speech_aeap.c
@@ -279,6 +279,11 @@ static int handle_response_setup(struct ast_aeap *aeap, struct ast_aeap_message 
 	struct ast_json *json = ast_aeap_message_data(message);
 	const char *codec_name;
 
+	if (!format) {
+		log_error(aeap, "no 'format' set");
+		return -1;
+	}
+
 	if (!json) {
 		log_error(aeap, "no 'setup' object returned");
 		return -1;


### PR DESCRIPTION
* Fixed issue in res_speech_aeap when unable to provide an
  input format to check against.
