### PR TITLE
file.c: Add ability to search custom dir for sounds

### DIFF
--- a/configs/samples/asterisk.conf.sample
+++ b/configs/samples/asterisk.conf.sample
@@ -126,6 +126,10 @@ documentation_language = en_US	; Set the language you want documentation
                 ; housekeeping AMI and ARI channel events.  This can
                 ; reduce the load on the manager and ARI applications
                 ; when the Digium Phone Module for Asterisk is in use.
+;sounds_search_custom_dir = no;  This option, if enabled, will
+                ; cause Asterisk to search for sounds files in
+                ; AST_DATA_DIR/sounds/custom before searching the
+                ; normal directories like AST_DATA_DIR/sounds/<lang>.
 
 ; Changing the following lines may compromise your security.
 ;[files]

--- a/include/asterisk/options.h
+++ b/include/asterisk/options.h
@@ -74,6 +74,8 @@ enum ast_option_flags {
 	AST_OPT_FLAG_TRANSMIT_SILENCE = (1 << 17),
 	/*! Suppress some warnings */
 	AST_OPT_FLAG_DONT_WARN = (1 << 18),
+	/*! Search custom directory for sounds first */
+	AST_OPT_FLAG_SOUNDS_SEARCH_CUSTOM = (1 << 19),
 	/*! Reference Debugging */
 	AST_OPT_FLAG_REF_DEBUG = (1 << 20),
 	/*! Always fork, even if verbose or debug settings are non-zero */
@@ -133,6 +135,7 @@ enum ast_option_flags {
 #define ast_opt_ref_debug           ast_test_flag(&ast_options, AST_OPT_FLAG_REF_DEBUG)
 #define ast_opt_generic_plc_on_equal_codecs  ast_test_flag(&ast_options, AST_OPT_FLAG_GENERIC_PLC_ON_EQUAL_CODECS)
 #define ast_opt_hide_messaging_ami_events  ast_test_flag(&ast_options, AST_OPT_FLAG_HIDE_MESSAGING_AMI_EVENTS)
+#define ast_opt_sounds_search_custom ast_test_flag(&ast_options, AST_OPT_FLAG_SOUNDS_SEARCH_CUSTOM)
 
 /*! Maximum log level defined by PJPROJECT. */
 #define MAX_PJ_LOG_MAX_LEVEL		6

--- a/main/asterisk.c
+++ b/main/asterisk.c
@@ -552,6 +552,7 @@ static char *handle_show_settings(struct ast_cli_entry *e, int cmd, struct ast_c
 	ast_cli(a->fd, "  Generic PLC:                 %s\n", ast_test_flag(&ast_options, AST_OPT_FLAG_GENERIC_PLC) ? "Enabled" : "Disabled");
 	ast_cli(a->fd, "  Generic PLC on equal codecs: %s\n", ast_test_flag(&ast_options, AST_OPT_FLAG_GENERIC_PLC_ON_EQUAL_CODECS) ? "Enabled" : "Disabled");
 	ast_cli(a->fd, "  Hide Msg Chan AMI events:    %s\n", ast_opt_hide_messaging_ami_events ? "Enabled" : "Disabled");
+	ast_cli(a->fd, "  Sounds search custom dir:    %s\n", ast_opt_sounds_search_custom ? "Enabled" : "Disabled");
 	ast_cli(a->fd, "  Min DTMF duration::          %u\n", option_dtmfminduration);
 #if !defined(LOW_MEMORY)
 	ast_cli(a->fd, "  Cache media frames:          %s\n", ast_opt_cache_media_frames ? "Enabled" : "Disabled");

--- a/main/manager.c
+++ b/main/manager.c
@@ -6745,6 +6745,7 @@ static int action_coresettings(struct mansession *s, const struct message *m)
 			"CoreRealTimeEnabled: %s\r\n"
 			"CoreCDRenabled: %s\r\n"
 			"CoreHTTPenabled: %s\r\n"
+			"SoundsSearchCustomDir: %s\r\n"
 			"\r\n",
 			idText,
 			AMI_VERSION,
@@ -6757,7 +6758,8 @@ static int action_coresettings(struct mansession *s, const struct message *m)
 			ast_option_maxfiles,
 			AST_CLI_YESNO(ast_realtime_enabled()),
 			AST_CLI_YESNO(ast_cdr_is_enabled()),
-			AST_CLI_YESNO(ast_webmanager_check_enabled())
+			AST_CLI_YESNO(ast_webmanager_check_enabled()),
+			AST_CLI_YESNO(ast_opt_sounds_search_custom)
 			);
 	return 0;
 }

--- a/main/options.c
+++ b/main/options.c
@@ -472,6 +472,8 @@ void load_asterisk_conf(void)
 			live_dangerously = ast_true(v->value);
 		} else if (!strcasecmp(v->name, "hide_messaging_ami_events")) {
 			ast_set2_flag(&ast_options, ast_true(v->value), AST_OPT_FLAG_HIDE_MESSAGING_AMI_EVENTS);
+		} else if (!strcasecmp(v->name, "sounds_search_custom_dir")) {
+			ast_set2_flag(&ast_options, ast_true(v->value), AST_OPT_FLAG_SOUNDS_SEARCH_CUSTOM);
 		}
 	}
 	if (!ast_opt_remote) {


### PR DESCRIPTION
To better co-exist with sounds files that may be managed by
packages, custom sound files may now be placed in
AST_DATA_DIR/sounds/custom instead of the standard
AST_DATA_DIR/sounds/<lang> directory.  If the new
"sounds_search_custom_dir" option in asterisk.conf is set
to "true", asterisk will search the custom directory for sounds
files before searching the standard directory.  For performance
reasons, the "sounds_search_custom_dir" defaults to "false".

Resolves: #315

UserNote: A new option "sounds_search_custom_dir" has been added to
asterisk.conf that allows asterisk to search
AST_DATA_DIR/sounds/custom for sounds files before searching the
standard AST_DATA_DIR/sounds/<lang> directory.
