### PR TITLE
safe_asterisk: Change directory permissions to 755

### DIFF
--- a/contrib/scripts/safe_asterisk
+++ b/contrib/scripts/safe_asterisk
@@ -97,7 +97,7 @@ else
 
 	if test ! -d "${ASTVARRUNDIR}"; then
 		mkdir -p "${ASTVARRUNDIR}"
-		chmod 770 "${ASTVARRUNDIR}"
+		chmod 755 "${ASTVARRUNDIR}"
 	fi
 
 fi


### PR DESCRIPTION
If the safe_asterisk script detects that the /var/lib/asterisk
directory doesn't exist, it now creates it with 755 permissions
instead of 770.  safe_asterisk needing to create that directory
should be extremely rare though because it's normally created
by 'make install' which already sets the permissions to 755.

Resolves: #316
