### PR TITLE
func_periodic_hook: Don't truncate channel name

### DIFF
--- a/funcs/func_periodic_hook.c
+++ b/funcs/func_periodic_hook.c
@@ -466,7 +466,7 @@ static int load_module(void)
 	 * Based on a handy recipe from the Asterisk Cookbook.
 	 */
 	res = ast_add_extension(context_name, 1, exten_name, 1, "", "",
-			"Set", "EncodedChannel=${CUT(HOOK_CHANNEL,-,1-2)}",
+			"Set", "EncodedChannel=${HOOK_CHANNEL}",
 			NULL, AST_MODULE);
 	res |= ast_add_extension(context_name, 1, exten_name, 2, "", "",
 			"Set", "GROUP_NAME=${EncodedChannel}${HOOK_ID}",


### PR DESCRIPTION
func_periodic_hook was truncating long channel names which
causes issues when you need to run other dialplan functions/apps
on the channel.

Resolves: #319
