### PR TITLE
make_buildopts_h, et. al.  Allow adding all cflags to buildopts.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -377,7 +377,7 @@ $(MOD_SUBDIRS_MENUSELECT_TREE):
 	+@$(SUBMAKE) -C $(@:-menuselect-tree=) SUBDIR=$(@:-menuselect-tree=) moduleinfo
 	+@$(SUBMAKE) -C $(@:-menuselect-tree=) SUBDIR=$(@:-menuselect-tree=) makeopts
 
-$(SUBDIRS): makeopts .lastclean main/version.c include/asterisk/build.h include/asterisk/buildopts.h defaults.h
+$(SUBDIRS): makeopts .lastclean main/version.c include/asterisk/build.h defaults.h
 
 ifeq ($(findstring $(OSARCH), mingw32 cygwin ),)
 main: third-party
@@ -403,7 +403,7 @@ defaults.h: makeopts .lastclean build_tools/make_defaults_h
 	@cmp -s $@.tmp $@ || mv $@.tmp $@
 	@rm -f $@.tmp
 
-main/version.c: FORCE menuselect.makeopts .lastclean
+main/version.c: FORCE include/asterisk/buildopts.h menuselect.makeopts .lastclean
 	@build_tools/make_version_c > $@.tmp
 	@cmp -s $@.tmp $@ || mv $@.tmp $@
 	@rm -f $@.tmp

--- a/build_tools/cflags.xml
+++ b/build_tools/cflags.xml
@@ -128,4 +128,8 @@
 			<defaultenabled>yes</defaultenabled>
 			<depend>native_arch</depend>
 		</member>
+		<member name="ADD_CFLAGS_TO_BUILDOPTS_H" displayname="Add ALL of the flags on this page to buildopts.h. Useful for IDEs but may cause slightly longer compile times after flags are changed.">
+			<support_level>core</support_level>
+			<defaultenabled>no</defaultenabled>
+		</member>
 	</category>

--- a/build_tools/make_buildopts_h
+++ b/build_tools/make_buildopts_h
@@ -18,42 +18,79 @@ then
 	# gets added to BUILDOPTS.
 fi
 
-TMP=`${GREP} -e "^MENUSELECT_CFLAGS" menuselect.makeopts | sed 's/MENUSELECT_CFLAGS\=//g' | sed 's/-D//g'`
-for x in ${TMP}; do
-	if test "${x}" = "AO2_DEBUG" \
-			-o "${x}" = "BETTER_BACKTRACES" \
-			-o "${x}" = "BUILD_NATIVE" \
-			-o "${x}" = "COMPILE_DOUBLE" \
-			-o "${x}" = "DEBUG_CHAOS" \
-			-o "${x}" = "DEBUG_SCHEDULER" \
-			-o "${x}" = "DETECT_DEADLOCKS" \
-			-o "${x}" = "DONT_OPTIMIZE" \
-			-o "${x}" = "DUMP_SCHEDULER" \
-			-o "${x}" = "LOTS_OF_SPANS" \
-			-o "${x}" = "MALLOC_DEBUG" \
-			-o "${x}" = "RADIO_RELAX" \
-			-o "${x}" = "REBUILD_PARSERS" \
-			-o "${x}" = "REF_DEBUG" \
-			-o "${x}" = "USE_HOARD_ALLOCATOR" ; then
-		# These options are only for specific sources and have no effect on public ABI.
-		# Keep them out of buildopts.h so ccache does not invalidate all sources.
-		continue
-	fi
+ADD_CFLAGS_TO_BUILDOPTS=false
+MENUSELECT_CFLAGS=$(${GREP} -e "^MENUSELECT_CFLAGS" menuselect.makeopts)
+echo "$MENUSELECT_CFLAGS" | grep -q -e "ADD_CFLAGS_TO_BUILDOPTS_H" && ADD_CFLAGS_TO_BUILDOPTS=true
 
+# Clean up MENUSELECT_CFLAGS by removing the "MENUSELECT_CFLAGS="
+# at the front, the "ADD_CFLAGS_TO_BUILDOPTS_H" flag, and any "-D"
+# entries.
+MENUSELECT_CFLAGS=$( echo "$MENUSELECT_CFLAGS" | \
+	sed -r -e "s/(MENUSELECT_CFLAGS=|ADD_CFLAGS_TO_BUILDOPTS_H|-D)//g")
+
+# This is a list of flags that don't affect the ABI.
+# "ADD_CFLAGS_TO_BUILDOPTS_H" is NOT set, we'll filter these
+# out of the buildopts.h file.
+#
+# These used to always be filtered out but if they're not in
+# buildopts.h, many IDEs will show them as undefined and mark
+# any code blocks enabled by them as disabled.
+#
+# The original reasoning for removing them was that trivial
+# changes to the buildopts.h file will cause ccache to
+# invalidate any source files that use it and increase the
+# compile time.  It's not such a huge deal these days but
+# to preserve backwards behavior the default is still to
+# remove them.
+# 
+# The ABI-breaking flags are always included in buildopts.h.
+
+# This variable is used by sed so it needs to be a valid
+# regex which will be surrounded by parens.]
+FILTER_OUT="\
+AO2_DEBUG|BETTER_BACKTRACES|BUILD_NATIVE|\
+COMPILE_DOUBLE|DEBUG_CHAOS|DEBUG_SCHEDULER|\
+DETECT_DEADLOCKS|DONT_OPTIMIZE|DUMP_SCHEDULER|\
+LOTS_OF_SPANS|MALLOC_DEBUG|RADIO_RELAX|\
+REBUILD_PARSERS|REF_DEBUG|USE_HOARD_ALLOCATOR"
+
+# Create buildopts.h
+
+INCLUDE_CFLAGS="$MENUSELECT_CFLAGS"
+# Do the filter-out if needed.
+if ! $ADD_CFLAGS_TO_BUILDOPTS ; then
+	INCLUDE_CFLAGS=$( echo "$MENUSELECT_CFLAGS" | \
+		sed -r -e "s/(${FILTER_OUT})//g")
+fi
+
+# Output the defines.
+for x in ${INCLUDE_CFLAGS}; do
 	echo "#define ${x} 1"
-	if test "${x}" = "LOW_MEMORY" ; then
-		# LOW_MEMORY isn't an ABI affecting option but it is used in many sources
-		# so it gets defined globally but is not included in AST_BUILTOPTS.
-		continue
-	fi
-	if test "x${BUILDOPTS}" != "x" ; then
-		BUILDOPTS="${BUILDOPTS}, ${x}"
-	else
-		BUILDOPTS="${x}"
-	fi
 done
 
-BUILDSUM=`echo ${BUILDOPTS} | ${MD5} | cut -c1-32`
+# We NEVER include the non-ABI-breaking flags in the
+# BUILDOPTS or use them to calculate the checksum so
+# we always filter out any that may exist.
+# After the filter-out, we also need to convert the
+# possibly-multi-spaced MENUSELECT_CFLAGS to a nice
+# comma-separated list.
+# I.E.
+#  Remove leading spaces.
+#  Convert consecutive interior spaces to a single space.
+#  Remove trailing spaces.
+#  Convert the now-single-spaces in the interior to ", ".
+BUILDOPTS=$( echo "$MENUSELECT_CFLAGS" | \
+	sed -r -e "s/(${FILTER_OUT}|LOW_MEMORY)//g" -e "s/^\s+//g;s/\s+/ /g;s/\s+$//g;s/\s/, /g" )
+
+# Calculate the checksum on only the ABI-breaking flags.
+BUILDSUM=$(echo "${BUILDOPTS}" | ${MD5} | cut -c1-32)
 
 echo "#define AST_BUILDOPT_SUM \"${BUILDSUM}\""
 echo "#define AST_BUILDOPTS \"${BUILDOPTS}\""
+
+# However, it'd be nice to see the non-ABI-breaking flags
+# when you do a "core show settings" so we create a separate
+# define for them.
+BUILDOPTS_ALL=$( echo "$MENUSELECT_CFLAGS" | \
+	sed -r -e "s/^\s+//g;s/\s+/ /g;s/\s+$//g;s/\s/, /g" )
+echo "#define AST_BUILDOPTS_ALL \"${BUILDOPTS_ALL}\""

--- a/build_tools/make_version_c
+++ b/build_tools/make_version_c
@@ -2,6 +2,11 @@
 
 GREP=${GREP:-grep}
 
+if test ! -f include/asterisk/buildopts.h ; then
+	echo "include/asterisk/buildopts.h is missing"
+	exit 1
+fi
+
 if test ! -f .flavor ; then
     EXTRA=""
 elif test ! -f .version ; then
@@ -18,14 +23,11 @@ then
 	BUILDOPTS="AST_DEVMODE"
 fi
 
-TMP=`${GREP} -e "^MENUSELECT_CFLAGS" menuselect.makeopts | sed 's/MENUSELECT_CFLAGS\=//g' | sed 's/-D//g'`
-for x in ${TMP}; do
-	if test "x${BUILDOPTS}" != "x" ; then
-		BUILDOPTS="${BUILDOPTS}, ${x}"
-	else
-		BUILDOPTS="${x}"
-	fi
-done
+BUILDOPTS=$(sed -n -r -e 's/#define\s+AST_BUILDOPTS\s+"([^"]+)"/\1/gp' \
+	include/asterisk/buildopts.h )
+
+BUILDOPTS_ALL=$(sed -n -r -e 's/#define\s+AST_BUILDOPTS_ALL\s+"([^"]+)"/\1/gp' \
+	include/asterisk/buildopts.h )
 
 cat << END
 /*
@@ -43,6 +45,8 @@ static const char asterisk_version_num[] = "${ASTERISKVERSIONNUM}";
 
 static const char asterisk_build_opts[] = "${BUILDOPTS}";
 
+static const char asterisk_build_opts_all[] = "${BUILDOPTS_ALL}";
+
 const char *ast_get_version(void)
 {
 	return asterisk_version;
@@ -56,6 +60,11 @@ const char *ast_get_version_num(void)
 const char *ast_get_build_opts(void)
 {
 	return asterisk_build_opts;
+}
+
+const char *ast_get_build_opts_all(void)
+{
+	return asterisk_build_opts_all;
 }
 
 END

--- a/include/asterisk/ast_version.h
+++ b/include/asterisk/ast_version.h
@@ -41,7 +41,10 @@ const char *ast_get_version(void);
  */
 const char *ast_get_version_num(void);
 
-/*! Retrieve the Asterisk build options */
+/*! Retrieve the ABI-breaking Asterisk build options */
 const char *ast_get_build_opts(void);
+
+/*! Retrieve all of the the Asterisk build options */
+const char *ast_get_build_opts_all(void);
 
 #endif /* __AST_VERSION_H */

--- a/main/asterisk.c
+++ b/main/asterisk.c
@@ -491,7 +491,8 @@ static char *handle_show_settings(struct ast_cli_entry *e, int cmd, struct ast_c
 	ast_cli(a->fd, "\nPBX Core settings\n");
 	ast_cli(a->fd, "-----------------\n");
 	ast_cli(a->fd, "  Version:                     %s\n", ast_get_version());
-	ast_cli(a->fd, "  Build Options:               %s\n", S_OR(ast_get_build_opts(), "(none)"));
+	ast_cli(a->fd, "  ABI related Build Options:   %s\n", S_OR(ast_get_build_opts(), "(none)"));
+	ast_cli(a->fd, "  All Build Options:           %s\n", S_OR(ast_get_build_opts_all(), "(none)"));
 	if (ast_option_maxcalls)
 		ast_cli(a->fd, "  Maximum calls:               %d (Current %d)\n", ast_option_maxcalls, ast_active_channels());
 	else


### PR DESCRIPTION
The previous behavior of make_buildopts_h was to not add the
non-ABI-breaking MENUSELECT_CFLAGS like DETECT_DEADLOCKS,
REF_DEBUG, etc. to the buildopts.h file because "it caused
ccache to invalidate files and extended compile times". They're
only defined by passing them on the gcc command line with '-D'
options.   In practice, including them in the include file rarely
causes any impact because the only time ccache cares is if you
actually change an option so the hit occurrs only once after
you change it.

OK so why would we want to include them?  Many IDEs follow the
include files to resolve defines and if the options aren't in an
include file, it can cause the IDE to mark blocks of "ifdeffed"
code as unused when they're really not.

So...

* Added a new menuselect compile option ADD_CFLAGS_TO_BUILDOPTS_H
  which tells make_buildopts_h to include the non-ABI-breaking
  flags in buildopts.h as well as the ABI-breaking ones. The default
  is disabled to preserve current behavior.  As before though,
  only the ABI-breaking flags appear in AST_BUILDOPTS and only
  those are used to calculate AST_BUILDOPT_SUM.
  A new AST_BUILDOPT_ALL define was created to capture all of the
  flags.

* make_version_c was streamlined to use buildopts.h and also to
  create asterisk_build_opts_all[] and ast_get_build_opts_all(void)

* "core show settings" now shows both AST_BUILDOPTS and
  AST_BUILDOPTS_ALL.

UserNote: The "Build Options" entry in the "core show settings"
CLI command has been renamed to "ABI related Build Options" and
a new entry named "All Build Options" has been added that shows
both breaking and non-breaking options.
