### PR TITLE
cel: add publish user event helper

### DIFF
--- a/include/asterisk/cel.h
+++ b/include/asterisk/cel.h
@@ -196,6 +196,22 @@ void ast_cel_publish_event(struct ast_channel *chan,
 	struct ast_json *blob);
 
 /*!
+ * \brief Publish a CEL user event
+ * \since 18
+ *
+ * \note
+ * This serves as a wrapper function around ast_cel_publish_event() to help pack the
+ * extra details before publishing.
+ *
+ * \param chan This is the primary channel associated with this channel event.
+ * \param event This is the user event being reported.
+ * \param extra This contains any extra parameters that need to be conveyed for this event.
+ */
+void ast_cel_publish_user_event(struct ast_channel *chan,
+	const char *event,
+	const char *extra);
+
+/*!
  * \brief Get the CEL topic
  *
  * \retval The CEL topic

--- a/main/cel.c
+++ b/main/cel.c
@@ -1689,6 +1689,21 @@ static int reload_module(void)
 	return 0;
 }
 
+void ast_cel_publish_user_event(struct ast_channel *chan,
+	const char *event,
+	const char *extra)
+{
+	RAII_VAR(struct ast_json *, blob, NULL, ast_json_unref);
+
+	blob = ast_json_pack("{s: s, s: {s: s}}",
+		"event", event,
+		"extra", "extra", S_OR(extra, ""));
+	if (!blob) {
+		return;
+	}
+	ast_cel_publish_event(chan, AST_CEL_USER_DEFINED, blob);
+}
+
 void ast_cel_publish_event(struct ast_channel *chan,
 	enum ast_cel_event_type event_type,
 	struct ast_json *blob)


### PR DESCRIPTION
Add a wrapper function around ast_cel_publish_event that
packs event and extras into a blob before publishing

Resolves:#330
