### PR TITLE
asterisk.c: Use the euid's home directory to read/write cli history

### DIFF
--- a/main/asterisk.c
+++ b/main/asterisk.c
@@ -3172,26 +3172,41 @@ static int ast_el_read_history(const char *filename)
 	return history(el_hist, &ev, H_LOAD, filename);
 }
 
+static void process_histfile(int (*readwrite)(const char *filename))
+{
+	struct passwd *pw = getpwuid(geteuid());
+	int ret = 0;
+	char *name = NULL;
+
+	if (!pw || ast_strlen_zero(pw->pw_dir)) {
+		ast_log(LOG_ERROR, "Unable to determine home directory.  History read/write disabled.\n");
+		return;
+	}
+
+	ret = ast_asprintf(&name, "%s/.asterisk_history", pw->pw_dir);
+	if (ret <= 0) {
+		ast_log(LOG_ERROR, "Unable to create history file name.  History read/write disabled.\n");
+		return;
+	}
+
+	ret = readwrite(name);
+	if (ret < 0) {
+		ast_log(LOG_ERROR, "Unable to read or write history file '%s'\n", name);
+	}
+
+	ast_free(name);
+
+	return;
+}
+
 static void ast_el_read_default_histfile(void)
 {
-	char histfile[80] = "";
-	const char *home = getenv("HOME");
-
-	if (!ast_strlen_zero(home)) {
-		snprintf(histfile, sizeof(histfile), "%s/.asterisk_history", home);
-		ast_el_read_history(histfile);
-	}
+	process_histfile(ast_el_read_history);
 }
 
 static void ast_el_write_default_histfile(void)
 {
-	char histfile[80] = "";
-	const char *home = getenv("HOME");
-
-	if (!ast_strlen_zero(home)) {
-		snprintf(histfile, sizeof(histfile), "%s/.asterisk_history", home);
-		ast_el_write_history(histfile);
-	}
+	process_histfile(ast_el_write_history);
 }
 
 static void ast_remotecontrol(char *data)


### PR DESCRIPTION
The CLI .asterisk_history file is read from/written to the directory
specified by the HOME environment variable. If the root user starts
asterisk with the -U/-G options, or with runuser/rungroup set in
asterisk.conf, the asterisk process is started as root but then it
calls setuid/setgid to set the new user/group. This does NOT reset
the HOME environment variable to the new user's home directory
though so it's still left as "/root". In this case, the new user
will almost certainly NOT have access to read from or write to the
history file.

* Added function process_histfile() which calls
  getpwuid(geteuid()) and uses pw->dir as the home directory
  instead of the HOME environment variable.
* ast_el_read_default_histfile() and ast_el_write_default_histfile()
  have been modified to use the new process_histfile()
  function.

Resolves: #337
