### PR TITLE
func_json: Fix crashes for some types

### DIFF
--- a/include/asterisk/json.h
+++ b/include/asterisk/json.h
@@ -269,6 +269,22 @@ struct ast_json *ast_json_boolean(int value);
 struct ast_json *ast_json_null(void);
 
 /*!
+ * \brief Check if \a value is JSON array.
+ * \since 12.0.0
+ * \retval True (non-zero) if \a value == \ref ast_json_array().
+ * \retval False (zero) otherwise..
+ */
+int ast_json_is_array(const struct ast_json *value);
+
+/*!
+ * \brief Check if \a value is JSON object.
+ * \since 12.0.0
+ * \retval True (non-zero) if \a value == \ref ast_json_object().
+ * \retval False (zero) otherwise..
+ */
+int ast_json_is_object(const struct ast_json *value);
+
+/*!
  * \brief Check if \a value is JSON true.
  * \since 12.0.0
  * \retval True (non-zero) if \a value == \ref ast_json_true().

--- a/main/json.c
+++ b/main/json.c
@@ -250,6 +250,16 @@ struct ast_json *ast_json_null(void)
 	return (struct ast_json *)json_null();
 }
 
+int ast_json_is_array(const struct ast_json *json)
+{
+	return json_is_array((const json_t *)json);
+}
+
+int ast_json_is_object(const struct ast_json *json)
+{
+	return json_is_object((const json_t *)json);
+}
+
 int ast_json_is_true(const struct ast_json *json)
 {
 	return json_is_true((const json_t *)json);


### PR DESCRIPTION
This commit fixes crashes in JSON_DECODE() for types null, true, false and real numbers.

In addition it ensures that a path is not deeper than 32 levels.

Also allow root object to be an array.

Add unit tests for above cases.