### PR TITLE
pjsip: Increase pj_sip Realm Size

### DIFF
--- a/contrib/ast-db-manage/config/versions/437f004ee12c_incease_pjsip_auth_realm.py
+++ b/contrib/ast-db-manage/config/versions/437f004ee12c_incease_pjsip_auth_realm.py
@@ -1,0 +1,22 @@
+"""incease pjsip auth realm
+
+Revision ID: 437f004ee12c
+Revises: a6ef36f1309
+Create Date: 2023-09-23 01:24:04.668434
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '437f004ee12c'
+down_revision = 'a6ef36f1309'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.alter_column('ps_auths', 'realm', type_=sa.String(255))
+
+
+def downgrade():
+    op.alter_column('ps_auths', 'realm', type_=sa.String(40))

--- a/res/ari/internal.h
+++ b/res/ari/internal.h
@@ -59,7 +59,7 @@ struct ast_ari_conf {
 };
 
 /*! Max length for auth_realm field */
-#define ARI_AUTH_REALM_LEN 80
+#define ARI_AUTH_REALM_LEN 256
 
 /*! \brief Global configuration options for ARI. */
 struct ast_ari_conf_general {

--- a/res/res_pjsip/pjsip_distributor.c
+++ b/res/res_pjsip/pjsip_distributor.c
@@ -42,7 +42,7 @@ static pjsip_module distributor_mod = {
 struct ast_sched_context *prune_context;
 
 /* From the auth/realm realtime column size */
-#define MAX_REALM_LENGTH 40
+#define MAX_REALM_LENGTH 255
 static char default_realm[MAX_REALM_LENGTH + 1];
 
 #define DEFAULT_SUSPECTS_BUCKETS 53

--- a/res/res_pjsip_authenticator_digest.c
+++ b/res/res_pjsip_authenticator_digest.c
@@ -32,7 +32,7 @@
  ***/
 
 /* From the auth/realm realtime column size */
-#define MAX_REALM_LENGTH 40
+#define MAX_REALM_LENGTH 255
 static char default_realm[MAX_REALM_LENGTH + 1];
 
 AO2_GLOBAL_OBJ_STATIC(entity_id);

--- a/res/res_pjsip_endpoint_identifier_user.c
+++ b/res/res_pjsip_endpoint_identifier_user.c
@@ -149,7 +149,7 @@ static struct ast_sip_endpoint *username_identify(pjsip_rx_data *rdata)
 
 static struct ast_sip_endpoint *auth_username_identify(pjsip_rx_data *rdata)
 {
-	char username[64], realm[64];
+	char username[64], realm[255];
 	struct ast_sip_endpoint *endpoint;
 	pjsip_authorization_hdr *auth_header = NULL;
 


### PR DESCRIPTION
The pjsip's realm size for pj_sip is set at a restrictive limit of 40 characters.
This limitation poses several drawbacks, such as preventing the full qualification of domain length and limiting the practical use of the realm.
To address these issues and enhance functionality, we propose increasing the realm size from its current limit of 40 characters to a more accommodating size of 255 characters.

Resolves: #345