### PR TITLE
res_pjsip: Increase pj_sip realm size

### DIFF
--- a/contrib/ast-db-manage/config/versions/dac2b4c328b8_incease_pjsip_auth_realm.py
+++ b/contrib/ast-db-manage/config/versions/dac2b4c328b8_incease_pjsip_auth_realm.py
@@ -1,0 +1,22 @@
+"""incease pjsip auth realm
+
+Revision ID: dac2b4c328b8
+Revises: f5b0e7427449
+Create Date: 2023-09-23 02:15:24.270526
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'dac2b4c328b8'
+down_revision = 'f5b0e7427449'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.alter_column('ps_auths', 'realm', type_=sa.String(255))
+
+
+def downgrade():
+    op.alter_column('ps_auths', 'realm', type_=sa.String(40))

--- a/include/asterisk/res_pjsip.h
+++ b/include/asterisk/res_pjsip.h
@@ -87,6 +87,8 @@
 #define AST_STIR_SHAKEN_RESPONSE_STR_UNSUPPORTED_CREDENTIAL "Unsupported Credential"
 #define AST_STIR_SHAKEN_RESPONSE_STR_INVALID_IDENTITY_HEADER "Invalid Identity Header"
 
+#define AST_SIP_AUTH_MAX_REALM_LENGTH 255	/* From the auth/realm realtime column size */
+
 /* ":12345" */
 #define COLON_PORT_STRLEN 6
 /*

--- a/res/ari/internal.h
+++ b/res/ari/internal.h
@@ -59,7 +59,7 @@ struct ast_ari_conf {
 };
 
 /*! Max length for auth_realm field */
-#define ARI_AUTH_REALM_LEN 80
+#define ARI_AUTH_REALM_LEN 256
 
 /*! \brief Global configuration options for ARI. */
 struct ast_ari_conf_general {

--- a/res/res_pjsip/pjsip_distributor.c
+++ b/res/res_pjsip/pjsip_distributor.c
@@ -41,9 +41,6 @@ static pjsip_module distributor_mod = {
 
 struct ast_sched_context *prune_context;
 
-/* From the auth/realm realtime column size */
-#define MAX_REALM_LENGTH 40
-
 #define DEFAULT_SUSPECTS_BUCKETS 53
 
 static struct ao2_container *unidentified_requests;
@@ -613,7 +610,7 @@ static AO2_GLOBAL_OBJ_STATIC(artificial_auth);
 
 static int create_artificial_auth(void)
 {
-	char default_realm[MAX_REALM_LENGTH + 1];
+	char default_realm[AST_SIP_AUTH_MAX_REALM_LENGTH + 1];
 	struct ast_sip_auth *fake_auth;
 
 	ast_sip_get_default_realm(default_realm, sizeof(default_realm));
@@ -1164,7 +1161,7 @@ static int clean_task(const void *data)
 
 static void global_loaded(const char *object_type)
 {
-	char default_realm[MAX_REALM_LENGTH + 1];
+	char default_realm[AST_SIP_AUTH_MAX_REALM_LENGTH + 1];
 	struct ast_sip_auth *fake_auth;
 	char *identifier_order;
 

--- a/res/res_pjsip_authenticator_digest.c
+++ b/res/res_pjsip_authenticator_digest.c
@@ -32,9 +32,7 @@
 	<support_level>core</support_level>
  ***/
 
-/* From the auth/realm realtime column size */
-#define MAX_REALM_LENGTH 40
-static char default_realm[MAX_REALM_LENGTH + 1];
+static char default_realm[AST_SIP_AUTH_MAX_REALM_LENGTH + 1];
 
 AO2_GLOBAL_OBJ_STATIC(entity_id);
 

--- a/res/res_pjsip_endpoint_identifier_user.c
+++ b/res/res_pjsip_endpoint_identifier_user.c
@@ -164,7 +164,7 @@ static struct ast_sip_endpoint *username_identify(pjsip_rx_data *rdata)
 
 static struct ast_sip_endpoint *auth_username_identify(pjsip_rx_data *rdata)
 {
-	char username[USERNAME_LEN + 1], realm[DOMAIN_NAME_LEN + 1];
+	char username[USERNAME_LEN + 1], realm[AST_SIP_AUTH_MAX_REALM_LENGTH + 1];
 	struct ast_sip_endpoint *endpoint;
 	pjsip_authorization_hdr *auth_header = NULL;
 


### PR DESCRIPTION
res_pjsip: Enlarge pj_sip auth realm size to 255 Characters

This commit extends the realm size for pj_sip auth from its 
existing 40-character limitation to a more versatile 255-character 
size. 
This enhancement addresses limitations in domain qualification 
and practical use, resulting in improved functionality. 
Additionally, it includes changes to the realtime database schema 
and ARI message length to accommodate the increased realm size.

Resolves: #345