### PR TITLE
res_pjsip: update qualify_timeout documentation with DNS note

### DIFF
--- a/res/res_pjsip/pjsip_config.xml
+++ b/res/res_pjsip/pjsip_config.xml
@@ -1900,7 +1900,8 @@
 					<synopsis>Timeout for qualify</synopsis>
 					<description><para>
 						If the contact doesn't respond to the OPTIONS request before the timeout,
-						the contact is marked unavailable.
+						the contact is marked unavailable. This includes time spent performing
+						any required DNS lookup(s) prior to sending the OPTIONS.
 						If <literal>0</literal> no timeout. Time in fractional seconds.
 					</para></description>
 				</configOption>
@@ -2125,7 +2126,8 @@
 					<synopsis>Timeout for qualify</synopsis>
 					<description><para>
 						If the contact doesn't respond to the OPTIONS request before the timeout,
-						the contact is marked unavailable.
+						the contact is marked unavailable. This includes time spent performing
+						any required DNS lookup(s) prior to sending the OPTIONS.
 						If <literal>0</literal> no timeout. Time in fractional seconds.
 					</para></description>
 				</configOption>


### PR DESCRIPTION
The documentation on qualify_timeout does not explicitly state that the timeout
includes any time required to perform any needed DNS queries on the endpoint.

If the OPTIONS response is delayed due to the DNS query, it can still render an
endpoint as Unreachable if the net time is enough for qualify_timeout to expire.

Resolves: #352
