### PR TITLE
app_voicemail: Disable ADSI if unavailable.

### DIFF
--- a/apps/app_voicemail.c
+++ b/apps/app_voicemail.c
@@ -7422,8 +7422,11 @@ static void adsi_begin(struct ast_channel *chan, int *useadsi)
 	if (!ast_adsi_available(chan))
 		return;
 	x = ast_adsi_load_session(chan, adsifdn, adsiver, 1);
-	if (x < 0)
+	if (x < 0) {
+		*useadsi = 0;
+		ast_channel_adsicpe_set(chan, AST_ADSI_UNAVAILABLE);
 		return;
+	}
 	if (!x) {
 		if (adsi_load_vmail(chan, useadsi)) {
 			ast_log(AST_LOG_WARNING, "Unable to upload voicemail scripts\n");


### PR DESCRIPTION
If ADSI is available on a channel, app_voicemail will repeatedly try to use ADSI, even if there is no CPE that supports it. This leads to many unnecessary delays during the session. If ADSI is available but ADSI setup fails, we now disable it to prevent further attempts to use ADSI during the session.

Resolves: #354