### PR TITLE
res_stasis: signal when new command is queued

### DIFF
--- a/res/res_stasis.c
+++ b/res/res_stasis.c
@@ -1548,7 +1548,11 @@ int stasis_app_exec(struct ast_channel *chan, const char *app_name, int argc,
 			continue;
 		}
 
+		/* Set this thread's id as the control thread id so that any
+		   new commands can signal out of this wait */
+		control_set_thread(control, pthread_self());
 		r = ast_waitfor(chan, MAX_WAIT_MS);
+		control_set_thread(control, AST_PTHREADT_NULL);
 
 		if (r < 0) {
 			ast_debug(3, "%s: Poll error\n",

--- a/res/stasis/control.c
+++ b/res/stasis/control.c
@@ -93,6 +93,10 @@ struct stasis_app_control {
 	 */
 	char *next_app;
 	/*!
+	 * The thread currently blocking on the channel.
+	 */
+	pthread_t control_thread;
+	/*!
 	 * The list of arguments to pass to StasisStart when moving to another app.
 	 */
 	AST_VECTOR(, char *) next_app_args;
@@ -156,6 +160,8 @@ struct stasis_app_control *control_create(struct ast_channel *channel, struct st
 	control->next_app = NULL;
 	AST_VECTOR_INIT(&control->next_app_args, 0);
 
+	control_set_thread(control, AST_PTHREADT_NULL);
+
 	return control;
 }
 
@@ -182,6 +188,13 @@ static void app_control_unregister_rule(
 		}
 	}
 	AST_RWLIST_TRAVERSE_SAFE_END;
+	ao2_unlock(control->command_queue);
+}
+
+void control_set_thread(struct stasis_app_control *control, pthread_t threadid)
+{
+	ao2_lock(control->command_queue);
+	control->control_thread = threadid;
 	ao2_unlock(control->command_queue);
 }
 
@@ -293,6 +306,13 @@ static struct stasis_app_command *exec_command_on_condition(
 
 	ao2_link_flags(control->command_queue, command, OBJ_NOLOCK);
 	ast_cond_signal(&control->wait_cond);
+
+	if (control->control_thread != AST_PTHREADT_NULL) {
+		/* if the control thread is waiting on the channel, send the SIGURG
+		   to let it know there is a new command */
+		pthread_kill(control->control_thread, SIGURG);
+	}
+
 	ao2_unlock(control->command_queue);
 
 	return command;

--- a/res/stasis/control.h
+++ b/res/stasis/control.h
@@ -49,6 +49,15 @@ struct stasis_app_control *control_create(struct ast_channel *channel, struct st
 void control_flush_queue(struct stasis_app_control *control);
 
 /*!
+ * \brief set the control's thread id
+ * \since 18
+ *
+ * \param control Control object on which to set the thread id.
+ * \param threadid id to set
+ */
+void control_set_thread(struct stasis_app_control *control, pthread_t threadid);
+
+/*!
  * \brief Dispatch all commands enqueued to this control.
  *
  * \param control Control object to dispatch.


### PR DESCRIPTION
res_statsis's app loop sleeps for up to .2s waiting on input
to a channel before re-checking the command queue. This can
cause delays between channel setup and bridge.

This change is to send a SIGURG on the sleeping thread when
a new command is enqueued. This exits the sleeping thread out
of the ast_waitfor() call triggering the new command being
processed on the channel immediately.

Resolves: #362

UserNote: Call setup times should be significantly improved
when using ARI.
