### PR TITLE
res_curl: Add convenience functions for curl.

### DIFF
--- a/include/asterisk/res_curl.h
+++ b/include/asterisk/res_curl.h
@@ -1,0 +1,493 @@
+/*
+ * Asterisk -- An open source telephony toolkit.
+ *
+ * Copyright (C) 2023, Sangoma Technologies Corporation
+ *
+ * George Joseph <gjoseph@sangoma.com>
+ *
+ * See http://www.asterisk.org for more information about
+ * the Asterisk project. Please do not directly contact
+ * any of the maintainers of this project for assistance;
+ * the project provides a web site, mailing lists and IRC
+ * channels for your use.
+ *
+ * This program is free software, distributed under the terms of
+ * the GNU General Public License Version 2. See the LICENSE file
+ * at the top of the source tree.
+ */
+
+#ifndef _RES_CRYPTO_H
+#define _RES_CRYPTO_H
+
+#include <curl/curl.h>
+#include "asterisk/config.h"
+#include "asterisk/acl.h"
+
+#define AST_CURL_DEFAULT_MAX_HEADER_LEN 2048
+
+#ifndef CURL_WRITEFUNC_ERROR
+#define CURL_WRITEFUNC_ERROR 0
+#endif
+
+/*! \defgroup curl_wrappers CURL Convenience Wrappers
+ * @{
+
+\section Overview Overview
+
+While libcurl is extremely flexible in what it allows you to do,
+that flexibility comes at complexity price. The convenience wrappers
+defined here aim to take away some of that complexity for run-of-the-mill
+requests.
+
+\par A Basic Example
+
+If all you need to do is receive a document into a buffer...
+
+\code
+	char *url = "https://someurl";
+	size_t returned_length;
+	char *returned_data = NULL;
+
+	long rc = ast_url_downlaod_to_memory(url, &returned_length,
+		&returned_data, NULL);
+
+	ast_log(LOG_ERROR, "rc: %ld  size: %zu  doc: %.*s \n",
+		rc, returned_length,
+		(int)returned_length, returned_data);
+	ast_std_free(returned_data);
+\endcode
+
+If you need the headers as well...
+
+\code
+	char *url = "https://someurl";
+	size_t returned_length;
+	char *returned_data = NULL;
+	struct ast_variable *headers;
+
+	long rc = ast_url_downlaod_to_memory(url, &returned_length,
+		&returned_data, &headers);
+
+	ast_log(LOG_ERROR, "rc: %ld  size: %zu  doc: %.*s \n",
+		rc, returned_length,
+		(int)returned_length, returned_data);
+
+	ast_std_free(returned_data);
+	ast_variables_destroy(headers);
+\endcode
+
+\par A More Complex Example
+
+If you need mmore control, you can specify callbacks to capture
+the response headers, do something other than write the data
+to a memory buffer, or do some special socket manipulation like
+check that the server's IP address matched an acl.
+
+Let's write the data to a file, capture the headers,
+and make sure the server's IP address is whitelisted.
+
+The default callbacks can do that so all we need to do is
+supply the data.
+
+\code
+	char *url = "http://something";
+
+	struct ast_curl_write_data data = {
+		.output = fopen("myfile.txt", "w");
+		.debug_info = url,
+	};
+	struct ast_curl_header_data hdata = {
+		.debug_info = url,
+	};
+	struct ast_curl_open_socket_data osdata = {
+		.acl = my_acl_list,
+		.debug_info = url,
+	};
+	struct ast_curl_optional_data opdata = {
+		.open_socket_cb = ast_curl_open_socket_cb,
+		.open_socket_data = &osdata,
+	};
+
+	long rc = ast_curler(url, 0, ast_curl_write_default_cb, &data,
+		ast_curl_header_default_cb, &hdata, &opdata);
+
+	fclose(data.output);
+	ast_variables_destroy(hdata.headers);
+
+\endcode
+
+If you need even more control, you can supply your own
+callbacks as well.  This is a silly example of providing
+your own write callback.  It's basically what
+ast_curler_write_to_file() does.
+
+\code
+static size_t my_write_cb(char *data, size_t size,
+	size_t nmemb, void *client_data)
+{
+	FILE *fp = (FILE *)client_data;
+	return fwrite(data, size, nmemb, fp);
+}
+
+static long myfunc(char *url, char *file)
+{
+	FILE *fp = fopen(file, "w");
+	long rc = ast_curler(url, 0, my_write_cb, fp, NULL, NULL, NULL);
+	fclose(fp);
+	return rc;
+}
+\endcode
+ */
+
+/*!
+ * \defgroup HeaderCallback  Header Callback
+ * \ingroup curl_wrappers
+ * @{
+ *
+ * If you need to access the headers returned on the response,
+ * you can define a callback that curl will call for every
+ * header it receives.
+ *
+ * Your callback must follow the specification defined for
+ * CURLOPT_HEADERFUNCTION and implement the curl_write_callback
+ * prototype.
+ *
+ * The following ast_curl_headers objects compose a default
+ * implementation that will accumulate the headers in an
+ * ast_variable list.
+ */
+
+/*!
+ *
+ * \brief Context structure passed to \ref ast_curl_header_default_cb
+ *
+ */
+struct ast_curl_header_data {
+	/*!
+	 * curl's default max header length is 100k but we rarely
+	 * need that much. It's also possible that a malicious remote
+	 * server could send tons of 100k headers in an attempt to
+	 * cause an out-of-memory condition.  Setting this value
+	 * will cause us to simply ignore any header with a length
+	 * that exceeds it.  If not set, the length defined in
+	 * #AST_CURL_DEFAULT_MAX_HEADER_LEN will be used.
+	 */
+	size_t max_header_len;
+	/*!
+	 * Identifying info placed at the start of log and trace messages.
+	 */
+	char *debug_info;
+	/*!
+	 * This list will contain all the headers received.
+	 * \note curl converts all header names to lower case.
+	 */
+	struct ast_variable *headers;
+	/*!
+	 * \internal
+	 * Private flag used to keep track of whether we're
+	 * capturing headers or not.  We only want them after
+	 * we've seen an HTTP response code in the 2XX range
+	 * and before the blank line that separaes the headers
+	 * from the body.
+	 */
+	int _capture;
+};
+
+/*!
+ * \brief A default implementation of a header callback.
+ *
+ * This is an implementation of #CURLOPT_HEADERFUNCTION that performs
+ * basic sanity checks and saves headers in the
+ * ast_curl_header_data.headers ast_variable list.
+ *
+ * The curl prototype for this function is \ref curl_write_callback
+ *
+ * \warning If you decide to write your own callback, curl doesn't
+ * guarantee a terminating NULL in data passed to the callbacks!
+ *
+ * \param data Will contain a header line that may not be NULL terminated.
+ * \param size Always 1.
+ * \param nitems The number of bytes in data.
+ * \param client_data A pointer to whatever structure you passed to
+ *        \ref ast_curler in the \p curl_header_data parameter.
+ *
+ * \return Number of bytes handled.  Must be (size * nitems) or an
+ *         error is signalled.
+ */
+size_t ast_curl_header_default_cb(char *data, size_t size,
+	size_t nitems, void *client_data);
+
+/*!
+ *  @}
+ */
+
+/*!
+ * \defgroup DataCallback  Received Data Callback
+ * \ingroup curl_wrappers
+ * @{
+ *
+ * If you need to do something with the data received other than
+ * save it in a memory buffer, you can define a callback that curl
+ * will call for each "chunk" of data it receives from the server.
+ *
+ * Your callback must follow the specification defined for
+ * CURLOPT_WRITEFUNCTION and implement the 'curl_write_callback'
+ * prototype.
+ *
+ * The following ast_curl_write objects compose a default
+ * implementation that will write the data to any FILE *
+ * descriptor you choose.
+ */
+
+/*!
+ * \brief Context structure passed to \ref ast_curl_write_default_cb.
+ */
+struct ast_curl_write_data {
+	/*!
+	 * If this value is > 0, the request will be cancelled when
+	 * \a bytes_downloaded exceeds it.
+	 */
+	size_t max_download_bytes;
+	/*!
+	 * Where to write to.  Could be anything you can get a FILE* for.
+	 * A file opened with fopen, a buffer opened with open_memstream(), etc.
+	 * Required by \ref ast_curl_write_default_cb.
+	 */
+	FILE *output;
+	/*!
+	 * Identifying info placed at the start of log and trace messages.
+	 */
+	char *debug_info;
+	/*!
+	 * Keeps track of the number of bytes read so far.
+	 * This is updated by the callback regardless of
+	 * whether the output stream is updating
+	 * \ref stream_bytes_downloaded.
+	 */
+	size_t bytes_downloaded;
+	/*!
+	 * A buffer to be used for anything the output stream needs.
+	 * For instance, the address of this member can be passed to
+	 * open_memstream which will update it as it reads data. When
+	 * the memstream is flushed/closed, this will contain all of
+	 * the data read so far.  You must free this yourself with
+	 * ast_std_free().
+	 */
+	char *stream_buffer;
+	/*!
+	 * Keeps track of the number of bytes read so far.
+	 * Can be used by memstream.
+	 */
+	size_t stream_bytes_downloaded;
+	/*!
+	 * \internal
+	 * Set if we automatically opened a memstream
+	 */
+	int _internal_memstream;
+};
+
+/*!
+ * \brief A default implementation of a write data callback.
+
+ * This is a default implementation of the function described
+ * by CURLOPT_WRITEFUNCTION that writes data received to a
+ * user-provided FILE *.  This function is called by curl itself
+ * when it determines it has enough data to warrant a write.
+ * This may be influenced by the value of
+ * ast_curl_optional_data.per_write_buffer_size.
+ * See the CURLOPT_WRITEFUNCTION documentation for more info.
+ *
+ * The curl prototype for this function is 'curl_write_callback'
+ *
+ * \param data Data read by curl.
+ * \param size Always 1.
+ * \param nitems The number of bytes read.
+ * \param client_data A pointer to whatever structure you passed to
+ *        \ref ast_curler in the \p curl_write_data parameter.
+ *
+ * \return Number of bytes handled.  Must be (size * nitems) or an
+ *         error is signalled.
+ */
+size_t ast_curl_write_default_cb(char *data, size_t size, size_t nmemb, void *clientp);
+
+/*!
+ *  @}
+ */
+
+/*!
+ * \defgroup OpenSocket  Open Socket Callback
+ * \ingroup curl_wrappers
+ * @{
+ *
+ * If you need to allocate the socket curl uses to make the
+ * request yourself or you need to do some checking on the
+ * request's resolved IP address, this is the callback for you.
+ *
+ * Your callback must follow the specification defined for
+ * CURLOPT_OPENSOCKETFUNCTION and implement the
+ * 'curl_opensocket_callback' prototype.
+ *
+ * The following ast_open_socket objects compose a default
+ * implementation that will not allow requests to servers
+ * not whitelisted in the provided ast_acl_list.
+ *
+ */
+
+/*!
+ * \brief Context structure passed to \ref ast_curl_open_socket_default_cb
+ */
+struct ast_curl_open_socket_data {
+	/*!
+	 * The acl should provide a whitelist.  Request to servers
+	 * with addresses not allowed by the acl will be rejected.
+	 */
+	const struct ast_acl_list *acl;
+	/*!
+	 * Identifying info placed at the start of log and trace messages.
+	 */
+	char *debug_info;
+	/*!
+	 * \internal
+	 * Set by the callback and passed to curl.
+	 */
+	curl_socket_t sockfd;
+};
+
+/*!
+ * \brief A default implementation of an open socket callback.
+
+ * This is an implementation of the function described
+ * by CURLOPT_OPENSOCKETFUNCTION that checks the request's IP
+ * address against a user-supplied ast_acl_list and either rejects
+ * the request if the IP address isn't allowed, or opens a socket
+ * and returns it to curl.
+ * See the CURLOPT_OPENSOCKETFUNCTION documentation for more info.
+ *
+ * \param client_data A pointer to whatever structure you passed to
+ *        \ref ast_curler in the \p curl_write_data parameter.
+ * \param purpose Will always be CURLSOCKTYPE_IPCXN
+ * \param address The request server's resolved IP address
+ *
+ * \return A socket opened by socket() or -1 to signal an error.
+ */
+curl_socket_t ast_curl_open_socket_default_cb(void *client_data,
+	curlsocktype purpose, struct curl_sockaddr *address);
+
+/*!
+ *  @}
+ */
+
+/*!
+ * \defgroup OptionalData  Optional Data
+ * \ingroup curl_wrappers
+ * @{
+
+ * \brief Structure pased to \ref ast_curler with infrequenty used
+ * control data.
+ */
+struct ast_curl_optional_data {
+	/*!
+	 * If not set, AST_CURL_USER_AGENT
+	 * (defined in asterisk.h) will be used.
+	 */
+	const char *user_agent;
+	/*!
+	 * Set this to limit the amount of data in each call to
+	 * ast_curl_write_cb_t.
+	 */
+	size_t per_write_buffer_size;
+	/*!
+	 * Set this to a custom function that has a matching
+	 * prototype, set it to \ref ast_curl_open_socket_default_cb
+	 * to use the default callback, or leave it at NULL
+	 * to not use any callback.
+	 * \note Will not be called if open_socket_data is NULL.
+	 */
+	curl_opensocket_callback curl_open_socket_cb;
+	/*!
+	 * Set this to whatever your curl_open_socket_cb needs.
+	 * If using \ref ast_curl_open_socket_default_cb, this MUST
+	 * be set to an \ref ast_curl_open_socket_data structure.
+	 * If set to NULL, curl_open_socket_cb will not be called.
+	 */
+	void *curl_open_socket_data;
+};
+
+/*!
+ *  @}
+ */
+
+/*!
+ * \defgroup requests Making Requests
+ * \ingroup curl_wrappers
+ * @{
+ */
+
+/*!
+ * \brief Perform a curl request.
+ *
+ * \param url The URL to request.
+ * \param request_timeout If > 0, timeout after this number of seconds.
+ * \param curl_write_cb Set this to a custom function that has a matching
+ *        prototype or set it to \ref ast_curl_write_default_cb.
+ * \param curl_write_data A pointer to whatever data \p curl_write_cb needs.
+ *        If you set \p curl_write_cb to \ref ast_curl_write_default_cb,
+ *        this MUST be a pointer to an \ref ast_curl_write_data structure. If
+ *        ast_curl_write_data.output is NULL, open_memstream will be called to
+ *        provide one and the resulting data will be available in
+ *        ast_curl_write_data.stream_buffer with the number of bytes
+ *        retrieved in ast_curl_write_data.stream_bytes_downloaded.
+ *        You must free ast_curl_write_data.stream_buffer yourself with
+ *        ast_std_free() when you no longer need it.
+ * \param curl_header_cb Set this to a custom function that has a matching
+ *        prototype or set it to \ref ast_curl_header_default_cb.
+ * \param curl_header_data A pointer to whatever data \p curl_header_cb needs.
+ *        If you set \p curl_header_cb to \ref ast_curl_header_default_cb,
+ *        this MUST be a pointer to an \ref ast_curl_header_data structure.
+ *        The headers read will be in the ast_curl_header_data.headers
+ *        ast_variable list which you must free with ast_variables_destroy()
+ *        when you're done with them.
+ * \param curl_optional_data A pointer to an ast_curl_optional_data structure
+ *        or NULL if you don't need it.
+ * \retval An HTTP response code.
+ * \retval -1 for internal error.
+ */
+long ast_curler(char *url, int request_timeout,
+	curl_write_callback curl_write_cb, void *curl_write_data,
+	curl_write_callback curl_header_cb, void *curl_header_data,
+	struct ast_curl_optional_data *curl_optional_data);
+
+/*!
+ * \brief Really simple document retrieval to memory
+ *
+ * \param url The URL to retrieve
+ * \param returned_length Pointer to a size_t to hold document length.
+ * \param returned_data Pointer to a buffer which will be updated to
+ *        point to the data.  Must be freed with ast_std_free() after use.
+ * \param headers Pointer to an ast_variable * that will contain
+ *        the response headers. Must be freed with ast_variables_destroy()
+ *        Set to NULL if you don't need the headers.
+ * \retval An HTTP response code.
+ * \retval -1 for internal error.
+ */
+long ast_url_download_to_memory(char *url, size_t *returned_length,
+	char **returned_data, struct ast_variable **headers);
+
+/*!
+ * \brief Really simple document retrieval to file
+ *
+ * \param url The URL to retrieve.
+ * \param filename The filename to save it to.
+ * \retval An HTTP response code.
+ * \retval -1 for internal error.
+ */
+long ast_url_download_to_file(char *url, char *filename);
+
+/*!
+ *  @}
+ */
+
+/*!
+ *  @}
+ */
+#endif /* _RES_CRYPTO_H */

--- a/res/res_curl.c
+++ b/res/res_curl.c
@@ -45,6 +45,293 @@
 #include <curl/curl.h>
 
 #include "asterisk/module.h"
+#include "asterisk/res_curl.h"
+
+size_t ast_curl_header_default_cb(char *data, size_t size,
+	size_t nitems, void *client_data)
+{
+	struct ast_curl_header_data *cb_data = client_data;
+	size_t realsize = size * nitems;
+	size_t adjusted_size = realsize;
+	char *debug_info = S_OR(cb_data->debug_info, "");
+	char *start = data;
+	char *colon = NULL;
+	struct ast_variable *h;
+	char *header;
+	char *value;
+	SCOPE_ENTER(3, "'%s': Header received with %zu bytes\n",
+		debug_info, realsize);
+
+	if (cb_data->max_header_len == 0) {
+		cb_data->max_header_len = AST_CURL_DEFAULT_MAX_HEADER_LEN;
+	}
+
+	if (realsize > cb_data->max_header_len) {
+		/*
+		 * Silently ignore any header over the length limit.
+		 */
+		SCOPE_EXIT_RTN_VALUE(realsize, "oversize header: %zu > %zu\n",
+			realsize, cb_data->max_header_len);
+	}
+
+	/* Per CURL: buffer may not be NULL terminated. */
+
+	/* Skip blanks */
+	while (*start && ((unsigned char) *start) < 33 && start < data + realsize) {
+		start++;
+		adjusted_size--;
+	}
+
+	if (adjusted_size < strlen("HTTP/") + 1) {
+		/* this is probably the \r\n\r\n sequence that ends the headers */
+		cb_data->_capture = 0;
+		SCOPE_EXIT_RTN_VALUE(realsize, "undersized header.  probably end-of-headers marker: %zu\n",
+			adjusted_size);
+	}
+
+	/*
+	 * We only want headers from a 2XX response
+	 * so don't start capturing until we see
+	 * the 2XX.
+	 */
+	if (ast_begins_with(start, "HTTP/")) {
+		int code;
+		/*
+		 * HTTP/1.1 200 OK
+		 * We want there to be a version after the HTTP/
+		 * and reason text after the code but we don't care
+		 * what they are.
+		 */
+		int rc = sscanf(start, "HTTP/%*s %d %*s", &code);
+		if (rc == 1) {
+			if (code / 100 == 2) {
+				cb_data->_capture = 1;
+			}
+		}
+		SCOPE_EXIT_RTN_VALUE(realsize, "HTTP response code: %d\n",
+			code);
+	}
+
+	if (!cb_data->_capture) {
+		SCOPE_EXIT_RTN_VALUE(realsize, "not capturing\n");
+	}
+
+	header = ast_alloca(adjusted_size + 1);
+	ast_copy_string(header, start, adjusted_size + 1);
+
+	/* We have a NULL terminated string now */
+
+	colon = strchr(header, ':');
+	if (!colon) {
+		SCOPE_EXIT_RTN_VALUE(realsize, "No colon in the eader.  Weird\n");
+	}
+
+	*colon++ = '\0';
+	value = colon;
+	value = ast_skip_blanks(ast_trim_blanks(value));
+
+	h = ast_variable_new(header, value, __FILE__);
+	if (!h) {
+		SCOPE_EXIT_LOG_RTN_VALUE(CURL_WRITEFUNC_ERROR, LOG_WARNING,
+			"'%s': Unable to allocate memory for header '%s'\n",
+			debug_info, header);
+	}
+	ast_variable_list_append(&cb_data->headers, h);
+
+	SCOPE_EXIT_RTN_VALUE(realsize, "header: <%s>  value: <%s>",
+		header, value);
+}
+
+size_t ast_curl_write_default_cb(char *data, size_t size,
+	size_t nmemb, void *client_data)
+{
+	struct ast_curl_write_data *cb_data = client_data;
+	size_t realsize = size * nmemb;
+	size_t bytes_written = 0;
+	char *debug_info = S_OR(cb_data->debug_info, "");
+	SCOPE_ENTER(3, "'%s': Writing data chunk of %zu bytes\n",
+		debug_info, realsize);
+
+	if (!cb_data->output) {
+		cb_data->output = open_memstream(
+			&cb_data->stream_buffer,
+			&cb_data->stream_bytes_downloaded);
+		if (!cb_data->output) {
+			SCOPE_EXIT_LOG_RTN_VALUE(CURL_WRITEFUNC_ERROR, LOG_WARNING,
+				"'%s': Xfer failed. "
+				"open_memstream failed: %s\n", debug_info, strerror(errno));
+		}
+		cb_data->_internal_memstream = 1;
+	}
+
+	if (cb_data->max_download_bytes > 0 &&
+		cb_data->stream_bytes_downloaded + realsize >
+		cb_data->max_download_bytes) {
+		SCOPE_EXIT_LOG_RTN_VALUE(CURL_WRITEFUNC_ERROR, LOG_WARNING,
+			"'%s': Xfer failed. "
+			"Exceeded maximum %zu bytes transferred\n", debug_info,
+			cb_data->max_download_bytes);
+	}
+
+	bytes_written = fwrite(data, 1, realsize, cb_data->output);
+	cb_data->bytes_downloaded += bytes_written;
+	if (bytes_written != realsize) {
+		SCOPE_EXIT_LOG_RTN_VALUE(CURL_WRITEFUNC_ERROR, LOG_WARNING,
+			"'%s': Xfer failed. "
+			"Expected to write %zu bytes but wrote %zu\n",
+			debug_info, realsize, bytes_written);
+	}
+
+	SCOPE_EXIT_RTN_VALUE(realsize, "Wrote %zu bytes\n", bytes_written);
+}
+
+curl_socket_t ast_curl_open_socket_default_cb(void *client_data,
+	curlsocktype purpose, struct curl_sockaddr *address)
+{
+	struct ast_curl_open_socket_data *cb_data = client_data;
+	char *debug_info = S_OR(cb_data->debug_info, "");
+	SCOPE_ENTER(3, "'%s': Opening socket\n", debug_info);
+
+	if (!ast_acl_list_is_empty((struct ast_acl_list *)cb_data->acl)) {
+		struct ast_sockaddr ast_address = { {0,} };
+
+		ast_sockaddr_copy_sockaddr(&ast_address, &address->addr, address->addrlen);
+
+		if (ast_apply_acl((struct ast_acl_list *)cb_data->acl, &ast_address, NULL) != AST_SENSE_ALLOW) {
+			SCOPE_EXIT_LOG_RTN_VALUE(CURL_SOCKET_BAD, LOG_WARNING,
+				"'%s': Unable to apply acl\n", debug_info);
+		}
+	}
+
+	cb_data->sockfd = socket(address->family, address->socktype, address->protocol);
+	if (cb_data->sockfd < 0) {
+		SCOPE_EXIT_LOG_RTN_VALUE(CURL_SOCKET_BAD, LOG_WARNING,
+			"'%s': Failed to open socket: %s\n", debug_info, strerror(errno));
+	}
+
+	SCOPE_EXIT_RTN_VALUE(cb_data->sockfd, "Success");
+}
+
+long ast_curler(char *url, int request_timeout,
+	curl_write_callback write_cb, void *write_data,
+	curl_write_callback header_cb, void *header_data,
+	struct ast_curl_optional_data *optional_data)
+{
+	RAII_VAR(CURL *, curl, NULL, curl_easy_cleanup);
+	long http_code = 0;
+	struct ast_curl_write_data *default_write_data = NULL;
+	CURLcode rc;
+
+	SCOPE_ENTER(1, "'%s': Retrieving\n", url);
+
+	if (ast_strlen_zero(url)) {
+		SCOPE_EXIT_LOG_RTN_VALUE(500, LOG_ERROR, "'missing': url is missing\n");
+	}
+
+	if (!write_cb || !write_data) {
+		SCOPE_EXIT_LOG_RTN_VALUE(500, LOG_ERROR, "'%s': Either wite_cb and write_data are missing\n", url);
+	}
+	if (write_cb == ast_curl_write_default_cb) {
+		default_write_data = write_data;
+	}
+
+	curl = curl_easy_init();
+	if (!curl) {
+		SCOPE_EXIT_LOG_RTN_VALUE(-1, LOG_ERROR, "'%s': Failed to set up CURL instance\n", url);
+	}
+
+	curl_easy_setopt(curl, CURLOPT_URL, url);
+	if (request_timeout) {
+		curl_easy_setopt(curl, CURLOPT_TIMEOUT, request_timeout);
+	}
+	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
+	curl_easy_setopt(curl, CURLOPT_WRITEDATA, write_data);
+
+	if (header_cb && header_data) {
+		curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, header_cb);
+		curl_easy_setopt(curl, CURLOPT_HEADERDATA, header_data);
+	}
+
+	if (optional_data && !ast_strlen_zero(optional_data->user_agent)) {
+		curl_easy_setopt(curl, CURLOPT_USERAGENT, optional_data->user_agent);
+	}
+	if (optional_data && optional_data->curl_open_socket_cb && optional_data->curl_open_socket_data) {
+		curl_easy_setopt(curl, CURLOPT_OPENSOCKETFUNCTION, optional_data->curl_open_socket_cb);
+		curl_easy_setopt(curl, CURLOPT_OPENSOCKETDATA, optional_data->curl_open_socket_data);
+	}
+
+	if (optional_data && optional_data->per_write_buffer_size) {
+		curl_easy_setopt(curl, CURLOPT_BUFFERSIZE, optional_data->per_write_buffer_size);
+	}
+
+	curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1);
+	curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1);
+
+	rc = curl_easy_perform(curl);
+	if (rc != CURLE_OK) {
+		char *err = ast_strdupa(curl_easy_strerror(rc));
+		curl_easy_cleanup(curl);
+		SCOPE_EXIT_LOG_RTN_VALUE(-1, LOG_ERROR, "'%s': %s\n", url, err);
+	}
+	if (default_write_data) {
+		fflush(default_write_data->output);
+		if (default_write_data->_internal_memstream) {
+			fclose(default_write_data->output);
+		}
+	}
+
+	curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+	curl_easy_cleanup(curl);
+	curl = NULL;
+
+	SCOPE_EXIT_RTN_VALUE(http_code, "'%s': Done: %ld\n", url, http_code);
+}
+
+long ast_url_download_to_memory(char *url, size_t *returned_length,
+	char **returned_data, struct ast_variable **headers)
+{
+	struct ast_curl_write_data data = {
+		.debug_info = url,
+	};
+	struct ast_curl_header_data hdata = {
+		.debug_info = url,
+	};
+
+	long rc = ast_curler(url, 0, ast_curl_write_default_cb, &data,
+		headers ? ast_curl_header_default_cb : NULL, &hdata, NULL);
+	*returned_length = data.stream_bytes_downloaded;
+	*returned_data = data.stream_buffer;
+	*headers = hdata.headers;
+
+	return rc;
+}
+
+static size_t my_write_cb(char *data, size_t size,
+	size_t nmemb, void *client_data)
+{
+	FILE *fp = (FILE *)client_data;
+	return fwrite(data, size, nmemb, fp);
+}
+
+long ast_url_download_to_file(char *url, char *filename)
+{
+	FILE *fp = NULL;
+	long rc = 0;
+
+	if (ast_strlen_zero(url) || ast_strlen_zero(filename)) {
+		ast_log(LOG_ERROR,"url or filename was NULL\n");
+		return -1;
+	}
+	fp = fopen(filename, "w");
+	if (!fp) {
+		ast_log(LOG_ERROR,"Unable to open file '%s': %s\n", filename,
+			strerror(errno));
+		return -1;
+	}
+	rc = ast_curler(url, 0, my_write_cb, fp, NULL, NULL, NULL);
+	fclose(fp);
+	return rc;
+}
 
 static int unload_module(void)
 {
@@ -55,17 +342,16 @@ static int unload_module(void)
 
 static int load_module(void)
 {
-	int res = AST_MODULE_LOAD_SUCCESS;
-
 	if (curl_global_init(CURL_GLOBAL_ALL)) {
 		ast_log(LOG_ERROR, "Unable to initialize the cURL library. Cannot load res_curl.so\n");
 		return AST_MODULE_LOAD_DECLINE;
 	}
 
-	return res;
+	return AST_MODULE_LOAD_SUCCESS;
 }
 
-AST_MODULE_INFO(ASTERISK_GPL_KEY, AST_MODFLAG_LOAD_ORDER, "cURL Resource Module",
+
+AST_MODULE_INFO(ASTERISK_GPL_KEY, AST_MODFLAG_GLOBAL_SYMBOLS | AST_MODFLAG_LOAD_ORDER, "cURL Resource Module",
 	.support_level = AST_MODULE_SUPPORT_CORE,
 	.load = load_module,
 	.unload = unload_module,

--- a/res/res_curl.exports.in
+++ b/res/res_curl.exports.in
@@ -1,0 +1,7 @@
+{
+	global:
+		LINKER_SYMBOL_PREFIX*ast_curl_*;
+		LINKER_SYMBOL_PREFIX*ast_curler;
+	local:
+		*;
+};


### PR DESCRIPTION
There are new functions available in res_curl that mame
using curl much easier.  See the documentation in res_curl.h
for more information.

At some point, the functions in func_curl that are not specifically
involved with providing a dialplan interface should be refactored
to use the the new functions in res_curl as should any other
modules that called func_curl as a convenience.
