### PR TITLE
ARI/stasis: Indicate the diversion target and make it available in hangup request

### DIFF
--- a/main/channel.c
+++ b/main/channel.c
@@ -9119,6 +9119,7 @@ void ast_channel_set_redirecting(struct ast_channel *chan, const struct ast_part
 	ast_channel_lock(chan);
 	ast_party_redirecting_set(ast_channel_redirecting(chan), redirecting, update);
 	ast_channel_snapshot_invalidate_segment(chan, AST_CHANNEL_SNAPSHOT_INVALIDATE_CALLER);
+	ast_channel_publish_snapshot(chan);
 	ast_channel_unlock(chan);
 }
 

--- a/main/stasis_channels.c
+++ b/main/stasis_channels.c
@@ -1323,6 +1323,10 @@ struct ast_json *ast_channel_snapshot_to_json(
 		"creationtime", ast_json_timeval(snapshot->base->creationtime, NULL),
 		"language", snapshot->base->language);
 
+	if (!ast_strlen_zero(snapshot->caller->rdnis)) {
+		ast_json_object_set(json_chan, "caller_rdnis", ast_json_string_create(snapshot->caller->rdnis));
+	}
+
 	if (snapshot->ari_vars && !AST_LIST_EMPTY(snapshot->ari_vars)) {
 		ast_json_object_set(json_chan, "channelvars", ast_json_channel_vars(snapshot->ari_vars));
 	}

--- a/res/ari/ari_model_validators.c
+++ b/res/ari/ari_model_validators.c
@@ -1067,6 +1067,15 @@ int ast_ari_validate_channel(struct ast_json *json)
 				res = 0;
 			}
 		} else
+		if (strcmp("caller_rdnis", ast_json_object_iter_key(iter)) == 0) {
+			int prop_is_valid;
+			prop_is_valid = ast_ari_validate_string(
+				ast_json_object_iter_value(iter));
+			if (!prop_is_valid) {
+				ast_log(LOG_ERROR, "ARI Channel field caller_rdnis failed validation\n");
+				res = 0;
+			}
+		} else
 		if (strcmp("channelvars", ast_json_object_iter_key(iter)) == 0) {
 			int prop_is_valid;
 			prop_is_valid = ast_ari_validate_object(

--- a/res/ari/ari_model_validators.h
+++ b/res/ari/ari_model_validators.h
@@ -1346,6 +1346,7 @@ ari_validator ast_ari_validate_application_fn(void);
  * Channel
  * - accountcode: string (required)
  * - caller: CallerID (required)
+ * - caller_rdnis: string
  * - channelvars: object
  * - connected: CallerID (required)
  * - creationtime: Date (required)

--- a/rest-api/api-docs/channels.json
+++ b/rest-api/api-docs/channels.json
@@ -2187,6 +2187,10 @@
 					"required": false,
 					"type": "object",
 					"description": "Channel variables"
+				},
+				"caller_rdnis": {
+					"type": "string",
+					"description": "The Caller ID RDNIS"
 				}
 			}
 		}


### PR DESCRIPTION
Add the `caller_rdnis` attribute to the channel in ARI. Update the channel snapshot before publishing the hangup request to have the latest information.