### PR TITLE
api.wiki.mustache: Fix indentation in generated markdown

### DIFF
--- a/rest-api-templates/api.wiki.mustache
+++ b/rest-api-templates/api.wiki.mustache
@@ -23,10 +23,10 @@ Parameters are case-sensitive.
 {{#path_parameters}}
 * {{name}}: _{{data_type}}_ - {{{wiki_description}}}
 {{#default_value}}
-  * Default: {{default_value}}
+    * Default: {{default_value}}
 {{/default_value}}
 {{#wiki_allowable_values}}
-  * {{wiki_allowable_values}}
+    * {{wiki_allowable_values}}
 {{/wiki_allowable_values}}
 {{/path_parameters}}
 {{/has_path_parameters}}
@@ -36,13 +36,13 @@ Parameters are case-sensitive.
 {{#query_parameters}}
 * {{name}}: _{{data_type}}_ -{{#required}} *(required)*{{/required}} {{{wiki_description}}}
 {{#default_value}}
-  * Default: {{default_value}}
+    * Default: {{default_value}}
 {{/default_value}}
 {{#wiki_allowable_values}}
-  * {{wiki_allowable_values}}
+    * {{wiki_allowable_values}}
 {{/wiki_allowable_values}}
 {{#allow_multiple}}
-  * Allows comma separated values.
+    * Allows comma separated values.
 {{/allow_multiple}}
 {{/query_parameters}}
 {{/has_query_parameters}}
@@ -53,7 +53,7 @@ Parameters are case-sensitive.
 {{#body_parameter}}
 * {{name}}: {{data_type}}{{#default_value}} = {{default_value}}{{/default_value}} -{{#required}} *(required)*{{/required}} {{{wiki_description}}}
 {{#allow_multiple}}
-  * Allows comma separated values.
+    * Allows comma separated values.
 {{/allow_multiple}}
 {{/body_parameter}}
 {{/has_body_parameter}}
@@ -63,7 +63,7 @@ Parameters are case-sensitive.
 {{#header_parameters}}
 * {{name}}: {{data_type}}{{#default_value}} = {{default_value}}{{/default_value}} -{{#required}} *(required)*{{/required}} {{{wiki_description}}}
 {{#allow_multiple}}
-  * Allows comma separated values.
+    * Allows comma separated values.
 {{/allow_multiple}}
 {{/header_parameters}}
 {{/has_header_parameters}}


### PR DESCRIPTION
The '*' list indicator for default values and allowable values for
path, query and POST parameters need to be indented 4 spaces
instead of 2.

Should resolve issue 38 in the documentation repo.
