### PR TITLE
main/utils: Implement ast_get_tid() for OpenBSD

### DIFF
--- a/main/utils.c
+++ b/main/utils.c
@@ -2763,6 +2763,8 @@ int ast_get_tid(void)
 	ret = lwpid;
 #elif defined(__NetBSD__)
 	ret = _lwp_self();
+#elif defined(__OpenBSD__)
+	ret = getthrid();
 #endif
 	return ret;
 }


### PR DESCRIPTION
Implement the ast_get_tid() function for OpenBSD. OpenBSD supports
getting the TID via getthrid().