### PR TITLE
chan_pjsip: handle crash if channel disapper while calling dtmf_begin

### DIFF
--- a/channels/chan_pjsip.c
+++ b/channels/chan_pjsip.c
@@ -1820,6 +1820,12 @@ static int chan_pjsip_digit_begin(struct ast_channel *chan, char digit)
 	struct chan_pjsip_pvt *pvt = channel->pvt;
 	struct ast_sip_session_media *media = pvt->media[SIP_MEDIA_AUDIO];
 
+	if (!channel || !channel->session) {
+		/* This happens when the channel is hungup while a DTMF digit is playing. See ASTERISK #377 */
+		ast_debug(3, "Channel %s disappeared while calling digit_begin\n", ast_channel_name(ast));
+		return -1;
+	}
+
 	switch (channel->session->dtmf) {
 	case AST_SIP_DTMF_RFC_4733:
 		if (!media || !media->rtp) {


### PR DESCRIPTION
Check if channel is still available in digit_begin like what we do in digit_end

Resolves issue #377 