### PR TITLE
codec_ilbc: Disable system ilbc if version >= 3.0.0

### DIFF
--- a/configure
+++ b/configure
@@ -21276,12 +21276,12 @@ if test -n "$ILBC_CFLAGS"; then
     pkg_cv_ILBC_CFLAGS="$ILBC_CFLAGS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libilbc\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "libilbc") 2>&5
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libilbc < 3\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "libilbc < 3") 2>&5
   ac_status=$?
   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
-  pkg_cv_ILBC_CFLAGS=`$PKG_CONFIG --cflags "libilbc" 2>/dev/null`
+  pkg_cv_ILBC_CFLAGS=`$PKG_CONFIG --cflags "libilbc < 3" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
 else
   pkg_failed=yes
@@ -21293,12 +21293,12 @@ if test -n "$ILBC_LIBS"; then
     pkg_cv_ILBC_LIBS="$ILBC_LIBS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libilbc\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "libilbc") 2>&5
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libilbc < 3\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "libilbc < 3") 2>&5
   ac_status=$?
   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
-  pkg_cv_ILBC_LIBS=`$PKG_CONFIG --libs "libilbc" 2>/dev/null`
+  pkg_cv_ILBC_LIBS=`$PKG_CONFIG --libs "libilbc < 3" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
 else
   pkg_failed=yes
@@ -21319,9 +21319,9 @@ else
         _pkg_short_errors_supported=no
 fi
         if test $_pkg_short_errors_supported = yes; then
-	        ILBC_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libilbc" 2>&1`
+	        ILBC_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libilbc < 3" 2>&1`
         else
-	        ILBC_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libilbc" 2>&1`
+	        ILBC_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libilbc < 3" 2>&1`
         fi
 	# Put the nasty error message in config.log where it belongs
 	echo "$ILBC_PKG_ERRORS" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -1732,7 +1732,7 @@ if test "${USE_ILBC}" != "no"; then
       ILBC_INTERNAL="no"
    fi
    if test "${ILBC_SYSTEM}" = "yes"; then
-      AST_PKG_CONFIG_CHECK(ILBC, libilbc)
+      AST_PKG_CONFIG_CHECK(ILBC, libilbc < 3)
       if test "$PBX_ILBC" = "1"; then
 	 ILBC_INTERNAL="no"
       fi


### PR DESCRIPTION
Fedora 37 started shipping ilbc 3.0.4 which we don't yet support.
configure.ac now checks the system for "libilbc < 3" instead of
just "libilbc".  If true, the system version of ilbc will be used.
If not, the version included at codecs/ilbc will be used.

Resolves: #84
