### PR TITLE
func_lock: Add missing see-also refs to documentation.

### DIFF
--- a/funcs/func_lock.c
+++ b/funcs/func_lock.c
@@ -64,6 +64,10 @@
 				dialplan, and not directly from external protocols.</para>
 			</note>
 		</description>
+		<see-also>
+			<ref type="function">TRYLOCK</ref>
+			<ref type="function">UNLOCK</ref>
+		</see-also>
 	</function>
 	<function name="TRYLOCK" language="en_US">
 		<synopsis>
@@ -82,6 +86,10 @@
 				dialplan, and not directly from external protocols.</para>
 			</note>
 		</description>
+		<see-also>
+			<ref type="function">LOCK</ref>
+			<ref type="function">UNLOCK</ref>
+		</see-also>
 	</function>
 	<function name="UNLOCK" language="en_US">
 		<synopsis>
@@ -101,6 +109,10 @@
 				dialplan, and not directly from external protocols.</para>
 			</note>
 		</description>
+		<see-also>
+			<ref type="function">LOCK</ref>
+			<ref type="function">TRYLOCK</ref>
+		</see-also>
 	</function>
  ***/
 


### PR DESCRIPTION
Resolves: #423