### PR TITLE
configs: Improve documentation for bandwidth in iax.conf.

### DIFF
--- a/configs/samples/iax.conf.sample
+++ b/configs/samples/iax.conf.sample
@@ -140,9 +140,13 @@
 
 ;
 ; Specify bandwidth of low, medium, or high to control which codecs are used
-; in general.
+; in general. This setting will restrict codecs used to only those that comply
+; with the bandwidth setting. In most cases, you should set this to 'high' so
+; that high-quality codecs may be used; if set to a lower value, this will
+; degrade call quality, so you probably only want to do this if you have
+; actual significant bandwidth constraints.
 ;
-bandwidth=low
+bandwidth=high
 ;
 
 ;


### PR DESCRIPTION
This improves the documentation for the bandwidth setting in iax.conf by making it clearer what the ramifications of this setting are. It also changes the sample default from low to high, since only high is compatible with good codecs that people will want to use in the vast majority of cases, and this is a common gotcha that trips up new users.

Resolves: #425