### PR TITLE
general: Fix broken links.

### DIFF
--- a/BUGS
+++ b/BUGS
@@ -10,7 +10,7 @@ For more information on using the bug tracker, or to
 learn how you can contribute by acting as a bug marshal
 please see:
 
-	https://wiki.asterisk.org/wiki/x/RgAtAQ
+	https://docs.asterisk.org/Asterisk-Community/Asterisk-Issue-Guidelines/
 
 If you would like to submit a feature request, please
 resist the temptation to post it to the bug tracker.

--- a/README-SERIOUSLY.bestpractices.md
+++ b/README-SERIOUSLY.bestpractices.md
@@ -379,9 +379,8 @@ is set to no.
 
 In Asterisk 12 and later, live_dangerously defaults to no.
 
-
-[voip-security-webinar]: https://www.asterisk.org/security/webinar/
-[blog-sip-security]: http://blogs.digium.com/2009/03/28/sip-security/
+[voip-security-webinar]: https://docs.asterisk.org/Deployment/Important-Security-Considerations/Asterisk-Security-Webinars/
+[blog-sip-security]: https://web.archive.org/web/20171030134647/http://blogs.digium.com/2009/03/28/sip-security/
 [Strong Password Generator]: https://www.strongpasswordgenerator.com
 [Filtering Data]: #filtering-data
 [Proper Device Naming]: #proper-device-naming
@@ -389,4 +388,4 @@ In Asterisk 12 and later, live_dangerously defaults to no.
 [Reducing Pattern Match Typos]: #reducing-pattern-match-typos
 [Manager Class Authorizations]: #manager-class-authorizations
 [Avoid Privilege Escalations]: #avoid-privilege-escalations
-[Important Security Considerations]: https://wiki.asterisk.org/wiki/display/AST/Important+Security+Considerations
+[Important Security Considerations]: https://docs.asterisk.org/Deployment/Important-Security-Considerations/

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ more telephony interfaces than just Internet telephony.  Asterisk also has a
 vast amount of support for traditional PSTN telephony, as well.
 
   For more information on the project itself, please visit the Asterisk
-[home page] and the official [wiki].  In addition you'll find lots
+[home page] and the official [documentation].  In addition you'll find lots
 of information compiled by the Asterisk community at [voip-info.org].
 
   There is a book on Asterisk published by O'Reilly under the Creative Commons
@@ -258,7 +258,7 @@ Asterisk is a trademark of Sangoma Technologies Corporation
 
 [home page]: https://www.asterisk.org
 [support]: https://www.asterisk.org/support
-[wiki]: https://wiki.asterisk.org/
+[documentation]: https://docs.asterisk.org/
 [mailing list]: http://lists.digium.com/mailman/listinfo/asterisk-users
 [chan_dahdi.conf]: configs/samples/chan_dahdi.conf.sample
 [voip-info.org]: http://www.voip-info.org/wiki-Asterisk
@@ -269,4 +269,4 @@ Asterisk is a trademark of Sangoma Technologies Corporation
 [CHANGES]: CHANGES
 [configs]: configs
 [doc]: doc
-[Important Security Considerations]: https://wiki.asterisk.org/wiki/display/AST/Important+Security+Considerations
+[Important Security Considerations]: https://docs.asterisk.org/Deployment/Important-Security-Considerations/

--- a/apps/app_audiosocket.c
+++ b/apps/app_audiosocket.c
@@ -61,7 +61,7 @@
 		</syntax>
 		<description>
 			<para>Connects to the given TCP service, then transmits channel audio over that socket.  In turn, audio is received from the socket and sent to the channel.  Only audio frames will be transmitted.</para>
-			<para>Protocol is specified at https://wiki.asterisk.org/wiki/display/AST/AudioSocket</para>
+			<para>Protocol is specified at https://docs.asterisk.org/Configuration/Channel-Drivers/AudioSocket/</para>
 			<para>This application does not automatically answer and should generally be preceeded by an application such as Answer() or Progress().</para>
 		</description>
 	</application>

--- a/apps/app_skel.c
+++ b/apps/app_skel.c
@@ -16,7 +16,7 @@
  * at the top of the source tree.
  *
  * Please follow coding guidelines
- * https://wiki.asterisk.org/wiki/display/AST/Coding+Guidelines
+ * https://docs.asterisk.org/Development/Policies-and-Procedures/Coding-Guidelines/
  */
 
 /*! \file

--- a/apps/app_voicemail.c
+++ b/apps/app_voicemail.c
@@ -27,7 +27,7 @@
  *
  * \par See also
  * \arg \ref voicemail.conf "Config_voicemail"
- * \note For information about voicemail IMAP storage, https://wiki.asterisk.org/wiki/display/AST/IMAP+Voicemail+Storage
+ * \note For information about voicemail IMAP storage, https://docs.asterisk.org/Configuration/Applications/Voicemail/IMAP-Voicemail-Storage/
  * \ingroup applications
  * \todo This module requires res_adsi to load. This needs to be optional
  * during compilation.

--- a/apps/confbridge/include/conf_state.h
+++ b/apps/confbridge/include/conf_state.h
@@ -22,7 +22,7 @@
  *
  * \author\verbatim Terry Wilson <twilson@digium.com> \endverbatim
  *
- * See https://wiki.asterisk.org/wiki/display/AST/Confbridge+state+changes for
+ * See https://docs.asterisk.org/Development/Reference-Information/Other-Reference-Information/Confbridge-state-changes/ for
  * a more complete description of how conference states work.
  */
 

--- a/configs/basic-pbx/README
+++ b/configs/basic-pbx/README
@@ -8,8 +8,8 @@ If you intend to use this configuration as a template for your own, then
 you will need to change many values in the various configuration files to
 match your own devices, network, SIP ITSP accounts and more.
 
-For further documentation on this configuration see the Asterisk wiki:
-https://wiki.asterisk.org/wiki/display/AST/Reference+Use+Cases+for+Asterisk.
+For further documentation on this configuration see the Asterisk documentation:
+https://docs.asterisk.org/Deployment/Reference-Use-Cases-for-Asterisk/.
 
 Please report bugs or errors in configuration on the Asterisk issue tracker:
-https://wiki.asterisk.org/wiki/display/AST/Asterisk+Issue+Guidelines
+https://docs.asterisk.org/Asterisk-Community/Asterisk-Issue-Guidelines/

--- a/configs/samples/ccss.conf.sample
+++ b/configs/samples/ccss.conf.sample
@@ -2,7 +2,7 @@
 ; --- Call Completion Supplementary Services ---
 ;
 ; For more information about CCSS, see the CCSS user documentation
-; https://wiki.asterisk.org/wiki/display/AST/Call+Completion+Supplementary+Services+(CCSS)
+; https://docs.asterisk.org/Deployment/PSTN-Connectivity/Call-Completion-Supplementary-Services-CCSS/
 ;
 
 [general]

--- a/configs/samples/chan_dahdi.conf.sample
+++ b/configs/samples/chan_dahdi.conf.sample
@@ -595,7 +595,7 @@ usecallerid=yes
 ;     polarity    = polarity reversal signals the start
 ;     polarity_IN = polarity reversal signals the start, for India,
 ;                   for dtmf dialtone detection; using DTMF.
-;     (see https://wiki.asterisk.org/wiki/display/AST/Caller+ID+in+India)
+; (see https://wiki.asterisk.org/wiki/display/AST/Caller+ID+in+India)
 ;     dtmf        = causes monitor loop to look for dtmf energy on the
 ;                   incoming channel to initate cid acquisition
 ;
@@ -1579,7 +1579,7 @@ pickupgroup=1
 ;#include ss7.timers
 
 ; For more information on setting up SS7, see the README file in libss7 or
-; https://wiki.asterisk.org/wiki/display/AST/Signaling+System+Number+7
+; https://docs.asterisk.org/Deployment/PSTN-Connectivity/Signaling-System-Number-7/
 ; ----------------- SS7 Options ----------------------------------------
 
 ; ---------------- Options for use with signalling=mfcr2 --------------

--- a/configs/samples/extconfig.conf.sample
+++ b/configs/samples/extconfig.conf.sample
@@ -2,7 +2,7 @@
 ; Static and realtime external configuration
 ; engine configuration
 ;
-; See https://wiki.asterisk.org/wiki/display/AST/Realtime+Database+Configuration
+; See https://docs.asterisk.org/Fundamentals/Asterisk-Configuration/Database-Support-Configuration/Realtime-Database-Configuration/
 ; for basic table formatting information.
 ;
 [settings]

--- a/configs/samples/geolocation.conf.sample
+++ b/configs/samples/geolocation.conf.sample
@@ -1,7 +1,7 @@
 ;--
   Geolocation Profile Sample Configuration
 
-  Please see https://wiki.asterisk.org/wiki/display/AST/Geolocation
+  Please see https://docs.asterisk.org/Deployment/Geolocation/
   for the most current information.
 --;
 
@@ -33,7 +33,7 @@ incoming calls (Asterisk is the UAS) and and one for outgoing calls
 
 NOTE:
 
-See https://wiki.asterisk.org/wiki/display/AST/Geolocation for the most
+See https://docs.asterisk.org/Deployment/Geolocation/ for the most
 complete and up-to-date information on valid values for the object
 parameters and a full list of references.
 
@@ -96,7 +96,7 @@ variables like ${EXTEN}, channel variables you may have added in the
 dialplan, or variables you may have specified in the profile that
 references this location object.
 
-NOTE: See https://wiki.asterisk.org/wiki/display/AST/Geolocation for the
+NOTE: See https://docs.asterisk.org/Deployment/Geolocation/ for the
 most complete and up-to-date information on valid values for the object
 parameters and a full list of references.
 

--- a/configs/samples/pjsip.conf.sample
+++ b/configs/samples/pjsip.conf.sample
@@ -20,7 +20,7 @@
 
 ; Documentation
 ;
-; The official documentation is at http://wiki.asterisk.org
+; The official documentation is at https://docs.asterisk.org
 ; You can read the XML configuration help via Asterisk command line with
 ; "config show help res_pjsip", then you can drill down through the various
 ; sections and their options.
@@ -31,8 +31,8 @@
 ; At a minimum please read the file "README-SERIOUSLY.bestpractices.txt",
 ; located in the Asterisk source directory before starting Asterisk.
 ; Otherwise you risk allowing the security of the Asterisk system to be
-; compromised. Beyond that please visit and read the security information on
-; the wiki at: https://wiki.asterisk.org/wiki/x/EwFB
+; compromised. Beyond that please visit and read the security information in
+; the documentation at: https://docs.asterisk.org/Deployment/Important-Security-Considerations/
 ;
 ; A few basics to pay attention to:
 ;
@@ -47,7 +47,7 @@
 ;
 ; See the example ACL configuration in this file. Read the configuration help
 ; for the section and all of its options. Look over the samples in acl.conf
-; and documentation at https://wiki.asterisk.org/wiki/x/uA80AQ
+; and documentation at https://docs.asterisk.org/Configuration/Core-Configuration/Named-ACLs/
 ; If possible, restrict access to only networks and addresses you trust.
 ;
 ; Dialplan Contexts
@@ -393,7 +393,7 @@
 ;rewrite_contact=yes  ; necessary if endpoint does not know/register public ip:port
 ;ice_support=yes   ;This is specific to clients that support NAT traversal
                    ;for media via ICE,STUN,TURN. See the wiki at:
-                   ;https://wiki.asterisk.org/wiki/x/D4FHAQ
+                   ;https://docs.asterisk.org/Configuration/Miscellaneous/Interactive-Connectivity-Establishment-ICE-in-Asterisk/
                    ;for a deeper explanation of this topic.
 
 ;[6002]
@@ -1454,7 +1454,7 @@
 
 ; MODULE PROVIDING BELOW SECTION(S): res_pjsip_outbound_publish
 ;======================OUTBOUND_PUBLISH SECTION OPTIONS=====================
-; See https://wiki.asterisk.org/wiki/display/AST/Publishing+Extension+State
+; See https://docs.asterisk.org/Configuration/Channel-Drivers/SIP/Configuring-res_pjsip/Publishing-Extension-State/
 ; for more information.
 ;[outbound-publish]
 ;type=outbound-publish     ; Must be of type 'outbound-publish'.
@@ -1509,9 +1509,9 @@
 
 
 ; MODULE PROVIDING BELOW SECTION(S): res_pjsip_pubsub
-;=============================RESOURCE-LIST===================================
-; See https://wiki.asterisk.org/wiki/pages/viewpage.action?pageId=30278158
+; See https://docs.asterisk.org/Configuration/Channel-Drivers/SIP/Configuring-res_pjsip/Resource-List-Subscriptions-RLS/
 ; for more information.
+;=============================RESOURCE-LIST===================================
 ;[resource_list]
 ;type=resource_list        ; Must be of type 'resource_list'.
 
@@ -1568,7 +1568,7 @@
 
 
 ;==========================INBOUND_PUBLICATION================================
-; See https://wiki.asterisk.org/wiki/display/AST/Exchanging+Device+and+Mailbox+State+Using+PJSIP
+; See https://docs.asterisk.org/Configuration/Channel-Drivers/SIP/Configuring-res_pjsip/Exchanging-Device-and-Mailbox-State-Using-PJSIP/
 ; for more information.
 ;[inbound-publication]
 ;type=                     ; Must be of type 'inbound-publication'.
@@ -1579,7 +1579,7 @@
 
 ; MODULE PROVIDING BELOW SECTION(S): res_pjsip_publish_asterisk
 ;==========================ASTERISK_PUBLICATION===============================
-; See https://wiki.asterisk.org/wiki/display/AST/Exchanging+Device+and+Mailbox+State+Using+PJSIP
+; See https://docs.asterisk.org/Configuration/Channel-Drivers/SIP/Configuring-res_pjsip/Exchanging-Device-and-Mailbox-State-Using-PJSIP/
 ; for more information.
 ;[asterisk-publication]
 ;type=asterisk-publication ; Must be of type 'asterisk-publication'.

--- a/configs/samples/pjsip_wizard.conf.sample
+++ b/configs/samples/pjsip_wizard.conf.sample
@@ -20,7 +20,7 @@
 
 ; Documentation
 ;
-; The official documentation is at http://wiki.asterisk.org
+; The official documentation is at https://docs.asterisk.org
 ; You can read the XML configuration help via Asterisk command line with
 ; "config show help res_pjsip_config_wizard", then you can drill down through
 ; the various sections and their options.

--- a/configs/samples/sla.conf.sample
+++ b/configs/samples/sla.conf.sample
@@ -1,7 +1,7 @@
 ;
 ; Configuration for Shared Line Appearances (SLA).
 ;
-; See http://wiki.asterisk.org or doc/AST.pdf for more information.
+; See https://docs.asterisk.org for more information.
 ;
 
 ; ---- General Options ----------------
@@ -37,7 +37,7 @@
                             ;       DAHDI channels can be directly used.  IP trunks
                             ;       require some indirect configuration which is
                             ;       described in
-                            ; https://wiki.asterisk.org/wiki/display/AST/SLA+Trunk+Configuration
+                            ; https://docs.asterisk.org/Configuration/Applications/Shared-Line-Appearances-SLA/
 
 ;autocontext=line1          ; This supports automatic generation of the dialplan entries
                             ; if the autocontext option is used.  Each trunk should have
@@ -73,7 +73,7 @@
 ;type=trunk
 ;device=Local/disa@line4_outbound ; A Local channel in combination with the Disa
                                   ; application can be used to support IP trunks.
-                                  ; See https://wiki.asterisk.org/wiki/display/AST/SLA+Trunk+Configuration
+                                  ; See https://docs.asterisk.org/Configuration/Applications/Shared-Line-Appearances-SLA/
 ;autocontext=line4
 ; --------------------------------------
 

--- a/configs/samples/stir_shaken.conf.sample
+++ b/configs/samples/stir_shaken.conf.sample
@@ -24,7 +24,7 @@
 ; config directory is.
 ;
 ; Visit the wiki page:
-; https://wiki.asterisk.org/wiki/display/AST/STIR+and+SHAKEN
+; https://docs.asterisk.org/Deployment/STIR-SHAKEN/
 ;
 ; [general]
 ;

--- a/doc/CODING-GUIDELINES
+++ b/doc/CODING-GUIDELINES
@@ -1,2 +1,2 @@
 Coding guidelines are available on the Asterisk wiki at:
-https://wiki.asterisk.org/wiki/display/AST/Coding+Guidelines
+https://docs.asterisk.org/Development/Policies-and-Procedures/Coding-Guidelines/

--- a/doc/README.txt
+++ b/doc/README.txt
@@ -1,13 +1,7 @@
 The vast majority of the Asterisk project documentation has been moved to the
-project wiki:
+project documentation:
 
-    https://wiki.asterisk.org/
-
-Asterisk release tarballs contain an export of the wiki in PDF and plain text
-form, which you can find in:
-
-    doc/AST.pdf
-    doc/AST.txt
+    https://docs.asterisk.org/
 
 Asterisk uses the Doxygen documentation software.  Run "make progdocs" and open
 the resulting documentation index at doc/api/index.html in a webbrowser or copy

--- a/doc/asterisk.8
+++ b/doc/asterisk.8
@@ -248,7 +248,7 @@ https://www.asterisk.org - The Asterisk Home Page
 .PP
 http://www.asteriskdocs.org - The Asterisk Documentation Project
 .PP
-https://wiki.asterisk.org - The Asterisk Wiki
+https://docs.asterisk.org - The Asterisk documentation
 .PP
 https://www.digium.com/ - Asterisk is sponsored by Digium
 .SH AUTHOR

--- a/doc/asterisk.sgml
+++ b/doc/asterisk.sgml
@@ -427,7 +427,7 @@
    http://www.asteriskdocs.org - The Asterisk Documentation Project
   </para>
   <para>
-   https://wiki.asterisk.org - The Asterisk Wiki
+   https://docs.asterisk.org/ - The Asterisk documentation
   </para>
   <para>
    https://www.digium.com/ - Asterisk is sponsored by Digium

--- a/doc/lang/language-criteria.txt
+++ b/doc/lang/language-criteria.txt
@@ -1,3 +1,3 @@
 This document has been moved to the Asterisk Wiki:
 
-https://wiki.asterisk.org/wiki/display/AST/Asterisk+Sounds+Submission+Process
+https://docs.asterisk.org/Development/Policies-and-Procedures/Asterisk-Sounds-Submission-Process/

--- a/main/ast_expr2.fl
+++ b/main/ast_expr2.fl
@@ -468,7 +468,7 @@ int ast_yyerror (const char *s,  yyltype *loc, struct parse_io *parseio )
 			(extra_error_message_supplied ? extra_error_message : ""), s2, parseio->string, spacebuf);
 #endif
 #ifndef STANDALONE
-	ast_log(LOG_WARNING,"If you have questions, please refer to https://wiki.asterisk.org/wiki/display/AST/Channel+Variables\n");
+	ast_log(LOG_WARNING,"If you have questions, please refer to https://docs.asterisk.org/Configuration/Dialplan/Variables/Channel-Variables/\n");
 #endif
 	free(s2);
 	return(0);

--- a/main/ast_expr2f.c
+++ b/main/ast_expr2f.c
@@ -2604,7 +2604,7 @@ int ast_yyerror (const char *s,  yyltype *loc, struct parse_io *parseio )
 			(extra_error_message_supplied ? extra_error_message : ""), s2, parseio->string, spacebuf);
 #endif
 #ifndef STANDALONE
-	ast_log(LOG_WARNING,"If you have questions, please refer to https://wiki.asterisk.org/wiki/display/AST/Channel+Variables\n");
+	ast_log(LOG_WARNING,"If you have questions, please refer to https://docs.asterisk.org/Configuration/Dialplan/Variables/Channel-Variables/\n");
 #endif
 	free(s2);
 	return(0);

--- a/main/asterisk.c
+++ b/main/asterisk.c
@@ -70,8 +70,8 @@
 /*!
  * \page asterisk_community_resources Asterisk Community Resources
  * \par Websites
- * \li http://www.asterisk.org Asterisk Homepage
- * \li http://wiki.asterisk.org Asterisk Wiki
+ * \li https://www.asterisk.org Asterisk Homepage
+ * \li https://docs.asterisk.org Asterisk documentation
  *
  * \par Mailing Lists
  * \par

--- a/main/config.c
+++ b/main/config.c
@@ -23,7 +23,7 @@
  * \author Mark Spencer <markster@digium.com>
  *
  * Includes the Asterisk Realtime API - ARA
- * See http://wiki.asterisk.org
+ * See https://docs.asterisk.org
  */
 
 /*** MODULEINFO

--- a/main/pbx_functions.c
+++ b/main/pbx_functions.c
@@ -467,7 +467,7 @@ void pbx_live_dangerously(int new_live_dangerously)
 {
 	if (new_live_dangerously && !live_dangerously) {
 		ast_log(LOG_WARNING, "Privilege escalation protection disabled!\n"
-			"See https://wiki.asterisk.org/wiki/x/1gKfAQ for more details.\n");
+			"See https://docs.asterisk.org/Configuration/Dialplan/Privilege-Escalations-with-Dialplan-Functions/ for more details.\n");
 	}
 
 	if (!new_live_dangerously && live_dangerously) {

--- a/main/stasis.c
+++ b/main/stasis.c
@@ -286,8 +286,8 @@
  * \par Subscriber shutdown sequencing
  *
  * Subscribers are sensitive to shutdown sequencing, specifically in how the
- * reference message types. This is fully detailed on the wiki at
- * https://wiki.asterisk.org/wiki/x/K4BqAQ.
+ * reference message types. This is fully detailed in the documentation at
+ * https://docs.asterisk.org/Development/Roadmap/Asterisk-12-Projects/Asterisk-12-API-Improvements/Stasis-Message-Bus/Using-the-Stasis-Message-Bus/Stasis-Subscriber-Shutdown-Problem/.
  *
  * In short, the lifetime of the \a data (and \a callback, if in a module) must
  * be held until the stasis_subscription_final_message() has been received.

--- a/res/ari/resource_channels.h
+++ b/res/ari/resource_channels.h
@@ -209,7 +209,7 @@ void ast_ari_channels_originate_with_id(struct ast_variable *headers, struct ast
 struct ast_ari_channels_hangup_args {
 	/*! Channel's id */
 	const char *channel_id;
-	/*! The reason code for hanging up the channel for detail use. Mutually exclusive with 'reason'. See detail hangup codes at here. https://wiki.asterisk.org/wiki/display/AST/Hangup+Cause+Mappings */
+	/*! The reason code for hanging up the channel for detail use. Mutually exclusive with 'reason'. See detail hangup codes at here. https://docs.asterisk.org/Configuration/Miscellaneous/Hangup-Cause-Mappings/ */
 	const char *reason_code;
 	/*! Reason for hanging up the channel for simple use. Mutually exclusive with 'reason_code'. */
 	const char *reason;

--- a/res/res_ari.c
+++ b/res/res_ari.c
@@ -93,7 +93,7 @@
 					</description>
 					<see-also>
 						<ref type="filename">http.conf</ref>
-						<ref type="link">https://wiki.asterisk.org/wiki/display/AST/Asterisk+Builtin+mini-HTTP+Server</ref>
+						<ref type="link">https://docs.asterisk.org/Configuration/Core-Configuration/Asterisk-Builtin-mini-HTTP-Server/</ref>
 					</see-also>
 				</configOption>
 				<configOption name="websocket_write_timeout" default="100">

--- a/res/res_pjsip/pjsip_config.xml
+++ b/res/res_pjsip/pjsip_config.xml
@@ -385,8 +385,8 @@
 						setup time.
 						</para>
 						<para>
-						A more detailed description of how this option functions can be found on
-						the Asterisk wiki https://wiki.asterisk.org/wiki/display/AST/SIP+Direct+Media+Reinvite+Glare+Avoidance
+						A more detailed description of how this option functions can be found in
+						the Asterisk documentation https://docs.asterisk.org/Configuration/Channel-Drivers/SIP/Concepts/SIP-Direct-Media-Reinvite-Glare-Avoidance/
 						</para>
 						<enumlist>
 							<enum name="none" />

--- a/res/res_pjsip_config_wizard.c
+++ b/res/res_pjsip_config_wizard.c
@@ -111,7 +111,7 @@
 
 			<para> </para>
 			<para>For more information, visit:</para>
-			<para><literal>https://wiki.asterisk.org/wiki/display/AST/PJSIP+Configuration+Wizard</literal></para>
+			<para><literal>https://docs.asterisk.org/Configuration/Channel-Drivers/SIP/Configuring-res_pjsip/PJSIP-Configuration-Wizard/</literal></para>
 		</description>
 
 		<configFile name="pjsip_wizard.conf">
@@ -119,7 +119,7 @@
 				<synopsis>Provides config wizard.</synopsis>
 				<description>
 				<para>For more information, visit:</para>
-				<para><literal>https://wiki.asterisk.org/wiki/display/AST/PJSIP+Configuration+Wizard</literal></para>
+				<para><literal>https://docs.asterisk.org/Configuration/Channel-Drivers/SIP/Configuring-res_pjsip/PJSIP-Configuration-Wizard/</literal></para>
 				</description>
 				<configOption name="type">
 					<synopsis>Must be 'wizard'.</synopsis>
@@ -214,7 +214,7 @@
 					<para>Normal dialplan precedence rules apply so if there's already a hint for
 					this extension in <literal>hint_context</literal>, this one will be ignored.
 					For more information, visit: </para>
-					<para><literal>https://wiki.asterisk.org/wiki/display/AST/PJSIP+Configuration+Wizard</literal></para>
+					<para><literal>https://docs.asterisk.org/Configuration/Channel-Drivers/SIP/Configuring-res_pjsip/PJSIP-Configuration-Wizard/</literal></para>
 					</description>
 				</configOption>
 				<configOption name="hint_application">
@@ -235,7 +235,7 @@
 					<para>Normal dialplan precedence rules apply so if there's already a priority 1
 					application for this specific extension in <literal>hint_context</literal>,
 					this one will be ignored. For more information, visit: </para>
-					<para><literal>https://wiki.asterisk.org/wiki/display/AST/PJSIP+Configuration+Wizard</literal></para>
+					<para><literal>https://docs.asterisk.org/Configuration/Channel-Drivers/SIP/Configuring-res_pjsip/PJSIP-Configuration-Wizard/</literal></para>
 					</description>
 				</configOption>
 				<configOption name="endpoint&#47;*">

--- a/res/res_srtp.c
+++ b/res/res_srtp.c
@@ -35,7 +35,7 @@
 	<support_level>core</support_level>
 ***/
 
-/* See https://wiki.asterisk.org/wiki/display/AST/Secure+Calling */
+/* See https://docs.asterisk.org/Deployment/Secure-Calling/ */
 
 #include "asterisk.h"                   /* for NULL, size_t, memcpy, etc */
 

--- a/res/res_timing_dahdi.c
+++ b/res/res_timing_dahdi.c
@@ -170,7 +170,7 @@ static int dahdi_timer_fd(void *data)
 	return timer->fd;
 }
 
-#define SEE_TIMING "For more information on Asterisk timing modules, including ways to potentially fix this problem, please see https://wiki.asterisk.org/wiki/display/AST/Timing+Interfaces\n"
+#define SEE_TIMING "For more information on Asterisk timing modules, including ways to potentially fix this problem, please see https://docs.asterisk.org/Configuration/Core-Configuration/Timing-Interfaces/\n"
 
 static int dahdi_test_timer(void)
 {

--- a/rest-api/api-docs/channels.json
+++ b/rest-api/api-docs/channels.json
@@ -416,7 +416,7 @@
 						},
 						{
 							"name": "reason_code",
-							"description": "The reason code for hanging up the channel for detail use. Mutually exclusive with 'reason'. See detail hangup codes at here. https://wiki.asterisk.org/wiki/display/AST/Hangup+Cause+Mappings",
+							"description": "The reason code for hanging up the channel for detail use. Mutually exclusive with 'reason'. See detail hangup codes at here. https://docs.asterisk.org/Configuration/Miscellaneous/Hangup-Cause-Mappings/",
 							"paramType": "query",
 							"required": false,
 							"allowMultiple": false,


### PR DESCRIPTION
This fixes a number of broken links throughout the tree, mostly caused by wiki.asterisk.org being replaced with docs.asterisk.org, which should eliminate the need for sporadic fixes as in f28047db36a70e81fe373a3d19132c43adf3f74b.

Resolves: #430