### PR TITLE
res_http_websocket.c: Set hostname on client for certificate validation.

### DIFF
--- a/main/tcptls.c
+++ b/main/tcptls.c
@@ -680,6 +680,10 @@ struct ast_tcptls_session_instance *ast_tcptls_client_create(struct ast_tcptls_s
 	int fd, x = 1;
 	struct ast_tcptls_session_instance *tcptls_session = NULL;
 
+	ast_assert(!desc->tls_cfg
+			|| ast_test_flag(&desc->tls_cfg->flags, AST_SSL_DONT_VERIFY_SERVER)
+			|| !ast_strlen_zero(desc->hostname));
+
 	/* Do nothing if nothing has changed */
 	if (!ast_sockaddr_cmp(&desc->old_address, &desc->remote_address)) {
 		ast_debug(1, "Nothing changed in %s\n", desc->name);

--- a/res/res_http_websocket.c
+++ b/res/res_http_websocket.c
@@ -1163,6 +1163,12 @@ static struct ast_tcptls_session_args *websocket_client_args_create(
 	}
 	ast_sockaddr_copy(&args->remote_address, addr);
 	ast_free(addr);
+
+	/* We need to save off the hostname but it may contain a port spec */
+	snprintf(args->hostname, sizeof(args->hostname),
+		"%.*s",
+		(int) strcspn(host, ":"), host);
+
 	return args;
 }
 


### PR DESCRIPTION
Additionally add a `assert()` to in the TLS client setup code to
ensure that hostname is set when it is supposed to be.

Fixes #433