### PR TITLE
func_channel: Expose previously unsettable options.

### DIFF
--- a/channels/chan_dahdi.c
+++ b/channels/chan_dahdi.c
@@ -263,6 +263,10 @@
 			</enum>
 			<enum name="dialmode">
 				<para>R/W Pulse and tone dialing mode of the channel.</para>
+				<para>Disabling tone dialing using this option will not disable the DSP used for DTMF detection.
+				To do that, also set the <literal>digitdetect</literal> option. If digit detection is disabled,
+				DTMF will not be detected, regardless of the <literal>dialmode</literal> setting.
+				The <literal>digitdetect</literal> setting has no impact on pulse dialing detection.</para>
 				<para>If set, overrides the setting in <literal>chan_dahdi.conf</literal> for that channel.</para>
 				<enumlist>
 					<enum name="both" />
@@ -6722,6 +6726,14 @@ static int dahdi_queryoption(struct ast_channel *chan, int option, void *data, i
 	}
 
 	switch (option) {
+	case AST_OPTION_TDD:
+		cp = (char *) data;
+		if (p->mate) {
+			*cp = 2;
+		} else {
+			*cp = p->tdd ? 1 : 0;
+		}
+		break;
 	case AST_OPTION_DIGIT_DETECT:
 		cp = (char *) data;
 		*cp = p->ignoredtmf ? 0 : 1;

--- a/funcs/func_channel.c
+++ b/funcs/func_channel.c
@@ -148,6 +148,16 @@
 					<enum name="checkhangup">
 						<para>R/O Whether the channel is hanging up (1/0)</para>
 					</enum>
+					<enum name="digitdetect">
+						<para>R/W Enable or disable DTMF detection on channel drivers that support it.</para>
+						<para>If set on a DAHDI channel, this will only disable DTMF detection, not pulse dialing detection.
+						To disable pulse dialing, use the <literal>dialmode</literal> option.</para>
+						<para>On DAHDI channels, this will disable DSP if it is not needed for anything else.
+						This will prevent DTMF detection regardless of the <literal>dialmode</literal> setting.</para>
+					</enum>
+					<enum name="faxdetect">
+						<para>R/W Enable or disable fax detection on channel drivers that support it.</para>
+					</enum>
 					<enum name="after_bridge_goto">
 						<para>R/W the parseable goto string indicating where the channel is
 						expected to return to in the PBX after exiting the next bridge it joins
@@ -192,6 +202,10 @@
 					<enum name="parkinglot">
 						<para>R/W parkinglot for parking.</para>
 					</enum>
+					<enum name="relaxdtmf">
+						<para>W/O Enable or disable relaxed DTMF detection for channel drivers that support it,
+						overriding any setting previously defaulted by the channel driver.</para>
+					</enum>
 					<enum name="rxgain">
 						<para>R/W set rxgain level on channel drivers that support it.</para>
 					</enum>
@@ -203,6 +217,11 @@
 					</enum>
 					<enum name="state">
 						<para>R/O state of the channel</para>
+					</enum>
+					<enum name="tdd">
+						<para>R/W Enable or disable TDD mode on channel drivers that support it.</para>
+						<para>When reading this option, 1 indicates TDD mode enabled, 0 indicates TDD mode disabled,
+						and <literal>mate</literal> indicates TDD mate mode.</para>
 					</enum>
 					<enum name="tonezone">
 						<para>R/W zone for indications played</para>
@@ -523,6 +542,29 @@ static int func_channel_read(struct ast_channel *chan, const char *function,
 			ast_callid_strnprint(buf, len, callid);
 		}
 		ast_channel_unlock(chan);
+	} else if (!strcasecmp(data, "tdd")) {
+		char status;
+		int status_size = (int) sizeof(status);
+		ret = ast_channel_queryoption(chan, AST_OPTION_TDD, &status, &status_size, 0);
+		if (!ret) {
+			ast_copy_string(buf, status == 2 ? "mate" : status ? "1" : "0", len);
+		}
+	} else if (!strcasecmp(data, "digitdetect")) {
+		char status;
+		int status_size = (int) sizeof(status);
+		ret = ast_channel_queryoption(chan, AST_OPTION_DIGIT_DETECT, &status, &status_size, 0);
+		if (!ret) {
+			ast_copy_string(buf, status ? "1" : "0", len);
+		}
+	} else if (!strcasecmp(data, "faxdetect")) {
+		char status;
+		int status_size = (int) sizeof(status);
+		ret = ast_channel_queryoption(chan, AST_OPTION_FAX_DETECT, &status, &status_size, 0);
+		if (!ret) {
+			ast_copy_string(buf, status ? "1" : "0", len);
+		}
+	} else if (!strcasecmp(data, "device_name")) {
+		ret = ast_channel_get_device_name(chan, buf, len);
 	} else if (!ast_channel_tech(chan) || !ast_channel_tech(chan)->func_channel_read || ast_channel_tech(chan)->func_channel_read(chan, function, data, buf, len)) {
 		ast_log(LOG_WARNING, "Unknown or unavailable item requested: '%s'\n", data);
 		ret = -1;
@@ -609,12 +651,29 @@ static int func_channel_write_real(struct ast_channel *chan, const char *functio
 		ast_channel_named_pickupgroups_set(chan, groups);
 		ast_channel_unlock(chan);
 		ast_unref_namedgroups(groups);
+	} else if (!strcasecmp(data, "tdd")) {
+		char enabled;
+		if (!strcasecmp(value, "mate")) {
+			enabled = 2;
+		} else {
+			enabled = ast_true(value) ? 1 : 0;
+		}
+		ast_channel_setoption(chan, AST_OPTION_TDD, &enabled, sizeof(enabled), 0);
+	} else if (!strcasecmp(data, "relaxdtmf")) {
+		char enabled = ast_true(value) ? 1 : 0;
+		ast_channel_setoption(chan, AST_OPTION_RELAXDTMF, &enabled, sizeof(enabled), 0);
 	} else if (!strcasecmp(data, "txgain")) {
 		sscanf(value, "%4hhd", &gainset);
 		ast_channel_setoption(chan, AST_OPTION_TXGAIN, &gainset, sizeof(gainset), 0);
 	} else if (!strcasecmp(data, "rxgain")) {
 		sscanf(value, "%4hhd", &gainset);
 		ast_channel_setoption(chan, AST_OPTION_RXGAIN, &gainset, sizeof(gainset), 0);
+	} else if (!strcasecmp(data, "digitdetect")) {
+		char enabled = ast_true(value) ? 1 : 0;
+		ast_channel_setoption(chan, AST_OPTION_DIGIT_DETECT, &enabled, sizeof(enabled), 0);
+	} else if (!strcasecmp(data, "faxdetect")) {
+		char enabled = ast_true(value) ? 1 : 0;
+		ast_channel_setoption(chan, AST_OPTION_FAX_DETECT, &enabled, sizeof(enabled), 0);
 	} else if (!strcasecmp(data, "transfercapability")) {
 		unsigned short i;
 

--- a/include/asterisk/frame.h
+++ b/include/asterisk/frame.h
@@ -462,7 +462,12 @@ struct ast_control_pvt_cause_code {
  * Option data is a single signed char value 0 or 1
  *
  * \note This option appears to be unused in the code. It is handled, but never
- * set or queried. */
+ * set or queried.
+ * (chan_dahdi does allow setting via CHANNEL(echocan_mode), but this uses
+ * the func_write callback, not the setoption callback.
+ * If another channel driver added echocan support, it might make sense to move
+ * this to the setoption callback and then actually use this option.)
+ */
 #define	AST_OPTION_ECHOCAN		8
 
 /*! \brief Handle channel write data


### PR DESCRIPTION
Certain channel options are not set anywhere or
exposed in any way to users, making them unusable. This exposes some of these options which make sense for users to manipulate at runtime.

Resolves: #442