### PR TITLE
func_curl.c: Remove CURLOPT() plaintext documentation.

### DIFF
--- a/funcs/func_curl.c
+++ b/funcs/func_curl.c
@@ -908,31 +908,6 @@ static struct ast_custom_function acf_curl = {
 
 static struct ast_custom_function acf_curlopt = {
 	.name = "CURLOPT",
-	.synopsis = "Set options for use with the CURL() function",
-	.syntax = "CURLOPT(<option>)",
-	.desc =
-"  cookie         - Send cookie with request [none]\n"
-"  conntimeout    - Number of seconds to wait for connection\n"
-"  dnstimeout     - Number of seconds to wait for DNS response\n"
-"  followlocation - Follow HTTP 3xx redirects (boolean)\n"
-"  ftptext        - For FTP, force a text transfer (boolean)\n"
-"  ftptimeout     - For FTP, the server response timeout\n"
-"  header         - Retrieve header information (boolean)\n"
-"  httpheader     - Add new custom http header (string)\n"
-"  httptimeout    - Number of seconds to wait for HTTP response\n"
-"  maxredirs      - Maximum number of redirects to follow\n"
-"  proxy          - Hostname or IP to use as a proxy\n"
-"  proxytype      - http, socks4, or socks5\n"
-"  proxyport      - port number of the proxy\n"
-"  proxyuserpwd   - A <user>:<pass> to use for authentication\n"
-"  referer        - Referer URL to use for the request\n"
-"  useragent      - UserAgent string to use\n"
-"  userpwd        - A <user>:<pass> to use for authentication\n"
-"  ssl_verifypeer - Whether to verify the peer certificate (boolean)\n"
-"  hashcompat     - Result data will be compatible for use with HASH()\n"
-"                 - if value is \"legacy\", will translate '+' to ' '\n"
-"  failurecodes   - A comma separated list of HTTP response codes to be treated as errors\n"
-"",
 	.read = acf_curlopt_read,
 	.read2 = acf_curlopt_read2,
 	.write = acf_curlopt_write,


### PR DESCRIPTION
I assume this was missed when initially converting to XML documentation and we've been kicking the can down the road since.