### PR TITLE
sig_analog: Fix channel leak when mwimonitor is enabled.

### DIFF
--- a/channels/sig_analog.c
+++ b/channels/sig_analog.c
@@ -1764,10 +1764,7 @@ static void *__analog_ss_thread(void *data)
 
 	ast_debug(1, "%s %d\n", __FUNCTION__, p->channel);
 
-	if (!chan) {
-		/* What happened to the channel? */
-		goto quit;
-	}
+	ast_assert(chan != NULL);
 
 	if ((callid = ast_channel_callid(chan))) {
 		ast_callid_threadassoc_add(callid);
@@ -2756,6 +2753,7 @@ int analog_ss_thread_start(struct analog_pvt *p, struct ast_channel *chan)
 {
 	pthread_t threadid;
 
+	p->ss_astchan = chan;
 	return ast_pthread_create_detached(&threadid, NULL, __analog_ss_thread, p);
 }
 


### PR DESCRIPTION
When mwimonitor=yes is enabled for an FXO port,
the do_monitor thread will launch mwi_thread if it thinks there could be MWI on an FXO channel, due to the noise threshold being satisfied. This, in turns, calls
analog_ss_thread_start in sig_analog. However, unlike all other instances where __analog_ss_thread is called in sig_analog, this call path does not properly set pvt->ss_astchan to the Asterisk channel, which means that the Asterisk channel is NULL when __analog_ss_thread starts executing. As a result, the thread exits and the channel is never properly cleaned up by calling ast_hangup.

This caused issues with do_monitor on incoming calls, as it would think the channel was still owned even while receiving events, leading to an infinite barrage of warning messages; additionally, the channel would persist improperly.

To fix this, the assignment is added to the call path where it is missing (which is only used for mwi_thread). A warning message is also added since previously there was no indication that __analog_ss_thread was exiting abnormally. This resolves both the channel leak and the condition that led to the warning messages.

Resolves: #458