### PR TITLE
chan_dahdi: Allow specifying waitfordialtone per call.

### DIFF
--- a/channels/chan_dahdi.h
+++ b/channels/chan_dahdi.h
@@ -651,6 +651,14 @@ struct dahdi_pvt {
 	 */
 	int waitfordialtone;
 	/*!
+	 * \brief Transient variable. Same as waitfordialtone, but temporarily set for a specific call, rather than permanently for the channel.
+	 */
+	int waitfordialtonetemp;
+	/*!
+	 * \brief Transient variable. Stored off waitfordialtone duration at runtime.
+	 */
+	int waitfordialtoneduration;
+	/*!
 	 * \brief Number of frames to watch for dialtone in incoming calls
 	 * \note Set from the "dialtone_detect" value read in from chan_dahdi.conf
 	 */


### PR DESCRIPTION
The existing "waitfordialtone" setting in chan_dahdi.conf applies permanently to a specific channel, regardless of how it is being used. This rather restrictively prevents a system from simultaneously being able to pick free lines for outgoing calls while also allowing barge-in to a trunk by some other arrangement.

This allows specifying "waitfordialtone" using the CHANNEL function for only the next call that will be placed, allowing significantly more flexibility in the use of trunk interfaces.

Resolves: #472

UserNote: "waitfordialtone" may now be specified for DAHDI trunk channels on a per-call basis using the CHANNEL function.