### PR TITLE
chan_iax2.c: Reduce repetitive diagnostic message code.

### DIFF
--- a/channels/chan_iax2.c
+++ b/channels/chan_iax2.c
@@ -1245,15 +1245,26 @@ static void iax_outputframe(struct iax_frame *f, struct ast_iax2_full_hdr *fhi, 
 	}
 }
 
-static void iax_debug_output(const char *data)
+static __attribute__((format(printf, 1, 2)))
+void iax_debug_output(const char *fmt, ...)
 {
-	if (iaxdebug)
-		ast_verbose("%s", data);
+	if (iaxdebug) {
+		va_list ap;
+
+		va_start(ap, fmt);
+		ast_log_ap(LOG_VERBOSE, fmt, ap);
+		va_end(ap);
+	}
 }
 
-static void iax_error_output(const char *data)
+static __attribute__((format(printf, 1, 2)))
+void iax_error_output(const char *fmt, ...)
 {
-	ast_log(LOG_WARNING, "%s", data);
+	va_list ap;
+
+	va_start(ap, fmt);
+	ast_log_ap(LOG_WARNING, fmt, ap);
+	va_end(ap);
 }
 
 static void __attribute__((format(printf, 1, 2))) jb_error_output(const char *fmt, ...)

--- a/channels/iax2/include/parser.h
+++ b/channels/iax2/include/parser.h
@@ -152,9 +152,10 @@ struct iax_ie_data {
 };
 
 /* Choose a different function for output */
-void iax_set_output(void (*output)(const char *data));
+void iax_set_output(void (*output)(const char *fmt, ...) __attribute__((format(printf, 1, 2))));
 /* Choose a different function for errors */
-void iax_set_error(void (*output)(const char *data));
+void iax_set_error(void (*output)(const char *fmt, ...) __attribute__((format(printf, 1, 2))));
+
 void iax_showframe(struct iax_frame *f, struct ast_iax2_full_hdr *fhi, int rx, struct ast_sockaddr *addr, int datalen);
 void iax_frame_subclass2str(enum iax_frame_subclass subclass, char *str, size_t len);
 


### PR DESCRIPTION
This replaces many instances of:

    snprintf(buffer, sizeof(buffer), "%s %s", x, y, ...);
    errorf(buffer);

With a cleaner:

    errorf("%s %s", x, y, ...);