### PR TITLE
res_calendar_icalendar: Print iCalendar error on parsing failure.

### DIFF
--- a/res/res_calendar_icalendar.c
+++ b/res/res_calendar_icalendar.c
@@ -155,6 +155,10 @@ static icalcomponent *fetch_icalendar(struct icalendar_pvt *pvt)
 
 	if (!ast_strlen_zero(ast_str_buffer(response))) {
 		comp = icalparser_parse_string(ast_str_buffer(response));
+		if (!comp) {
+			ast_debug(3, "iCalendar response data: %s\n", ast_str_buffer(response));
+			ast_log(LOG_WARNING, "Failed to parse iCalendar data: %s\n", icalerror_perror());
+		}
 	}
 	ast_free(response);
 


### PR DESCRIPTION
If libical fails to parse a calendar, print the error message it provdes.

Resolves: #492