### PR TITLE
res_pjsip_header_funcs: Duplicate new header value, don't copy.

### DIFF
--- a/res/res_pjsip_header_funcs.c
+++ b/res/res_pjsip_header_funcs.c
@@ -676,6 +676,7 @@ static int add_header(void *obj)
 static int update_header(void *obj)
 {
 	struct header_data *data = obj;
+	pj_pool_t *pool = data->channel->session->inv_session->dlg->pool;
 	pjsip_hdr *hdr = NULL;
 	RAII_VAR(struct ast_datastore *, datastore,
 			 ast_sip_session_get_datastore(data->channel->session, data->header_datastore->type),
@@ -694,7 +695,7 @@ static int update_header(void *obj)
 		return -1;
 	}
 
-	pj_strcpy2(&((pjsip_generic_string_hdr *) hdr)->hvalue, data->header_value);
+	pj_strdup2(pool, &((pjsip_generic_string_hdr *) hdr)->hvalue, data->header_value);
 
 	return 0;
 }


### PR DESCRIPTION
When updating an existing header the 'update' code incorrectly
just copied the new value into the existing buffer. If the
new value exceeded the available buffer size memory outside
of the buffer would be written into, potentially causing
a crash.

This change makes it so that the 'update' now duplicates
the new header value instead of copying it into the existing
buffer.
