### PR TITLE
res_pjsip: disable raw bad packet logging

### DIFF
--- a/configs/samples/pjproject.conf.sample
+++ b/configs/samples/pjproject.conf.sample
@@ -38,6 +38,10 @@
 ;  - 5: trace
 ;  - 6: more detailed trace
 ;
+; Note:  setting the pjproject debug level to 4 (debug) or above may result in
+; raw packets being logged. This should only be enabled during active debugging
+; to avoid a potential security issue due to logging injection.
+;
 ;asterisk_error =    ; A comma separated list of pjproject log levels to map to
                      ; Asterisk errors.
                      ; (default: "0,1")

--- a/res/res_pjproject.c
+++ b/res/res_pjproject.c
@@ -398,7 +398,9 @@ static char *handle_pjproject_set_log_level(struct ast_cli_entry *e, int cmd, st
 			"\n"
 			"       Set the maximum active pjproject logging level.\n"
 			"       See pjproject.conf.sample for additional information\n"
-			"       about the various levels pjproject uses.\n";
+			"       about the various levels pjproject uses.\n"
+			"       Note: setting this level at 4 or above may result in\n"
+			"       raw packet logging.\n";
 		return NULL;
 	case CLI_GENERATE:
 		return NULL;

--- a/third-party/pjproject/patches/0220-log-dropped-packet-in-debug.patch
+++ b/third-party/pjproject/patches/0220-log-dropped-packet-in-debug.patch
@@ -1,0 +1,28 @@
+diff --git a/pjsip/src/pjsip/sip_transport.c b/pjsip/src/pjsip/sip_transport.c
+index 4f483faa1..12439e3ee 100644
+--- a/pjsip/src/pjsip/sip_transport.c
++++ b/pjsip/src/pjsip/sip_transport.c
+@@ -2071,15 +2071,17 @@
+ 	     * which were sent to keep NAT bindings.
+ 	     */
+ 	    if (tmp.slen) {
+-		PJ_LOG(1, (THIS_FILE, 
+-		      "Error processing %d bytes packet from %s %s:%d %.*s:\n"
+-		      "%.*s\n"
+-		      "-- end of packet.",
++		PJ_LOG(2, (THIS_FILE,
++			  "Dropping %d bytes packet from %s %s:%d %.*s\n",
+ 		      msg_fragment_size,
+ 		      rdata->tp_info.transport->type_name,
+-		      rdata->pkt_info.src_name, 
++		      rdata->pkt_info.src_name,
+ 		      rdata->pkt_info.src_port,
+-		      (int)tmp.slen, tmp.ptr,
++		      (int)tmp.slen, tmp.ptr));
++		PJ_LOG(4, (THIS_FILE,
++		      "Dropped packet:"
++		      "%.*s\n"
++		      "-- end of packet.",
+ 		      (int)msg_fragment_size,
+ 		      rdata->msg_info.msg_buf));
+ 	    }


### PR DESCRIPTION
    Add patch to split the log level for invalid packets received on the signaling port.
    The warning regarding the packet will move to level 2 so that it can still be displayed,
    while the raw packet will be at level 4.
