### PR TITLE
doc: Remove obsolete CHANGES-staging directrory

### DIFF
--- a/doc/CHANGES-staging/app_directory_skip_call.txt
+++ b/doc/CHANGES-staging/app_directory_skip_call.txt
@@ -1,5 +1,0 @@
-Subject: app_directory
-
-A new option 's' has been added to the Directory() application that
-will skip calling the extension and instead set the extension as
-DIRECTORY_EXTEN channel variable.

--- a/doc/CHANGES-staging/app_read_return_terminator.txt
+++ b/doc/CHANGES-staging/app_read_return_terminator.txt
@@ -1,5 +1,0 @@
-Subject: app_read
-
-A new option 'e' has been added to allow Read() to return the
-terminator as the dialed digits in the case where only the terminator
-is entered.

--- a/doc/CHANGES-staging/app_senddtmf_answer.txt
+++ b/doc/CHANGES-staging/app_senddtmf_answer.txt
@@ -1,5 +1,0 @@
-Subject: app_senddtmf
-
-A new option has been added to SendDTMF() which will answer the
-specified channel if it is not already up. If no channel is specified,
-the current channel will be answered instead.


### PR DESCRIPTION
This should have been removed after the last release but
was missed.
