### PR TITLE
manager.c: Fix regression due to using wrong free function.

### DIFF
--- a/main/manager.c
+++ b/main/manager.c
@@ -3763,7 +3763,7 @@ static int restrictedFile(const char *filename)
 {
 	char *stripped_filename;
 	RAII_VAR(char *, path, NULL, ast_free);
-	RAII_VAR(char *, real_path, NULL, ast_free);
+	RAII_VAR(char *, real_path, NULL, ast_std_free);
 
 	if (live_dangerously) {
 		return 0;


### PR DESCRIPTION
Commit 424be345639d75c6cb7d0bd2da5f0f407dbd0bd5 introduced a regression by calling ast_free on memory allocated by realpath. This causes Asterisk to abort when executing this function. Since the memory is allocated by glibc, it should be freed using ast_std_free.

Resolves: #513