### PR TITLE
app_queue.c: use ast_time_t_to_string()

### DIFF
--- a/apps/app_queue.c
+++ b/apps/app_queue.c
@@ -4599,8 +4599,12 @@ static int is_longest_waiting_caller(struct queue_ent *caller, struct member *me
 					 * will be unused until the first caller is picked up.
 					 */
 					if (ch->start < caller->start && !ch->pending) {
-						ast_debug(1, "Queue %s has a call at position %i that's been waiting longer (%li vs %li)\n",
-								  q->name, ch->pos, ch->start, caller->start);
+						char time1[AST_TIME_T_LEN];
+						char time2[AST_TIME_T_LEN];
+						ast_time_t_to_string(ch->start, time1, sizeof(time1));
+						ast_time_t_to_string(caller->start, time2, sizeof(time2));
+						ast_debug(1, "Queue %s has a call at position %i that's been waiting longer (%s vs %s)\n",
+								  q->name, ch->pos, time1, time2);
 						is_longest_waiting = 0;
 						break;
 					}


### PR DESCRIPTION
@pprindeville Hi Philip,

Please check if this is using your function properly. The warnings go away, so looks fine to me.

Commit 292834d1ba2dbac0a413049a800f4ae82ca91f36 uses time_t directly, which may result in wrong timestamps:

```
In file included from ../include/asterisk/lock.h:63,
                 from app_queue.c:77:
app_queue.c: In function 'is_longest_waiting_caller': app_queue.c:4617:62: warning: format '%li' expects argument of type 'long int', but argument 8 has type 'time_t' {aka 'long long int'} [-Wformat=]
 4617 |                                                 ast_debug(1, "Queue %s has a call at position %i that's been waiting longer (%li vs %li)\n",+      |                                                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 4618 |                                                                   q->name, ch->pos, ch->start, caller->start);
      |                                                                                     ~~~~~~~~~
      |                                                                                       |
      |                                                                                       time_t {aka long long int}
```

Use ast_time_t_to_string() to diplay timestamps properly every time.