### PR TITLE
menuselect: Use more specific error message.

### DIFF
--- a/menuselect/menuselect.c
+++ b/menuselect/menuselect.c
@@ -1933,14 +1933,17 @@ static int sanity_check(void)
 				fprintf(stderr, "\n"
 					"***********************************************************\n"
 					"  The existing menuselect.makeopts file did not specify    \n"
-					"  that '%s' should not be included.  However, either some  \n"
-					"  dependencies for this module were not found or a         \n"
-					"  conflict exists.                                         \n"
+					"  that '%s' should not be included.  However,              \n"
+					"  %s%s\n"
+					"  %s.\n"
 					"                                                           \n"
 					"  Either run 'make menuselect' or remove the existing      \n"
 					"  menuselect.makeopts file to resolve this issue.          \n"
 					"***********************************************************\n"
-					"\n", mem->name);
+					"\n", mem->name,
+					mem->depsfailed ? "dependencies for this module were not found" : "",
+					mem->depsfailed && mem->conflictsfailed ? " and" : "",
+					mem->conflictsfailed ? "a conflict exists" : "");
 				insane = 1;
 			}
 		}


### PR DESCRIPTION
Instead of using the same error message for
missing dependencies and conflicts, be specific
about what actually went wrong.

Resolves: #520