### PR TITLE
res_pjsip_nat: Fix potential use of uninitialized transport details

### DIFF
--- a/res/res_pjsip.c
+++ b/res/res_pjsip.c
@@ -605,7 +605,7 @@ struct ast_sip_transport_state *ast_sip_find_transport_state_in_use(struct ast_s
 int ast_sip_rewrite_uri_to_local(pjsip_sip_uri *uri, pjsip_tx_data *tdata) {
 	RAII_VAR(struct ast_sip_transport *, transport, NULL, ao2_cleanup);
 	RAII_VAR(struct ast_sip_transport_state *, transport_state, NULL, ao2_cleanup);
-	struct ast_sip_request_transport_details details;
+	struct ast_sip_request_transport_details details = { 0, };
 	pjsip_sip_uri *tmp_uri;
 	pjsip_dialog *dlg;
 	struct ast_sockaddr addr = { { 0, } };

--- a/res/res_pjsip_nat.c
+++ b/res/res_pjsip_nat.c
@@ -319,8 +319,8 @@ static pj_status_t process_nat(pjsip_tx_data *tdata)
 {
 	RAII_VAR(struct ast_sip_transport *, transport, NULL, ao2_cleanup);
 	RAII_VAR(struct ast_sip_transport_state *, transport_state, NULL, ao2_cleanup);
+	struct ast_sip_request_transport_details details = { 0, };
 	pjsip_via_hdr *via = NULL;
-	struct ast_sip_request_transport_details details;
 	struct ast_sockaddr addr = { { 0, } };
 	pjsip_sip_uri *uri = NULL;
 	RAII_VAR(struct ao2_container *, hooks, NULL, ao2_cleanup);


### PR DESCRIPTION
The `ast_sip_request_transport_details` must be zero initialized, otherwise this could lead to a SEGV.

Resolves: #509