### PR TITLE
chan_rtp.c: MulticastRTP missing refcount without codec option

### DIFF
--- a/channels/chan_rtp.c
+++ b/channels/chan_rtp.c
@@ -129,7 +129,8 @@ static struct ast_format *derive_format_from_cap(struct ast_format_cap *cap)
 		 * assignments. Signed linear @ 8kHz does not map, so if that is our
 		 * only capability, we force μ-law instead.
 		 */
-		fmt = ast_format_ulaw;
+		ao2_ref(fmt, -1);
+		fmt = ao2_bump(ast_format_ulaw);
 	}
 
 	return fmt;


### PR DESCRIPTION
Fixes: #529
