### PR TITLE
master issue 536

### DIFF
--- a/channels/chan_rtp.c
+++ b/channels/chan_rtp.c
@@ -212,7 +212,7 @@ static struct ast_channel *multicast_rtp_request(const char *type, struct ast_fo
 	}
 
 	chan = ast_channel_alloc(1, AST_STATE_DOWN, "", "", "", "", "", assignedids,
-		requestor, 0, "MulticastRTP/%p", instance);
+		requestor, 0, "MulticastRTP/%s-%p", args.destination, instance);
 	if (!chan) {
 		ast_rtp_instance_destroy(instance);
 		goto failure;

--- a/channels/chan_rtp.c
+++ b/channels/chan_rtp.c
@@ -129,7 +129,8 @@ static struct ast_format *derive_format_from_cap(struct ast_format_cap *cap)
 		 * assignments. Signed linear @ 8kHz does not map, so if that is our
 		 * only capability, we force μ-law instead.
 		 */
-		fmt = ast_format_ulaw;
+		ao2_ref(fmt, -1);
+		fmt = ao2_bump(ast_format_ulaw);
 	}
 
 	return fmt;


### PR DESCRIPTION
- chan_rtp.c: MulticastRTP missing refcount without codec option
