### PR TITLE
chan_rtp.c: Change MulticastRTP nameing to avoid memory leak

### DIFF
--- a/channels/chan_rtp.c
+++ b/channels/chan_rtp.c
@@ -211,7 +211,7 @@ static struct ast_channel *multicast_rtp_request(const char *type, struct ast_fo
 	}
 
 	chan = ast_channel_alloc(1, AST_STATE_DOWN, "", "", "", "", "", assignedids,
-		requestor, 0, "MulticastRTP/%p", instance);
+		requestor, 0, "MulticastRTP/%s-%p", args.destination, instance);
 	if (!chan) {
 		ast_rtp_instance_destroy(instance);
 		goto failure;


### PR DESCRIPTION
Fixes: asterisk#536
