### PR TITLE
app_voicemail: add NoOp alembic script to maintain sync

### DIFF
--- a/contrib/ast-db-manage/voicemail/versions/1c55c341360f_macrocontext_NoOp.py
+++ b/contrib/ast-db-manage/voicemail/versions/1c55c341360f_macrocontext_NoOp.py
@@ -1,0 +1,20 @@
+"""Macrocontext NoOp for sync
+Revision ID: 1c55c341360f
+Revises: 39428242f7f5
+Create Date: 2024-01-09 15:01:39.698918
+"""
+
+# revision identifiers, used by Alembic.
+revision = '1c55c341360f'
+down_revision = '39428242f7f5'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
Adding a NoOp alembic script for the voicemail database to maintain
version sync with other branches.

Fixes: #527
