### PR TITLE
manager.c: Fix erroneous reloads in UpdateConfig.

### DIFF
--- a/main/manager.c
+++ b/main/manager.c
@@ -4329,9 +4329,10 @@ static int action_updateconfig(struct mansession *s, const struct message *m)
 		astman_send_ack(s, m, NULL);
 		if (!ast_strlen_zero(rld)) {
 			if (ast_true(rld)) {
-				rld = NULL;
+				ast_module_reload(NULL); /* Reload everything */
+			} else if (!ast_false(rld)) {
+				ast_module_reload(rld); /* Reload the specific module */
 			}
-			ast_module_reload(rld);
 		}
 	} else {
 		ast_config_destroy(cfg);


### PR DESCRIPTION
Currently, a reload will always occur if the
Reload header is provided for the UpdateConfig
action. However, we should not be doing a reload
if the header value has a falsy value, per the
documentation, so this makes the reload behavior
consistent with the existing documentation.

Resolves: #551