### PR TITLE
main/utils: Simplify the FreeBSD ast_get_tid() handling

### DIFF
--- a/configure
+++ b/configure
@@ -18454,20 +18454,6 @@ rm -f core conftest.err conftest.$ac_objext \
 #)
 #fi
 
-# for FreeBSD thr_self
-for ac_header in sys/thr.h
-do :
-  ac_fn_c_check_header_mongrel "$LINENO" "sys/thr.h" "ac_cv_header_sys_thr_h" "$ac_includes_default"
-if test "x$ac_cv_header_sys_thr_h" = xyes; then :
-  cat >>confdefs.h <<_ACEOF
-#define HAVE_SYS_THR_H 1
-_ACEOF
-
-fi
-
-done
-
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for compiler sync operations" >&5
 $as_echo_n "checking for compiler sync operations... " >&6; }
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext

--- a/configure.ac
+++ b/configure.ac
@@ -1172,9 +1172,6 @@ AC_LINK_IFELSE(
 #)
 #fi
 
-# for FreeBSD thr_self
-AC_CHECK_HEADERS([sys/thr.h])
-
 AC_MSG_CHECKING(for compiler sync operations)
 AC_LINK_IFELSE(
 [AC_LANG_PROGRAM([], [int foo1; int foo2 = __sync_fetch_and_add(&foo1, 1);])],

--- a/include/asterisk/autoconfig.h.in
+++ b/include/asterisk/autoconfig.h.in
@@ -1156,9 +1156,6 @@
 /* Define to 1 if you have the <sys/stat.h> header file. */
 #undef HAVE_SYS_STAT_H
 
-/* Define to 1 if you have the <sys/thr.h> header file. */
-#undef HAVE_SYS_THR_H
-
 /* Define to 1 if you have the <sys/time.h> header file. */
 #undef HAVE_SYS_TIME_H
 

--- a/main/utils.c
+++ b/main/utils.c
@@ -36,10 +36,10 @@
 #include <unistd.h>
 #if defined(__APPLE__)
 #include <mach/mach.h>
+#elif defined(__FreeBSD__)
+#include <sys/thr.h>
 #elif defined(__NetBSD__)
 #include <lwp.h>
-#elif defined(HAVE_SYS_THR_H)
-#include <sys/thr.h>
 #endif
 
 #include "asterisk/network.h"
@@ -2757,9 +2757,9 @@ int ast_get_tid(void)
 #elif defined(__APPLE__)
 	ret = mach_thread_self();
 	mach_port_deallocate(mach_task_self(), ret);
-#elif defined(__FreeBSD__) && defined(HAVE_SYS_THR_H)
+#elif defined(__FreeBSD__)
 	long lwpid;
-	thr_self(&lwpid); /* available since sys/thr.h creation 2003 */
+	thr_self(&lwpid);
 	ret = lwpid;
 #elif defined(__NetBSD__)
 	ret = _lwp_self();


### PR DESCRIPTION
FreeBSD has had kernel threads for 20+ years.