### PR TITLE
res_pjsip_session.c: Correctly format SDP connection addresses.

### DIFF
--- a/res/res_pjsip_session.c
+++ b/res/res_pjsip_session.c
@@ -5631,8 +5631,8 @@ static void session_outgoing_nat_hook(pjsip_tx_data *tdata, struct ast_sip_trans
 		 * rewriting. No localnet configured? Always rewrite. */
 		if (ast_sip_transport_is_local(transport_state, &our_sdp_addr) || !transport_state->localnet) {
 			ast_debug(5, "%s: Setting external media address to %s\n", ast_sip_session_get_name(session),
-				ast_sockaddr_stringify_host(&transport_state->external_media_address));
-			pj_strdup2(tdata->pool, &sdp->conn->addr, ast_sockaddr_stringify_host(&transport_state->external_media_address));
+				ast_sockaddr_stringify_addr_remote(&transport_state->external_media_address));
+			pj_strdup2(tdata->pool, &sdp->conn->addr, ast_sockaddr_stringify_addr_remote(&transport_state->external_media_address));
 			pj_strassign(&sdp->origin.addr, &sdp->conn->addr);
 		}
 	}

--- a/res/res_pjsip_t38.c
+++ b/res/res_pjsip_t38.c
@@ -1097,8 +1097,8 @@ static void change_outgoing_sdp_stream_media_address(pjsip_tx_data *tdata, struc
 	if (ast_sip_transport_is_nonlocal(transport_state, &our_sdp_addr) && transport_state->localnet) {
 		return;
 	}
-	ast_debug(5, "Setting media address to %s\n", ast_sockaddr_stringify_host(&transport_state->external_media_address));
-	pj_strdup2(tdata->pool, &stream->conn->addr, ast_sockaddr_stringify_host(&transport_state->external_media_address));
+	ast_debug(5, "Setting media address to %s\n", ast_sockaddr_stringify_addr_remote(&transport_state->external_media_address));
+	pj_strdup2(tdata->pool, &stream->conn->addr, ast_sockaddr_stringify_addr_remote(&transport_state->external_media_address));
 }
 
 /*! \brief Function which destroys the UDPTL instance when session ends */


### PR DESCRIPTION
Resolves a regression identified by @justinludwig involving the rendering of IPv6 addresses in outgoing SDP.

Also updates `media_address` on PJSIP endpoints so that if we are able to parse the configured value as an IP we store it in a format that we can directly use later. Based on my reading of the code it appeared that one could configure `media_address` as:

```
[foo]
type = endpoint
...
media_address = [2001:db8::]
```

And that value would be blindly copied into the outgoing SDP without regard to its format.

Fixes #541