### PR TITLE
res_pjsip_t38.c: Permit IPv6 SDP connection addresses.

### DIFF
--- a/res/res_pjsip_t38.c
+++ b/res/res_pjsip_t38.c
@@ -883,7 +883,7 @@ static int negotiate_incoming_sdp_stream(struct ast_sip_session *session,
 	ast_copy_pj_str(host, stream->conn ? &stream->conn->addr : &sdp->conn->addr, sizeof(host));
 
 	/* Ensure that the address provided is valid */
-	if (ast_sockaddr_resolve(&addrs, host, PARSE_PORT_FORBID, AST_AF_INET) <= 0) {
+	if (ast_sockaddr_resolve(&addrs, host, PARSE_PORT_FORBID, AST_AF_UNSPEC) <= 0) {
 		/* The provided host was actually invalid so we error out this negotiation */
 		ast_debug(3, "Declining; provided host is invalid\n");
 		return 0;


### PR DESCRIPTION
The existing code prevented IPv6 addresses from being properly parsed.

Fixes #558