### PR TITLE
utils: Make behavior of ast_strsep* match strsep.

### DIFF
--- a/include/asterisk/strings.h
+++ b/include/asterisk/strings.h
@@ -271,7 +271,7 @@ enum ast_strsep_flags {
   AST_STRSEP_UNESCAPE unescapes '\' sequences.
   AST_STRSEP_ALL does all of the above processing.
   \return The next token or NULL if done or if there are more than 8 levels of
-  nested quotes.
+  nested quotes. If provided an empty string, will return the empty string.
 
   This function acts like strsep with three exceptions...
   The separator is a single character instead of a string.
@@ -323,7 +323,7 @@ char *ast_strsep(char **s, const char sep, uint32_t flags);
   AST_STRSEP_UNESCAPE unescapes '\' sequences.
   AST_STRSEP_ALL does all of the above processing.
   \return The next token or NULL if done or if there are more than 8 levels of
-  nested quotes.
+  nested quotes. If provided an empty string, will return the empty string.
  */
 char *ast_strsep_quoted(char **s, const char sep, const char quote, uint32_t flags);
 

--- a/main/utils.c
+++ b/main/utils.c
@@ -1841,7 +1841,8 @@ char *ast_strsep(char **iss, const char sep, uint32_t flags)
 	char stack[8];
 
 	if (ast_strlen_zero(st)) {
-		return NULL;
+		*iss = NULL;
+		return st;
 	}
 
 	memset(stack, 0, sizeof(stack));
@@ -1905,7 +1906,8 @@ char *ast_strsep_quoted(char **iss, const char sep, const char quote, uint32_t f
 	const char qstr[] = { quote };
 
 	if (ast_strlen_zero(st)) {
-		return NULL;
+		*iss = NULL;
+		return st;
 	}
 
 	memset(stack, 0, sizeof(stack));


### PR DESCRIPTION
Given the scenario of passing an empty string to the ast_strsep functions the functions would return NULL instead of an empty string. This is counter to how strsep itself works.

This change alters the behavior of the functions to match that of strsep.

Fixes: #565