### PR TITLE
Partial speech results collection even when backend is not complete done.

### DIFF
--- a/apps/app_speech_utils.c
+++ b/apps/app_speech_utils.c
@@ -933,6 +933,11 @@ static int speech_background(struct ast_channel *chan, const char *data)
 		}
 	}
 
+	/* Copy to speech structure the results, even partial ones, if available */
+	if (speech->state == AST_SPEECH_STATE_READY) {
+		speech->results = ast_speech_results_get(speech);
+	}
+
 	if (!ast_strlen_zero(dtmf)) {
 		/* We sort of make a results entry */
 		speech->results = ast_calloc(1, sizeof(*speech->results));


### PR DESCRIPTION
Some speech backends might generate partial results before the final results. If Asterisk timeout happens before they are finalized, then this patch will at least return the partial results instead of empty strings.

Resolves: #572 