### PR TITLE
pseudo-MOS calculation formula change

### DIFF
--- a/res/res_rtp_asterisk.c
+++ b/res/res_rtp_asterisk.c
@@ -6240,7 +6240,7 @@ static double calc_media_experience_score(struct ast_rtp_instance *instance,
 	} else if (r_value > 100) {
 		pseudo_mos = 4.5;
 	} else {
-		pseudo_mos = 1 + (0.035 * r_value) + (r_value * (r_value - 60) * (100 - r_value) * 0.0000007);
+		pseudo_mos = 1 + (0.035 * r_value) + (r_value * (r_value - 60) * (100 - r_value) * 0.000007);
 	}
 
 	/*


### PR DESCRIPTION
res_rtp_asterisk.c: Correct coefficient in MOS calculation.

Media Experience Score relies on incorrect pseudo_mos variable
calculation. According to forming an opinion section of the
documentation, calculation relies on ITU-T G.107 standard:

    https://docs.asterisk.org/Deployment/Media-Experience-Score/#forming-an-opinion

ITU-T G.107 Annex B suggests to calculate MOS with a coefficient
"seven times ten to the power of negative six", 7 * 10^(-6). which
would mean 6 digits after the decimal point. Current implementation
has 7 digits after the decimal point, which downrates the calls.

Fixes: #597