### PR TITLE
Reduce startup/shutdown verbose logging

### DIFF
--- a/apps/app_amd.c
+++ b/apps/app_amd.c
@@ -567,7 +567,7 @@ static int load_config(int reload)
 
 	ast_config_destroy(cfg);
 
-	ast_verb(3, "AMD defaults: initialSilence [%d] greeting [%d] afterGreetingSilence [%d] "
+	ast_verb(5, "AMD defaults: initialSilence [%d] greeting [%d] afterGreetingSilence [%d] "
 		"totalAnalysisTime [%d] minimumWordLength [%d] betweenWordsSilence [%d] maximumNumberOfWords [%d] silenceThreshold [%d] maximumWordLength [%d]\n",
 		dfltInitialSilence, dfltGreeting, dfltAfterGreetingSilence, dfltTotalAnalysisTime,
 		dfltMinimumWordLength, dfltBetweenWordsSilence, dfltMaximumNumberOfWords, dfltSilenceThreshold, dfltMaximumWordLength);

--- a/codecs/codec_speex.c
+++ b/codecs/codec_speex.c
@@ -597,20 +597,20 @@ static int parse_config(int reload)
 		if (!strcasecmp(var->name, "quality")) {
 			res = abs(atoi(var->value));
 			if (res > -1 && res < 11) {
-				ast_verb(3, "CODEC SPEEX: Setting Quality to %d\n",res);
+				ast_verb(5, "CODEC SPEEX: Setting Quality to %d\n",res);
 				quality = res;
 			} else
 				ast_log(LOG_ERROR,"Error Quality must be 0-10\n");
 		} else if (!strcasecmp(var->name, "complexity")) {
 			res = abs(atoi(var->value));
 			if (res > -1 && res < 11) {
-				ast_verb(3, "CODEC SPEEX: Setting Complexity to %d\n",res);
+				ast_verb(5, "CODEC SPEEX: Setting Complexity to %d\n",res);
 				complexity = res;
 			} else
 				ast_log(LOG_ERROR,"Error! Complexity must be 0-10\n");
 		} else if (!strcasecmp(var->name, "vbr_quality")) {
 			if (sscanf(var->value, "%30f", &res_f) == 1 && res_f >= 0 && res_f <= 10) {
-				ast_verb(3, "CODEC SPEEX: Setting VBR Quality to %f\n",res_f);
+				ast_verb(5, "CODEC SPEEX: Setting VBR Quality to %f\n",res_f);
 				vbr_quality = res_f;
 			} else
 				ast_log(LOG_ERROR,"Error! VBR Quality must be 0-10\n");
@@ -618,62 +618,62 @@ static int parse_config(int reload)
 			ast_log(LOG_ERROR,"Error! ABR Quality setting obsolete, set ABR to desired bitrate\n");
 		} else if (!strcasecmp(var->name, "enhancement")) {
 			enhancement = ast_true(var->value) ? 1 : 0;
-			ast_verb(3, "CODEC SPEEX: Perceptual Enhancement Mode. [%s]\n",enhancement ? "on" : "off");
+			ast_verb(5, "CODEC SPEEX: Perceptual Enhancement Mode. [%s]\n",enhancement ? "on" : "off");
 		} else if (!strcasecmp(var->name, "vbr")) {
 			vbr = ast_true(var->value) ? 1 : 0;
-			ast_verb(3, "CODEC SPEEX: VBR Mode. [%s]\n",vbr ? "on" : "off");
+			ast_verb(5, "CODEC SPEEX: VBR Mode. [%s]\n",vbr ? "on" : "off");
 		} else if (!strcasecmp(var->name, "abr")) {
 			res = abs(atoi(var->value));
 			if (res >= 0) {
 					if (res > 0)
-					ast_verb(3, "CODEC SPEEX: Setting ABR target bitrate to %d\n",res);
+					ast_verb(5, "CODEC SPEEX: Setting ABR target bitrate to %d\n",res);
 					else
-					ast_verb(3, "CODEC SPEEX: Disabling ABR\n");
+					ast_verb(5, "CODEC SPEEX: Disabling ABR\n");
 				abr = res;
 			} else
 				ast_log(LOG_ERROR,"Error! ABR target bitrate must be >= 0\n");
 		} else if (!strcasecmp(var->name, "vad")) {
 			vad = ast_true(var->value) ? 1 : 0;
-			ast_verb(3, "CODEC SPEEX: VAD Mode. [%s]\n",vad ? "on" : "off");
+			ast_verb(5, "CODEC SPEEX: VAD Mode. [%s]\n",vad ? "on" : "off");
 		} else if (!strcasecmp(var->name, "dtx")) {
 			dtx = ast_true(var->value) ? 1 : 0;
-			ast_verb(3, "CODEC SPEEX: DTX Mode. [%s]\n",dtx ? "on" : "off");
+			ast_verb(5, "CODEC SPEEX: DTX Mode. [%s]\n",dtx ? "on" : "off");
 		} else if (!strcasecmp(var->name, "preprocess")) {
 			preproc = ast_true(var->value) ? 1 : 0;
-			ast_verb(3, "CODEC SPEEX: Preprocessing. [%s]\n",preproc ? "on" : "off");
+			ast_verb(5, "CODEC SPEEX: Preprocessing. [%s]\n",preproc ? "on" : "off");
 		} else if (!strcasecmp(var->name, "pp_vad")) {
 			pp_vad = ast_true(var->value) ? 1 : 0;
-			ast_verb(3, "CODEC SPEEX: Preprocessor VAD. [%s]\n",pp_vad ? "on" : "off");
+			ast_verb(5, "CODEC SPEEX: Preprocessor VAD. [%s]\n",pp_vad ? "on" : "off");
 		} else if (!strcasecmp(var->name, "pp_agc")) {
 			pp_agc = ast_true(var->value) ? 1 : 0;
-			ast_verb(3, "CODEC SPEEX: Preprocessor AGC. [%s]\n",pp_agc ? "on" : "off");
+			ast_verb(5, "CODEC SPEEX: Preprocessor AGC. [%s]\n",pp_agc ? "on" : "off");
 		} else if (!strcasecmp(var->name, "pp_agc_level")) {
 			if (sscanf(var->value, "%30f", &res_f) == 1 && res_f >= 0) {
-				ast_verb(3, "CODEC SPEEX: Setting preprocessor AGC Level to %f\n",res_f);
+				ast_verb(5, "CODEC SPEEX: Setting preprocessor AGC Level to %f\n",res_f);
 				pp_agc_level = res_f;
 			} else
 				ast_log(LOG_ERROR,"Error! Preprocessor AGC Level must be >= 0\n");
 		} else if (!strcasecmp(var->name, "pp_denoise")) {
 			pp_denoise = ast_true(var->value) ? 1 : 0;
-			ast_verb(3, "CODEC SPEEX: Preprocessor Denoise. [%s]\n",pp_denoise ? "on" : "off");
+			ast_verb(5, "CODEC SPEEX: Preprocessor Denoise. [%s]\n",pp_denoise ? "on" : "off");
 		} else if (!strcasecmp(var->name, "pp_dereverb")) {
 			pp_dereverb = ast_true(var->value) ? 1 : 0;
-			ast_verb(3, "CODEC SPEEX: Preprocessor Dereverb. [%s]\n",pp_dereverb ? "on" : "off");
+			ast_verb(5, "CODEC SPEEX: Preprocessor Dereverb. [%s]\n",pp_dereverb ? "on" : "off");
 		} else if (!strcasecmp(var->name, "pp_dereverb_decay")) {
 			if (sscanf(var->value, "%30f", &res_f) == 1 && res_f >= 0) {
-				ast_verb(3, "CODEC SPEEX: Setting preprocessor Dereverb Decay to %f\n",res_f);
+				ast_verb(5, "CODEC SPEEX: Setting preprocessor Dereverb Decay to %f\n",res_f);
 				pp_dereverb_decay = res_f;
 			} else
 				ast_log(LOG_ERROR,"Error! Preprocessor Dereverb Decay must be >= 0\n");
 		} else if (!strcasecmp(var->name, "pp_dereverb_level")) {
 			if (sscanf(var->value, "%30f", &res_f) == 1 && res_f >= 0) {
-				ast_verb(3, "CODEC SPEEX: Setting preprocessor Dereverb Level to %f\n",res_f);
+				ast_verb(5, "CODEC SPEEX: Setting preprocessor Dereverb Level to %f\n",res_f);
 				pp_dereverb_level = res_f;
 			} else
 				ast_log(LOG_ERROR,"Error! Preprocessor Dereverb Level must be >= 0\n");
 		} else if (!strcasecmp(var->name, "experimental_rtcp_feedback")) {
 			exp_rtcp_fb = ast_true(var->value) ? 1 : 0;
-			ast_verb(3, "CODEC SPEEX: Experimental RTCP Feedback. [%s]\n",exp_rtcp_fb ? "on" : "off");
+			ast_verb(5, "CODEC SPEEX: Experimental RTCP Feedback. [%s]\n",exp_rtcp_fb ? "on" : "off");
 		}
 	}
 	ast_config_destroy(cfg);

--- a/main/bridge.c
+++ b/main/bridge.c
@@ -255,7 +255,7 @@ int __ast_bridge_technology_register(struct ast_bridge_technology *technology, s
 
 	AST_RWLIST_UNLOCK(&bridge_technologies);
 
-	ast_verb(2, "Registered bridge technology %s\n", technology->name);
+	ast_verb(5, "Registered bridge technology %s\n", technology->name);
 
 	return 0;
 }
@@ -270,7 +270,7 @@ int ast_bridge_technology_unregister(struct ast_bridge_technology *technology)
 	AST_RWLIST_TRAVERSE_SAFE_BEGIN(&bridge_technologies, current, entry) {
 		if (current == technology) {
 			AST_RWLIST_REMOVE_CURRENT(entry);
-			ast_verb(2, "Unregistered bridge technology %s\n", technology->name);
+			ast_verb(5, "Unregistered bridge technology %s\n", technology->name);
 			break;
 		}
 	}

--- a/main/bucket.c
+++ b/main/bucket.c
@@ -305,7 +305,7 @@ int __ast_bucket_scheme_register(const char *name, struct ast_sorcery_wizard *bu
 
 	ao2_link_flags(schemes, scheme, OBJ_NOLOCK);
 
-	ast_verb(2, "Registered bucket scheme '%s'\n", name);
+	ast_verb(5, "Registered bucket scheme '%s'\n", name);
 
 	ast_module_shutdown_ref(module);
 

--- a/main/cdr.c
+++ b/main/cdr.c
@@ -3041,7 +3041,7 @@ static int ast_cdr_generic_unregister(struct be_list *generic_list, const char *
 	AST_RWLIST_REMOVE(generic_list, match, list);
 	AST_RWLIST_UNLOCK(generic_list);
 
-	ast_verb(2, "Unregistered '%s' CDR backend\n", name);
+	ast_verb(5, "Unregistered '%s' CDR backend\n", name);
 	ast_free(match);
 
 	return 0;

--- a/main/channel.c
+++ b/main/channel.c
@@ -557,9 +557,9 @@ int ast_channel_register(const struct ast_channel_tech *tech)
 	chan->tech = tech;
 	AST_RWLIST_INSERT_HEAD(&backends, chan, list);
 
-	ast_debug(1, "Registered handler for '%s' (%s)\n", chan->tech->type, chan->tech->description);
+	ast_debug(5, "Registered handler for '%s' (%s)\n", chan->tech->type, chan->tech->description);
 
-	ast_verb(2, "Registered channel type '%s' (%s)\n", chan->tech->type, chan->tech->description);
+	ast_verb(5, "Registered channel type '%s' (%s)\n", chan->tech->type, chan->tech->description);
 
 	AST_RWLIST_UNLOCK(&backends);
 
@@ -571,7 +571,7 @@ void ast_channel_unregister(const struct ast_channel_tech *tech)
 {
 	struct chanlist *chan;
 
-	ast_debug(1, "Unregistering channel type '%s'\n", tech->type);
+	ast_debug(5, "Unregistering channel type '%s'\n", tech->type);
 
 	AST_RWLIST_WRLOCK(&backends);
 
@@ -579,7 +579,7 @@ void ast_channel_unregister(const struct ast_channel_tech *tech)
 		if (chan->tech == tech) {
 			AST_LIST_REMOVE_CURRENT(list);
 			ast_free(chan);
-			ast_verb(2, "Unregistered channel type '%s'\n", tech->type);
+			ast_verb(5, "Unregistered channel type '%s'\n", tech->type);
 			break;
 		}
 	}

--- a/main/codec.c
+++ b/main/codec.c
@@ -316,7 +316,7 @@ int __ast_codec_register_with_format(struct ast_codec *codec, const char *format
 	/* Once registered a codec can not be unregistered, and the module must persist until shutdown */
 	ast_module_shutdown_ref(mod);
 
-	ast_verb(2, "Registered '%s' codec '%s' at sample rate '%u' with id '%u'\n",
+	ast_verb(5, "Registered '%s' codec '%s' at sample rate '%u' with id '%u'\n",
 		ast_codec_media_type2str(codec->type), codec->name, codec->sample_rate, codec_new->external.id);
 
 	ao2_ref(codec_new, -1);

--- a/main/config.c
+++ b/main/config.c
@@ -3068,7 +3068,7 @@ static int ast_realtime_append_mapping(const char *name, const char *driver, con
 	map->next = config_maps;
 	config_maps = map;
 
-	ast_verb(2, "Binding %s to %s/%s/%s\n", map->name, map->driver, map->database, map->table ? map->table : map->name);
+	ast_verb(5, "Binding %s to %s/%s/%s\n", map->name, map->driver, map->database, map->table ? map->table : map->name);
 
 	return 0;
 }

--- a/main/dns_core.c
+++ b/main/dns_core.c
@@ -672,7 +672,7 @@ int ast_dns_resolver_register(struct ast_dns_resolver *resolver)
 
 	AST_RWLIST_UNLOCK(&resolvers);
 
-	ast_verb(2, "Registered DNS resolver '%s' with priority '%d'\n", resolver->name, resolver->priority);
+	ast_verb(5, "Registered DNS resolver '%s' with priority '%d'\n", resolver->name, resolver->priority);
 
 	return 0;
 }
@@ -695,7 +695,7 @@ void ast_dns_resolver_unregister(struct ast_dns_resolver *resolver)
 	AST_RWLIST_TRAVERSE_SAFE_END;
 	AST_RWLIST_UNLOCK(&resolvers);
 
-	ast_verb(2, "Unregistered DNS resolver '%s'\n", resolver->name);
+	ast_verb(5, "Unregistered DNS resolver '%s'\n", resolver->name);
 }
 
 char *dns_find_record(const char *record, size_t record_size, const char *response, size_t response_size)

--- a/main/file.c
+++ b/main/file.c
@@ -153,7 +153,7 @@ int __ast_format_def_register(const struct ast_format_def *f, struct ast_module 
 
 	AST_RWLIST_INSERT_HEAD(&formats, tmp, list);
 	AST_RWLIST_UNLOCK(&formats);
-	ast_verb(2, "Registered file format %s, extension(s) %s\n", f->name, f->exts);
+	ast_verb(5, "Registered file format %s, extension(s) %s\n", f->name, f->exts);
 	publish_format_update(f, ast_format_register_type());
 
 	return 0;
@@ -177,7 +177,7 @@ int ast_format_def_unregister(const char *name)
 	AST_RWLIST_UNLOCK(&formats);
 
 	if (!res)
-		ast_verb(2, "Unregistered format %s\n", name);
+		ast_verb(5, "Unregistered format %s\n", name);
 	else
 		ast_log(LOG_WARNING, "Tried to unregister format %s, already unregistered\n", name);
 

--- a/main/format.c
+++ b/main/format.c
@@ -117,7 +117,7 @@ int __ast_format_interface_register(const char *codec, const struct ast_format_i
 	ao2_link_flags(interfaces, format_interface, OBJ_NOLOCK);
 	ao2_ref(format_interface, -1);
 
-	ast_verb(2, "Registered format interface for codec '%s'\n", codec);
+	ast_verb(5, "Registered format interface for codec '%s'\n", codec);
 
 	return 0;
 }

--- a/main/format_cache.c
+++ b/main/format_cache.c
@@ -490,7 +490,7 @@ int ast_format_cache_set(struct ast_format *format)
 
 	set_cached_format(ast_format_get_name(format), format);
 
-	ast_verb(2, "%s cached format with name '%s'\n",
+	ast_verb(5, "%s cached format with name '%s'\n",
 		old_format ? "Updated" : "Created",
 		ast_format_get_name(format));
 

--- a/main/image.c
+++ b/main/image.c
@@ -50,7 +50,7 @@ int ast_image_register(struct ast_imager *img)
 	AST_RWLIST_WRLOCK(&imagers);
 	AST_RWLIST_INSERT_HEAD(&imagers, img, list);
 	AST_RWLIST_UNLOCK(&imagers);
-	ast_verb(2, "Registered format '%s' (%s)\n", img->name, img->desc);
+	ast_verb(5, "Registered format '%s' (%s)\n", img->name, img->desc);
 	return 0;
 }
 
@@ -61,7 +61,7 @@ void ast_image_unregister(struct ast_imager *img)
 	AST_RWLIST_UNLOCK(&imagers);
 
 	if (img)
-		ast_verb(2, "Unregistered format '%s' (%s)\n", img->name, img->desc);
+		ast_verb(5, "Unregistered format '%s' (%s)\n", img->name, img->desc);
 }
 
 int ast_supports_images(struct ast_channel *chan)

--- a/main/indications.c
+++ b/main/indications.c
@@ -539,7 +539,7 @@ static int ast_register_indication_country(struct ast_tone_zone *zone)
 
 	ao2_link(ast_tone_zones, zone);
 
-	ast_verb(3, "Registered indication country '%s'\n", zone->country);
+	ast_verb(5, "Registered indication country '%s'\n", zone->country);
 
 	return 0;
 }

--- a/main/loader.c
+++ b/main/loader.c
@@ -1192,7 +1192,7 @@ int modules_shutdown(void)
 			}
 			AST_DLLIST_REMOVE_CURRENT(entry);
 			if (mod->flags.running && !mod->flags.declined && mod->info->unload) {
-				ast_verb(1, "Unloading %s\n", mod->resource);
+				ast_verb(4, "Unloading %s\n", mod->resource);
 				mod->info->unload();
 			}
 			module_destroy(mod);
@@ -1259,7 +1259,7 @@ int ast_unload_resource(const char *resource_name, enum ast_module_unload_mode f
 		/* Request any channels attached to the module to hangup. */
 		__ast_module_user_hangup_all(mod);
 
-		ast_verb(1, "Unloading %s\n", mod->resource);
+		ast_verb(4, "Unloading %s\n", mod->resource);
 		res = mod->info->unload();
 		if (res) {
 			ast_log(LOG_WARNING, "Firm unload failed for %s\n", resource_name);
@@ -1713,16 +1713,16 @@ static enum ast_module_load_result start_resource(struct ast_module *mod)
 	}
 
 	if (!ast_fully_booted) {
-		ast_verb(1, "Loading %s.\n", mod->resource);
+		ast_verb(4, "Loading %s.\n", mod->resource);
 	}
 	res = mod->info->load();
 
 	switch (res) {
 	case AST_MODULE_LOAD_SUCCESS:
 		if (!ast_fully_booted) {
-			ast_verb(2, "%s => (%s)\n", mod->resource, term_color(tmp, mod->info->description, COLOR_BROWN, COLOR_BLACK, sizeof(tmp)));
+			ast_verb(5, "%s => (%s)\n", mod->resource, term_color(tmp, mod->info->description, COLOR_BROWN, COLOR_BLACK, sizeof(tmp)));
 		} else {
-			ast_verb(1, "Loaded %s => (%s)\n", mod->resource, mod->info->description);
+			ast_verb(4, "Loaded %s => (%s)\n", mod->resource, mod->info->description);
 		}
 
 		mod->flags.running = 1;

--- a/main/manager.c
+++ b/main/manager.c
@@ -7955,7 +7955,7 @@ int ast_manager_unregister(const char *action)
 		ao2_unlock(cur);
 
 		ao2_t_ref(cur, -1, "action object removed from list");
-		ast_verb(2, "Manager unregistered action %s\n", action);
+		ast_verb(5, "Manager unregistered action %s\n", action);
 	}
 
 	return 0;
@@ -8030,7 +8030,7 @@ static int ast_manager_register_struct(struct manager_action *act)
 		AST_RWLIST_INSERT_HEAD(&actions, act, list);
 	}
 
-	ast_verb(2, "Manager registered action %s\n", act->action);
+	ast_verb(5, "Manager registered action %s\n", act->action);
 
 	AST_RWLIST_UNLOCK(&actions);
 

--- a/main/message.c
+++ b/main/message.c
@@ -1614,7 +1614,7 @@ int ast_msg_tech_register(const struct ast_msg_tech *tech)
 		ast_rwlock_unlock(&msg_techs_lock);
 		return -1;
 	}
-	ast_verb(3, "Message technology '%s' registered.\n", tech->name);
+	ast_verb(5, "Message technology '%s' registered.\n", tech->name);
 
 	ast_rwlock_unlock(&msg_techs_lock);
 
@@ -1649,7 +1649,7 @@ int ast_msg_tech_unregister(const struct ast_msg_tech *tech)
 		return -1;
 	}
 
-	ast_verb(2, "Message technology '%s' unregistered.\n", tech->name);
+	ast_verb(5, "Message technology '%s' unregistered.\n", tech->name);
 
 	return 0;
 }
@@ -1674,7 +1674,7 @@ int ast_msg_handler_register(const struct ast_msg_handler *handler)
 		ast_rwlock_unlock(&msg_handlers_lock);
 		return -1;
 	}
-	ast_verb(2, "Message handler '%s' registered.\n", handler->name);
+	ast_verb(5, "Message handler '%s' registered.\n", handler->name);
 
 	ast_rwlock_unlock(&msg_handlers_lock);
 
@@ -1710,7 +1710,7 @@ int ast_msg_handler_unregister(const struct ast_msg_handler *handler)
 		return -1;
 	}
 
-	ast_verb(3, "Message handler '%s' unregistered.\n", handler->name);
+	ast_verb(5, "Message handler '%s' unregistered.\n", handler->name);
 	return 0;
 }
 

--- a/main/pbx.c
+++ b/main/pbx.c
@@ -5067,7 +5067,7 @@ int ast_context_remove_extension_callerid2(struct ast_context *con, const char *
 					}
 				}
 			} else {
-				ast_log(LOG_ERROR,"Could not find priority %d of exten %s in context %s!\n",
+				ast_debug(3,"Could not find priority %d of exten %s in context %s!\n",
 						priority, exten->name, con->name);
 			}
 		}
@@ -6640,20 +6640,20 @@ void ast_merge_contexts_and_delete(struct ast_context **extcontexts, struct ast_
 
 	ft = ast_tvdiff_us(writelocktime, begintime);
 	ft /= 1000000.0;
-	ast_verb(3,"Time to scan old dialplan and merge leftovers back into the new: %8.6f sec\n", ft);
+	ast_verb(5,"Time to scan old dialplan and merge leftovers back into the new: %8.6f sec\n", ft);
 
 	ft = ast_tvdiff_us(endlocktime, writelocktime);
 	ft /= 1000000.0;
-	ast_verb(3,"Time to restore hints and swap in new dialplan: %8.6f sec\n", ft);
+	ast_verb(5,"Time to restore hints and swap in new dialplan: %8.6f sec\n", ft);
 
 	ft = ast_tvdiff_us(enddeltime, endlocktime);
 	ft /= 1000000.0;
-	ast_verb(3,"Time to delete the old dialplan: %8.6f sec\n", ft);
+	ast_verb(5,"Time to delete the old dialplan: %8.6f sec\n", ft);
 
 	ft = ast_tvdiff_us(enddeltime, begintime);
 	ft /= 1000000.0;
-	ast_verb(3,"Total time merge_contexts_delete: %8.6f sec\n", ft);
-	ast_verb(3, "%s successfully loaded %d contexts (enable debug for details).\n", registrar, ctx_count);
+	ast_verb(5,"Total time merge_contexts_delete: %8.6f sec\n", ft);
+	ast_verb(5, "%s successfully loaded %d contexts (enable debug for details).\n", registrar, ctx_count);
 }
 
 /*
@@ -8133,7 +8133,7 @@ void __ast_context_destroy(struct ast_context *list, struct ast_hashtab *context
 						if (!prio_item->registrar || strcmp(prio_item->registrar, registrar) != 0) {
 							continue;
 						}
-						ast_verb(3, "Remove %s/%s/%d, registrar=%s; con=%s(%p); con->root=%p\n",
+						ast_verb(5, "Remove %s/%s/%d, registrar=%s; con=%s(%p); con->root=%p\n",
 								 tmp->name, prio_item->name, prio_item->priority, registrar, con? con->name : "<nil>", con, con? con->root_table: NULL);
 						ast_copy_string(extension, prio_item->exten, sizeof(extension));
 						if (prio_item->cidmatch) {
@@ -8427,7 +8427,7 @@ int load_pbx(void)
 	/* Initialize the PBX */
 	ast_verb(1, "Asterisk PBX Core Initializing\n");
 
-	ast_verb(2, "Registering builtin functions:\n");
+	ast_verb(5, "Registering builtin functions:\n");
 	ast_cli_register_multiple(pbx_cli, ARRAY_LEN(pbx_cli));
 	__ast_custom_function_register(&exception_function, NULL);
 	__ast_custom_function_register(&testtime_function, NULL);

--- a/main/pbx_app.c
+++ b/main/pbx_app.c
@@ -182,7 +182,7 @@ int ast_register_application2(const char *app, int (*execute)(struct ast_channel
 	if (!cur)
 		AST_RWLIST_INSERT_TAIL(&apps, tmp, list);
 
-	ast_verb(2, "Registered application '" COLORIZE_FMT "'\n", COLORIZE(COLOR_BRCYAN, 0, tmp->name));
+	ast_verb(5, "Registered application '" COLORIZE_FMT "'\n", COLORIZE(COLOR_BRCYAN, 0, tmp->name));
 
 	AST_RWLIST_UNLOCK(&apps);
 
@@ -409,7 +409,7 @@ int ast_unregister_application(const char *app)
 			/* Found it. */
 			unreference_cached_app(cur);
 			AST_RWLIST_REMOVE_CURRENT(list);
-			ast_verb(2, "Unregistered application '%s'\n", cur->name);
+			ast_verb(5, "Unregistered application '%s'\n", cur->name);
 			ast_string_field_free_memory(cur);
 			ast_free(cur);
 			break;

--- a/main/pbx_functions.c
+++ b/main/pbx_functions.c
@@ -286,7 +286,7 @@ int ast_custom_function_unregister(struct ast_custom_function *acf)
 			ast_string_field_free_memory(acf);
 		}
 #endif
-		ast_verb(2, "Unregistered custom function %s\n", cur->name);
+		ast_verb(5, "Unregistered custom function %s\n", cur->name);
 	}
 	AST_RWLIST_UNLOCK(&acf_root);
 
@@ -410,7 +410,7 @@ int __ast_custom_function_register(struct ast_custom_function *acf, struct ast_m
 
 	AST_RWLIST_UNLOCK(&acf_root);
 
-	ast_verb(2, "Registered custom function '" COLORIZE_FMT "'\n", COLORIZE(COLOR_BRCYAN, 0, acf->name));
+	ast_verb(5, "Registered custom function '" COLORIZE_FMT "'\n", COLORIZE(COLOR_BRCYAN, 0, acf->name));
 
 	return 0;
 }

--- a/main/refer.c
+++ b/main/refer.c
@@ -463,7 +463,7 @@ int ast_refer_tech_register(const struct ast_refer_tech *tech)
 		ast_rwlock_unlock(&refer_techs_lock);
 		return -1;
 	}
-	ast_verb(3, "Refer technology '%s' registered.\n", tech->name);
+	ast_verb(5, "Refer technology '%s' registered.\n", tech->name);
 
 	ast_rwlock_unlock(&refer_techs_lock);
 
@@ -501,7 +501,7 @@ int ast_refer_tech_unregister(const struct ast_refer_tech *tech)
 		return -1;
 	}
 
-	ast_verb(2, "Refer technology '%s' unregistered.\n", tech->name);
+	ast_verb(5, "Refer technology '%s' unregistered.\n", tech->name);
 
 	return 0;
 }

--- a/main/rtp_engine.c
+++ b/main/rtp_engine.c
@@ -355,7 +355,7 @@ int ast_rtp_engine_register2(struct ast_rtp_engine *engine, struct ast_module *m
 
 	AST_RWLIST_UNLOCK(&engines);
 
-	ast_verb(2, "Registered RTP engine '%s'\n", engine->name);
+	ast_verb(5, "Registered RTP engine '%s'\n", engine->name);
 
 	return 0;
 }
@@ -367,7 +367,7 @@ int ast_rtp_engine_unregister(struct ast_rtp_engine *engine)
 	AST_RWLIST_WRLOCK(&engines);
 
 	if ((current_engine = AST_RWLIST_REMOVE(&engines, engine, entry))) {
-		ast_verb(2, "Unregistered RTP engine '%s'\n", engine->name);
+		ast_verb(5, "Unregistered RTP engine '%s'\n", engine->name);
 	}
 
 	AST_RWLIST_UNLOCK(&engines);
@@ -399,7 +399,7 @@ int ast_rtp_glue_register2(struct ast_rtp_glue *glue, struct ast_module *module)
 
 	AST_RWLIST_UNLOCK(&glues);
 
-	ast_verb(2, "Registered RTP glue '%s'\n", glue->type);
+	ast_verb(5, "Registered RTP glue '%s'\n", glue->type);
 
 	return 0;
 }
@@ -411,7 +411,7 @@ int ast_rtp_glue_unregister(struct ast_rtp_glue *glue)
 	AST_RWLIST_WRLOCK(&glues);
 
 	if ((current_glue = AST_RWLIST_REMOVE(&glues, glue, entry))) {
-		ast_verb(2, "Unregistered RTP glue '%s'\n", glue->type);
+		ast_verb(5, "Unregistered RTP glue '%s'\n", glue->type);
 	}
 
 	AST_RWLIST_UNLOCK(&glues);

--- a/main/sorcery.c
+++ b/main/sorcery.c
@@ -459,7 +459,7 @@ int __ast_sorcery_wizard_register(const struct ast_sorcery_wizard *interface, st
 	ao2_link_flags(wizards, wizard, OBJ_NOLOCK);
 	res = 0;
 
-	ast_verb(2, "Sorcery registered wizard '%s'\n", interface->name);
+	ast_verb(5, "Sorcery registered wizard '%s'\n", interface->name);
 
 	NOTIFY_GLOBAL_OBSERVERS(observers, wizard_registered,
 		interface->name, interface);
@@ -480,7 +480,7 @@ int ast_sorcery_wizard_unregister(const struct ast_sorcery_wizard *interface)
 		NOTIFY_GLOBAL_OBSERVERS(observers, wizard_unregistering, wizard->callbacks.name, &wizard->callbacks);
 		ao2_unlink(wizards, wizard);
 		ao2_ref(wizard, -1);
-		ast_verb(2, "Sorcery unregistered wizard '%s'\n", interface->name);
+		ast_verb(5, "Sorcery unregistered wizard '%s'\n", interface->name);
 		return 0;
 	} else {
 		return -1;

--- a/main/translate.c
+++ b/main/translate.c
@@ -1297,7 +1297,7 @@ int __ast_register_translator(struct ast_translator *t, struct ast_module *mod)
 
 	generate_computational_cost(t, 1);
 
-	ast_verb(2, "Registered translator '%s' from codec %s to %s, table cost, %d, computational cost %d\n",
+	ast_verb(5, "Registered translator '%s' from codec %s to %s, table cost, %d, computational cost %d\n",
 		 term_color(tmp, t->name, COLOR_MAGENTA, COLOR_BLACK, sizeof(tmp)),
 		 t->src_codec.name, t->dst_codec.name, t->table_cost, t->comp_cost);
 
@@ -1340,7 +1340,7 @@ int ast_unregister_translator(struct ast_translator *t)
 	AST_RWLIST_TRAVERSE_SAFE_BEGIN(&translators, u, list) {
 		if (u == t) {
 			AST_RWLIST_REMOVE_CURRENT(list);
-			ast_verb(2, "Unregistered translator '%s' from codec %s to %s\n",
+			ast_verb(5, "Unregistered translator '%s' from codec %s to %s\n",
 				term_color(tmp, t->name, COLOR_MAGENTA, COLOR_BLACK, sizeof(tmp)),
 				t->src_codec.name, t->dst_codec.name);
 			found = 1;

--- a/res/res_agi.c
+++ b/res/res_agi.c
@@ -3848,7 +3848,7 @@ int AST_OPTIONAL_API_NAME(ast_agi_register)(struct ast_module *mod, agi_command 
 		AST_RWLIST_WRLOCK(&agi_commands);
 		AST_LIST_INSERT_TAIL(&agi_commands, cmd, list);
 		AST_RWLIST_UNLOCK(&agi_commands);
-		ast_verb(2, "AGI Command '%s' registered\n",fullcmd);
+		ast_verb(5, "AGI Command '%s' registered\n",fullcmd);
 		return 1;
 	} else {
 		ast_log(LOG_WARNING, "Command already registered!\n");
@@ -3887,7 +3887,7 @@ int AST_OPTIONAL_API_NAME(ast_agi_unregister)(agi_command *cmd)
 	AST_RWLIST_TRAVERSE_SAFE_END;
 	AST_RWLIST_UNLOCK(&agi_commands);
 	if (unregistered) {
-		ast_verb(2, "AGI Command '%s' unregistered\n",fullcmd);
+		ast_verb(5, "AGI Command '%s' unregistered\n",fullcmd);
 	}
 	return unregistered;
 }

--- a/res/res_audiosocket.c
+++ b/res/res_audiosocket.c
@@ -326,13 +326,13 @@ struct ast_frame *ast_audiosocket_receive_frame(const int svc)
 
 static int load_module(void)
 {
-	ast_verb(1, "Loading AudioSocket Support module\n");
+	ast_verb(5, "Loading AudioSocket Support module\n");
 	return AST_MODULE_LOAD_SUCCESS;
 }
 
 static int unload_module(void)
 {
-	ast_verb(1, "Unloading AudioSocket Support module\n");
+	ast_verb(5, "Unloading AudioSocket Support module\n");
 	return AST_MODULE_LOAD_SUCCESS;
 }
 

--- a/res/res_clialiases.c
+++ b/res/res_clialiases.c
@@ -236,7 +236,7 @@ static void load_config(int reload)
 				continue;
 			}
 			ao2_link(cli_aliases, alias);
-			ast_verb(2, "Aliased CLI command '%s' to '%s'\n", v1->name, v1->value);
+			ast_verb(5, "Aliased CLI command '%s' to '%s'\n", v1->name, v1->value);
 			ao2_ref(alias, -1);
 		}
 	}

--- a/res/res_http_websocket.c
+++ b/res/res_http_websocket.c
@@ -257,7 +257,7 @@ int AST_OPTIONAL_API_NAME(ast_websocket_server_add_protocol2)(struct ast_websock
 	ao2_link_flags(server->protocols, protocol, OBJ_NOLOCK);
 	ao2_unlock(server->protocols);
 
-	ast_verb(2, "WebSocket registered sub-protocol '%s'\n", protocol->name);
+	ast_verb(5, "WebSocket registered sub-protocol '%s'\n", protocol->name);
 	ao2_ref(protocol, -1);
 
 	return 0;
@@ -279,7 +279,7 @@ int AST_OPTIONAL_API_NAME(ast_websocket_server_remove_protocol)(struct ast_webso
 	ao2_unlink(server->protocols, protocol);
 	ao2_ref(protocol, -1);
 
-	ast_verb(2, "WebSocket unregistered sub-protocol '%s'\n", name);
+	ast_verb(5, "WebSocket unregistered sub-protocol '%s'\n", name);
 
 	return 0;
 }

--- a/res/res_speech.c
+++ b/res/res_speech.c
@@ -329,14 +329,14 @@ int ast_speech_register(struct ast_speech_engine *engine)
 		return -1;
 	}
 
-	ast_verb(2, "Registered speech recognition engine '%s'\n", engine->name);
+	ast_verb(5, "Registered speech recognition engine '%s'\n", engine->name);
 
 	/* Add to the engine linked list and make default if needed */
 	AST_RWLIST_WRLOCK(&engines);
 	AST_RWLIST_INSERT_HEAD(&engines, engine, list);
 	if (!default_engine) {
 		default_engine = engine;
-		ast_verb(2, "Made '%s' the default speech recognition engine\n", engine->name);
+		ast_verb(5, "Made '%s' the default speech recognition engine\n", engine->name);
 	}
 	AST_RWLIST_UNLOCK(&engines);
 
@@ -366,7 +366,7 @@ struct ast_speech_engine *ast_speech_unregister2(const char *engine_name)
 			if (engine == default_engine) {
 				default_engine = AST_RWLIST_FIRST(&engines);
 			}
-			ast_verb(2, "Unregistered speech recognition engine '%s'\n", engine_name);
+			ast_verb(5, "Unregistered speech recognition engine '%s'\n", engine_name);
 			/* All went well */
 			break;
 		}
@@ -396,7 +396,7 @@ void ast_speech_unregister_engines(
 			if (engine == default_engine) {
 				default_engine = AST_RWLIST_FIRST(&engines);
 			}
-			ast_verb(2, "Unregistered speech recognition engine '%s'\n", engine->name);
+			ast_verb(5, "Unregistered speech recognition engine '%s'\n", engine->name);
 			/* All went well */
 			if (on_unregistered) {
 				on_unregistered(engine);


### PR DESCRIPTION
When started with a verbose level of 3, asterisk can emit over 1500
verbose message that serve no real purpose other than to fill up
logs. When asterisk shuts down, it emits another 1100 that are of
even less use. Since the testsuite runs asterisk with a verbose
level of 3, and asterisk starts and stops for every one of the 700+
tests, the number of log messages is staggering.  Besides taking up
resources, it also makes it hard to debug failing tests.

This commit changes the log level for those verbose messages to 5
instead of 3 which reduces the number of log messages to only a
handful. Of course, NOTICE, WARNING and ERROR message are
unaffected.

There's also one other minor change...
ast_context_remove_extension_callerid2() logs a DEBUG message
instead of an ERROR if the extension you're deleting doesn't exist.
The pjsip_config_wizard calls that function to clean up the config
and has been triggering that annoying error message for years.

Resolves: #582
