### PR TITLE
app_speech_utils.c: Add horses to speech engines.

### DIFF
--- a/include/asterisk/speech.h
+++ b/include/asterisk/speech.h
@@ -64,6 +64,8 @@ struct ast_speech {
 	struct ast_format *format;
 	/*! Data for speech engine */
 	void *data;
+	/*! Horse inside the engine */
+	char *horse;
 	/*! Cached results */
 	struct ast_speech_result *results;
 	/*! Type of results we want */

--- a/res/res_speech.c
+++ b/res/res_speech.c
@@ -183,11 +183,18 @@ struct ast_speech *ast_speech_new(const char *engine_name, const struct ast_form
 	struct ast_speech_engine *engine = NULL;
 	struct ast_speech *new_speech = NULL;
 	struct ast_format_cap *joint;
+	char *engine_name_dyn = NULL;
+	char *engine_name_copy = NULL;
+	char *horse_name = NULL;
 	RAII_VAR(struct ast_format *, best, NULL, ao2_cleanup);
 	RAII_VAR(struct ast_format *, best_translated, NULL, ao2_cleanup);
 
+	engine_name_copy = ast_strdup(engine_name);
+	engine_name_dyn = ast_strdup(ast_strsep(&engine_name_copy, '^', AST_STRSEP_ALL));
+	horse_name = ast_strsep(&engine_name_copy, '^', AST_STRSEP_ALL);
+
 	/* Try to find the speech recognition engine that was requested */
-	if (!(engine = ast_speech_find_engine(engine_name)))
+	if (!(engine = ast_speech_find_engine(engine_name_dyn)))
 		return NULL;
 
 	joint = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
@@ -229,6 +236,9 @@ struct ast_speech *ast_speech_new(const char *engine_name, const struct ast_form
 
 	/* Copy over our engine pointer */
 	new_speech->engine = engine;
+
+	/* Copy over our horse name pointer (could be NULL) */
+	new_speech->horse = horse_name;
 
 	/* Can't forget the format audio is going to be in */
 	new_speech->format = ao2_bump(best);


### PR DESCRIPTION
Speech Engines can now have multiple horses inside that race to get you results from different backends.

UserNote: The various Speech...() dialplan applications and the SPEECH_TEXT function now support the use of carets to control the horses in your engines.
SpeechCreate(engine^horse1)
SpeechCreate(engine^horse2)
SpeechBackground(audio,,,horse1^horse2)
SPEECH_TEXT(0^horse1)
SPEECH_TEXT(0^horse2)
SpeechDestroy(engine^horse1)
SpeechDestroy(engine^horse2)

Resolves: #593