### PR TITLE
res_pjsip_endpoint_identifier_ip: Endpoint identifier request URI

### DIFF
--- a/configs/samples/pjsip.conf.sample
+++ b/configs/samples/pjsip.conf.sample
@@ -686,6 +686,7 @@
                         ; "auth_username": Identify by the Authorization username and realm
                         ; "ip": Identify by the source IP address
                         ; "header": Identify by a configured SIP header value.
+                        ; "request_uri": Identify by the configured SIP request URI.
                         ; In the username and auth_username cases, if an exact match
                         ; on both username and domain/realm fails, the match is
                         ; retried with just the username.

--- a/contrib/ast-db-manage/config/versions/cf150a175fd3_add_match_request_uri_attribute_to_.py
+++ b/contrib/ast-db-manage/config/versions/cf150a175fd3_add_match_request_uri_attribute_to_.py
@@ -1,0 +1,20 @@
+"""add match_request_uri attribute to identify
+
+Revision ID: cf150a175fd3
+Revises: 8fce8496f03e
+Create Date: 2024-03-28 14:19:15.033869
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'cf150a175fd3'
+down_revision = '8fce8496f03e'
+
+from alembic import op
+import sqlalchemy as sa
+
+def upgrade():
+    op.add_column('ps_endpoint_id_ips', sa.Column('match_request_uri', sa.String(255)))
+
+def downgrade():
+    op.drop_column('ps_endpoint_id_ips', 'match_request_uri')

--- a/include/asterisk/res_pjsip.h
+++ b/include/asterisk/res_pjsip.h
@@ -615,6 +615,8 @@ enum ast_sip_endpoint_identifier_type {
 	AST_SIP_ENDPOINT_IDENTIFY_BY_IP = (1 << 2),
 	/*! Identify based on arbitrary headers */
 	AST_SIP_ENDPOINT_IDENTIFY_BY_HEADER = (1 << 3),
+	/*! Identify based on request uri */
+	AST_SIP_ENDPOINT_IDENTIFY_BY_REQUEST_URI = (1 << 4),
 };
 AST_VECTOR(ast_sip_identify_by_vector, enum ast_sip_endpoint_identifier_type);
 

--- a/res/res_pjsip/pjsip_config.xml
+++ b/res/res_pjsip/pjsip_config.xml
@@ -557,6 +557,14 @@
 								endpoint identification.
 								</para>
 							</enum>
+							<enum name="request_uri">
+								<para>Matches the endpoint based on the configured SIP
+								request uri.
+								</para>
+								<para>This method of identification is not configured here
+								but simply allowed by this configuration option.
+								</para>
+							</enum>
 						</enumlist>
 					</description>
 				</configOption>

--- a/res/res_pjsip/pjsip_configuration.c
+++ b/res/res_pjsip/pjsip_configuration.c
@@ -423,6 +423,9 @@ static const char *sip_endpoint_identifier_type2str(enum ast_sip_endpoint_identi
 	case AST_SIP_ENDPOINT_IDENTIFY_BY_HEADER:
 		str = "header";
 		break;
+	case AST_SIP_ENDPOINT_IDENTIFY_BY_REQUEST_URI:
+		str = "request_uri";
+		break;
 	}
 	return str;
 }
@@ -448,6 +451,8 @@ static int sip_endpoint_identifier_str2type(const char *str)
 		method = AST_SIP_ENDPOINT_IDENTIFY_BY_IP;
 	} else if (!strcasecmp(str, "header")) {
 		method = AST_SIP_ENDPOINT_IDENTIFY_BY_HEADER;
+	} else if (!strcasecmp(str, "request_uri")) {
+		method = AST_SIP_ENDPOINT_IDENTIFY_BY_REQUEST_URI;
 	} else {
 		method = -1;
 	}


### PR DESCRIPTION
Add ability to match against PJSIP request URI.
Use the 'request_uri' identifier in the identify_by field.

Fixes: #599