### PR TITLE
res_pjsip_endpoint_identifier_ip: Add endpoint identifier transport address

### DIFF
--- a/configs/samples/pjsip.conf.sample
+++ b/configs/samples/pjsip.conf.sample
@@ -197,6 +197,47 @@
 ;tcp_keepalive_interval_time=10  ; The time in seconds between individual keepalive probes
 ;tcp_keepalive_probe_count=5     ; The maximum number of keepalive probes TCP should send before dropping the connection
 
+;===============ENDPOINT IDENTIFIER TRANSPORT EXAMPLE==========================
+;
+; When Asterisk has multiple bound IP addresses, and endpoints don't use any
+; other means of identification (e.g.: username), the transports' bind addresses
+; can be used to identify them. Can be useful in case you're connecting to the
+; same ITSP multiple times on different IPs / NICs.
+;
+;[transport-eth0]
+;type=transport
+;protocol=tcp
+;bind=192.168.1.1:5060
+;
+;[transport-eth1]
+;type=transport
+;protocol=udp
+;bind=192.168.2.1:5060
+;
+;
+;[myprovider-a]
+;type=endpoint
+;transport=transport-eth0
+;identify_by=transport
+;
+;[myprovider-b]
+;type=endpoint
+;transport=transport-eth1
+;identify_by=transport
+;
+;
+;[identify-a]
+;type=identify
+;endpoint=myprovider-a
+;match=192.168.1.1:5060	; This is the bind address of [transport-eth0]
+;;transport=tcp		; Optionally, this is the transport protocol of [transport-eth0]
+;
+;[identify-b]
+;type=identify
+;endpoint=myprovider-b
+;match=192.168.2.1:5060	; This is the bind address of [transport-eth1]
+;;transport=udp		; Optionally, This is the transport protocol of [transport-eth1]
+
 ;===============OUTBOUND REGISTRATION WITH OUTBOUND AUTHENTICATION============
 ;
 ; This is a simple registration that works with some SIP trunking providers.
@@ -684,9 +725,10 @@
                         ; identified.
                         ; "username": Identify by the From or To username and domain
                         ; "auth_username": Identify by the Authorization username and realm
-                        ; "ip": Identify by the source IP address
+                        ; "ip": Identify by the source (remote) IP address
                         ; "header": Identify by a configured SIP header value.
                         ; "request_uri": Identify by the configured SIP request URI.
+                        ; "transport": Identify by the bound (local) IP address
                         ; In the username and auth_username cases, if an exact match
                         ; on both username and domain/realm fails, the match is
                         ; retried with just the username.
@@ -1271,9 +1313,10 @@
             ; (default: "no")
 ;endpoint_identifier_order=ip,username,anonymous
             ; The order by which endpoint identifiers are given priority.
-            ; Currently, "ip", "header", "username", "auth_username" and "anonymous"
-            ; are valid identifiers as registered by the res_pjsip_endpoint_identifier_*
-            ; modules.  Some modules like res_pjsip_endpoint_identifier_user register
+            ; Currently, "ip", "header", "request_uri", "transport", "username",
+            ; "auth_username" and "anonymous"  are valid identifiers as registered by
+            ; the res_pjsip_endpoint_identifier_* modules.
+            ; Some modules like res_pjsip_endpoint_identifier_user register
             ; more than one identifier.  Use the CLI command "pjsip show identifiers"
             ; to see the identifiers currently available.
             ; (default: ip,username,anonymous)
@@ -1461,6 +1504,8 @@
 ;match= ; Comma separated list of IP addresses, networks, or hostnames to match
         ; against (default: "")
 ;match_header= ; SIP header with specified value to match against (default: "")
+;match_request_uri= ; SIP request URI to match against (default: "")
+;transport= ; Match ageinst the transport protocol (tcp or udp) (default: "")
 ;type=  ; Must be of type identify (default: "")
 
 

--- a/contrib/ast-db-manage/config/versions/d5122576cca8_add_transport_attribute_to_identify.py
+++ b/contrib/ast-db-manage/config/versions/d5122576cca8_add_transport_attribute_to_identify.py
@@ -1,0 +1,20 @@
+"""add transport attribute to identify
+
+Revision ID: d5122576cca8
+Revises: cf150a175fd3
+Create Date: 2024-03-28 14:29:43.372496
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'd5122576cca8'
+down_revision = 'cf150a175fd3'
+
+from alembic import op
+import sqlalchemy as sa
+
+def upgrade():
+    op.add_column('ps_endpoint_id_ips', sa.Column('transport', sa.String(128)))
+
+def downgrade():
+    op.drop_column('ps_endpoint_id_ips', 'transport')

--- a/include/asterisk/res_pjsip.h
+++ b/include/asterisk/res_pjsip.h
@@ -617,6 +617,8 @@ enum ast_sip_endpoint_identifier_type {
 	AST_SIP_ENDPOINT_IDENTIFY_BY_HEADER = (1 << 3),
 	/*! Identify based on request uri */
 	AST_SIP_ENDPOINT_IDENTIFY_BY_REQUEST_URI = (1 << 4),
+	/*! Identify based on bound (local) IP address */
+	AST_SIP_ENDPOINT_IDENTIFY_BY_TRANSPORT = (1 << 5),
 };
 AST_VECTOR(ast_sip_identify_by_vector, enum ast_sip_endpoint_identifier_type);
 

--- a/res/res_pjsip/pjsip_config.xml
+++ b/res/res_pjsip/pjsip_config.xml
@@ -565,6 +565,14 @@
 								but simply allowed by this configuration option.
 								</para>
 							</enum>
+							<enum name="transport">
+								<para>Matches the endpoint based on the destination IP
+								address.
+								</para>
+								<para>This method of identification is not configured here
+								but simply allowed by this configuration option.
+								</para>
+							</enum>
 						</enumlist>
 					</description>
 				</configOption>

--- a/res/res_pjsip/pjsip_configuration.c
+++ b/res/res_pjsip/pjsip_configuration.c
@@ -426,6 +426,9 @@ static const char *sip_endpoint_identifier_type2str(enum ast_sip_endpoint_identi
 	case AST_SIP_ENDPOINT_IDENTIFY_BY_REQUEST_URI:
 		str = "request_uri";
 		break;
+	case AST_SIP_ENDPOINT_IDENTIFY_BY_TRANSPORT:
+		str = "transport";
+		break;
 	}
 	return str;
 }
@@ -453,6 +456,8 @@ static int sip_endpoint_identifier_str2type(const char *str)
 		method = AST_SIP_ENDPOINT_IDENTIFY_BY_HEADER;
 	} else if (!strcasecmp(str, "request_uri")) {
 		method = AST_SIP_ENDPOINT_IDENTIFY_BY_REQUEST_URI;
+	} else if (!strcasecmp(str, "transport")) {
+		method = AST_SIP_ENDPOINT_IDENTIFY_BY_TRANSPORT;
 	} else {
 		method = -1;
 	}


### PR DESCRIPTION
Add a new identify_by option to res_pjsip_endpoint_identifier_ip called 'transport' this matches endpoints based on the bound ip address (local) instead of the 'ip' option, which matches on the source ip address (remote).

Fixes: #672