### PR TITLE
pjsip show channelstats: Prevent possible segfault when faxing

### DIFF
--- a/main/rtp_engine.c
+++ b/main/rtp_engine.c
@@ -2460,6 +2460,10 @@ int ast_rtp_instance_get_stats(struct ast_rtp_instance *instance, struct ast_rtp
 {
 	int res;
 
+	if (!instance || !instance->engine || !stats) {
+		return -1;
+	}
+
 	if (instance->engine->get_stat) {
 		ao2_lock(instance);
 		res = instance->engine->get_stat(instance, stats, stat);


### PR DESCRIPTION
Under rare circumstances, it's possible for the original audio
session in the active_media_state default_session to be corrupted
instead of removed when switching to the t38/image media session
during fax negotiation.  This can cause a segfault when a "pjsip
show channelstats" attempts to print that audio media session's
rtp statistics.  In these cases, the active_media_state
topology is correctly showing only a single t38/image stream
so we now check that there's an audio stream in the topology
before attempting to use the audio media session to get the rtp
statistics.

Resolves: #592
