### PR TITLE
res_pjsip_session: Reset pending_media_state->read_callbacks

### DIFF
--- a/res/res_pjsip_session.c
+++ b/res/res_pjsip_session.c
@@ -1106,6 +1106,8 @@ static int handle_negotiated_sdp(struct ast_sip_session *session, const pjmedia_
 		SCOPE_EXIT_RTN_VALUE(-1, "Media stream count mismatch\n");
 	}
 
+	AST_VECTOR_RESET(&session->pending_media_state->read_callbacks, AST_VECTOR_ELEM_CLEANUP_NOOP);
+
 	for (i = 0; i < local->media_count; ++i) {
 		struct ast_sip_session_media *session_media;
 		struct ast_stream *stream;


### PR DESCRIPTION
In `handle_negotiated_sdp` the `pending_media_state->read_callbacks` must be reset before they are added in the SDP handlers in `handle_negotiated_sdp_session_media`. Otherwise, old callbacks for removed streams and file descriptors could be added to the channel and Asterisk would poll on non-existing file descriptors.

Resolves: #611