### PR TITLE
strings.h: Ensure ast_str_buffer(…) returns a 0 terminated string.

### DIFF
--- a/include/asterisk/strings.h
+++ b/include/asterisk/strings.h
@@ -753,7 +753,10 @@ char * attribute_pure ast_str_buffer(const struct ast_str *buf),
 	 * being returned; eventually, it should become truly const
 	 * and only be modified via accessor functions
 	 */
-	return (char *) buf->__AST_STR_STR;
+	if (__builtin_expect(buf->__AST_STR_LEN > 0, 1)) {
+		return (char *) buf->__AST_STR_STR;
+	}
+	return "";
 }
 )
 


### PR DESCRIPTION
If a dynamic string is created with an initial length of 0, `ast_str_buffer(…)` will return an invalid pointer.

This was a secondary discovery when fixing #65.