### PR TITLE
Makefile: Add stir_shaken/cache to directories created on install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -545,7 +545,7 @@ INSTALLDIRS="$(ASTLIBDIR)" "$(ASTMODDIR)" "$(ASTSBINDIR)" "$(ASTCACHEDIR)" "$(AS
 	"$(ASTDATADIR)/firmware/iax" "$(ASTDATADIR)/images" "$(ASTDATADIR)/keys" \
 	"$(ASTDATADIR)/phoneprov" "$(ASTDATADIR)/rest-api" "$(ASTDATADIR)/static-http" \
 	"$(ASTDATADIR)/sounds" "$(ASTDATADIR)/moh" "$(ASTMANDIR)/man8" "$(AGI_DIR)" "$(ASTDBDIR)" \
-	"$(ASTDATADIR)/third-party" "${ASTDATADIR}/keys/stir_shaken"
+	"$(ASTDATADIR)/third-party" "${ASTDATADIR}/keys/stir_shaken" "${ASTDATADIR}/keys/stir_shaken/cache"
 
 installdirs:
 	@for i in $(INSTALLDIRS); do \


### PR DESCRIPTION
The default location for the stir_shaken cache is
/var/lib/asterisk/keys/stir_shaken/cache but we were only creating
/var/lib/asterisk/keys/stir_shaken on istall.  We now create
the cache sub-directory.

Resolves: #634
