### PR TITLE
attestation_config.c: Use ast_free instead of ast_std_free

### DIFF
--- a/res/res_stir_shaken/attestation_config.c
+++ b/res/res_stir_shaken/attestation_config.c
@@ -179,7 +179,7 @@ int as_check_common_config(const char *id, struct attestation_cfg_common *acfg_c
 
 	if (!ast_strlen_zero(acfg_common->private_key_file)) {
 		EVP_PKEY *private_key;
-		RAII_VAR(unsigned char *, raw_key, NULL, ast_std_free);
+		RAII_VAR(unsigned char *, raw_key, NULL, ast_free);
 
 		private_key = crypto_load_privkey_from_file(acfg_common->private_key_file);
 		if (!private_key) {


### PR DESCRIPTION
In as_check_common_config, we were calling ast_std_free on
raw_key but raw_key was allocated with ast_malloc so it
should be freed with ast_free.

Resolves: #636
