### PR TITLE
chan_pjsip:  Add the same details as PJSIPShowContacts to the CLI via 'pjsip show contact'

### DIFF
--- a/channels/pjsip/cli_commands.c
+++ b/channels/pjsip/cli_commands.c
@@ -42,14 +42,14 @@
 #include "include/cli_functions.h"
 
 
-static int cli_channel_iterate(void *endpoint, ao2_callback_fn callback, void *arg)
+static int cli_channel_iterate(void *endpoint, ao2_callback_fn callback, void *arg, int flags)
 {
-	return ast_sip_for_each_channel(endpoint, callback, arg);
+	return ast_sip_for_each_channel(endpoint, callback, arg, flags);
 }
 
-static int cli_channelstats_iterate(void *endpoint, ao2_callback_fn callback, void *arg)
+static int cli_channelstats_iterate(void *endpoint, ao2_callback_fn callback, void *arg, int flags)
 {
-	return ast_sip_for_each_channel(endpoint, callback, arg);
+	return ast_sip_for_each_channel(endpoint, callback, arg, flags);
 }
 
 static int cli_channel_sort(const void *obj, const void *arg, int flags)

--- a/include/asterisk/res_pjsip.h
+++ b/include/asterisk/res_pjsip.h
@@ -2978,7 +2978,7 @@ void *ast_sip_dict_set(pj_pool_t* pool, void *ht,
  * \retval 0 Success, non-zero on failure
  */
 int ast_sip_for_each_contact(const struct ast_sip_aor *aor,
-		ao2_callback_fn on_contact, void *arg);
+		ao2_callback_fn on_contact, void *arg, int flags);
 
 /*!
  * \brief Handler used to convert a contact to a string.
@@ -3149,7 +3149,7 @@ const char *ast_sip_get_device_state(const struct ast_sip_endpoint *endpoint);
  */
 int ast_sip_for_each_channel_snapshot(const struct ast_endpoint_snapshot *endpoint_snapshot,
 		ao2_callback_fn on_channel_snapshot,
-				      void *arg);
+				      void *arg, int flags);
 
 /*!
  * \brief For every channel snapshot on an endpoint all the given
@@ -3162,7 +3162,7 @@ int ast_sip_for_each_channel_snapshot(const struct ast_endpoint_snapshot *endpoi
  */
 int ast_sip_for_each_channel(const struct ast_sip_endpoint *endpoint,
 		ao2_callback_fn on_channel_snapshot,
-				      void *arg);
+				      void *arg, int flags);
 
 enum ast_sip_supplement_priority {
 	/*! Top priority. Supplements with this priority are those that need to run before any others */

--- a/include/asterisk/res_pjsip_cli.h
+++ b/include/asterisk/res_pjsip_cli.h
@@ -63,7 +63,7 @@ struct ast_sip_cli_formatter_entry {
 	/*! The function used to retrieve a container of all objects of this type. */
 	struct ao2_container *(* get_container)(const char *regex);
 	/*! The function used to iterate over a container of objects. */
-	int (* iterate)(void *container, ao2_callback_fn callback, void *args);
+	int (* iterate)(void *container, ao2_callback_fn callback, void *args, int flags);
 	/*! The function used to retrieve a specific object from it's container. */
 	void *(* retrieve_by_id)(const char *id);
 	/*! The function used to retrieve an id string from an object. */

--- a/res/res_pjsip/config_auth.c
+++ b/res/res_pjsip/config_auth.c
@@ -298,7 +298,7 @@ static struct ao2_container *cli_get_container(const char *regex)
 	return s_container;
 }
 
-static int cli_iterator(void *container, ao2_callback_fn callback, void *args)
+static int cli_iterator(void *container, ao2_callback_fn callback, void *args, int flags)
 {
 	return ast_sip_for_each_auth(container, callback, args);
 }

--- a/res/res_pjsip/config_transport.c
+++ b/res/res_pjsip/config_transport.c
@@ -1581,7 +1581,7 @@ static struct ao2_container *cli_get_container(const char *regex)
 	return s_container;
 }
 
-static int cli_iterate(void *container, ao2_callback_fn callback, void *args)
+static int cli_iterate(void *container, ao2_callback_fn callback, void *args, int flags)
 {
 	const struct ast_sip_endpoint *endpoint = container;
 	struct ast_sip_transport *transport = ast_sorcery_retrieve_by_id(ast_sip_get_sorcery(),

--- a/res/res_pjsip/pjsip_configuration.c
+++ b/res/res_pjsip/pjsip_configuration.c
@@ -1657,7 +1657,7 @@ struct ast_endpoint_snapshot *ast_sip_get_endpoint_snapshot(
 
 int ast_sip_for_each_channel_snapshot(
 	const struct ast_endpoint_snapshot *endpoint_snapshot,
-	ao2_callback_fn on_channel_snapshot, void *arg)
+	ao2_callback_fn on_channel_snapshot, void *arg, int flags)
 {
 	int num, num_channels = endpoint_snapshot->num_channels;
 
@@ -1684,10 +1684,10 @@ int ast_sip_for_each_channel_snapshot(
 
 int ast_sip_for_each_channel(
 	const struct ast_sip_endpoint *endpoint,
-	ao2_callback_fn on_channel_snapshot, void *arg)
+	ao2_callback_fn on_channel_snapshot, void *arg, int flags)
 {
 	RAII_VAR(struct ast_endpoint_snapshot *, endpoint_snapshot, ast_sip_get_endpoint_snapshot(endpoint), ao2_cleanup);
-	return ast_sip_for_each_channel_snapshot(endpoint_snapshot, on_channel_snapshot, arg);
+	return ast_sip_for_each_channel_snapshot(endpoint_snapshot, on_channel_snapshot, arg, flags);
 }
 
 static int active_channels_to_str_cb(void *object, void *arg, int flags)
@@ -1710,7 +1710,7 @@ static void active_channels_to_str(const struct ast_sip_endpoint *endpoint,
 	}
 
 	ast_sip_for_each_channel_snapshot(endpoint_snapshot,
-					  active_channels_to_str_cb, str);
+					  active_channels_to_str_cb, str, 0);
 	ast_str_truncate(*str, -1);
 }
 
@@ -1767,7 +1767,7 @@ static int sip_endpoints_aors_ami(void *obj, void *arg, int flags)
 	struct ast_str **buf = arg;
 
 	ast_str_append(buf, 0, "Contacts: ");
-	ast_sip_for_each_contact(aor, ast_sip_contact_to_str, arg);
+	ast_sip_for_each_contact(aor, ast_sip_contact_to_str, arg, flags);
 	ast_str_append(buf, 0, "\r\n");
 
 	return 0;
@@ -1952,7 +1952,7 @@ static struct ao2_container *cli_endpoint_get_container(const char *regex)
 	return s_container;
 }
 
-static int cli_endpoint_iterate(void *obj, ao2_callback_fn callback, void *args)
+static int cli_endpoint_iterate(void *obj, ao2_callback_fn callback, void *args, int flags)
 {
 	ao2_callback(obj, OBJ_NODATA, callback, args);
 
@@ -2002,7 +2002,7 @@ static void cli_endpoint_print_child_body(char *type, const void *obj, struct as
 
 	formatter_entry = ast_sip_lookup_cli_formatter(type);
 	if (formatter_entry) {
-		formatter_entry->iterate((void *)obj, formatter_entry->print_body, context);
+		formatter_entry->iterate((void *)obj, formatter_entry->print_body, context, 2);
 	}
 }
 

--- a/res/res_pjsip/pjsip_distributor.c
+++ b/res/res_pjsip/pjsip_distributor.c
@@ -1063,7 +1063,7 @@ static struct ao2_container *cli_unid_get_container(const char *regex)
 	return s_container;
 }
 
-static int cli_unid_iterate(void *container, ao2_callback_fn callback, void *args)
+static int cli_unid_iterate(void *container, ao2_callback_fn callback, void *args, int flags)
 {
 	ao2_callback(container, 0, callback, args);
 

--- a/res/res_pjsip/pjsip_options.c
+++ b/res/res_pjsip/pjsip_options.c
@@ -2777,7 +2777,7 @@ static int format_contact_status_for_aor(void *obj, void *arg, int flags)
 {
 	struct ast_sip_aor *aor = obj;
 
-	return ast_sip_for_each_contact(aor, ast_sip_format_contact_ami, arg);
+	return ast_sip_for_each_contact(aor, ast_sip_format_contact_ami, arg, 0);
 }
 
 static int format_ami_contact_status(const struct ast_sip_endpoint *endpoint,

--- a/res/res_pjsip_endpoint_identifier_ip.c
+++ b/res/res_pjsip_endpoint_identifier_ip.c
@@ -672,7 +672,7 @@ struct ast_sip_endpoint_formatter endpoint_identify_formatter = {
 	.format_ami = format_ami_endpoint_identify
 };
 
-static int cli_iterator(void *container, ao2_callback_fn callback, void *args)
+static int cli_iterator(void *container, ao2_callback_fn callback, void *args, int flags)
 {
 	const struct ast_sip_endpoint *endpoint = container;
 	struct ao2_container *identifies;

--- a/res/res_pjsip_outbound_registration.c
+++ b/res/res_pjsip_outbound_registration.c
@@ -2509,7 +2509,7 @@ static struct ao2_container *cli_get_container(const char *regex)
 	return s_container;
 }
 
-static int cli_iterator(void *container, ao2_callback_fn callback, void *args)
+static int cli_iterator(void *container, ao2_callback_fn callback, void *args, int flags)
 {
 	ao2_callback(container, OBJ_NODATA, callback, args);
 

--- a/res/res_pjsip_registrar.c
+++ b/res/res_pjsip_registrar.c
@@ -1242,7 +1242,7 @@ static int ami_registrations_aor(void *obj, void *arg, int flags)
 
 	ast_sip_sorcery_object_to_ami(aor, &buf);
 	ast_str_append(&buf, 0, "Contacts: ");
-	ast_sip_for_each_contact(aor, sip_contact_to_str, &buf);
+	ast_sip_for_each_contact(aor, sip_contact_to_str, &buf, flags);
 	ast_str_append(&buf, 0, "\r\n");
 
 	astman_append(ami->s, "%s\r\n", ast_str_buffer(buf));


### PR DESCRIPTION
CLI 'pjsip show contact' does not show enough information.
One must telnet to AMI or write a script to ask Asterisk for example what the User-Agent is on a Contact
This feature adds the same details as PJSIPShowContacts to the CLI
