### PR TITLE
manager.c: Add new parameter 'PreDialGoSub' to Originate AMI action.

### DIFF
--- a/main/manager.c
+++ b/main/manager.c
@@ -712,6 +712,9 @@
 			<parameter name="OtherChannelId">
 				<para>Channel UniqueId to be set on the second local channel.</para>
 			</parameter>
+			<parameter name="PreDialGoSub">
+				<para>PreDialGoSub Context,Extension,Priority to set options/headers needed before start the outgoing extension</para>
+			</parameter>
 		</syntax>
 		<description>
 			<para>Generates an outgoing call to a
@@ -6235,6 +6238,8 @@ static int action_originate(struct mansession *s, const struct message *m)
 		.uniqueid = astman_get_header(m, "ChannelId"),
 		.uniqueid2 = astman_get_header(m, "OtherChannelId"),
 	};
+	const char *gosub = astman_get_header(m, "PreDialGoSub");
+
 	struct ast_variable *vars = NULL;
 	char *tech, *data;
 	char *l = NULL, *n = NULL;
@@ -6404,10 +6409,10 @@ static int action_originate(struct mansession *s, const struct message *m)
 		ast_variables_destroy(vars);
 	} else {
 		if (exten && context && pi) {
-			res = ast_pbx_outgoing_exten(tech, cap, data, to,
+			res = ast_pbx_outgoing_exten_predial(tech, cap, data, to,
 					context, exten, pi, &reason, AST_OUTGOING_WAIT,
 					l, n, vars, account, NULL, bridge_early,
-					assignedids.uniqueid ? &assignedids : NULL);
+					assignedids.uniqueid ? &assignedids : NULL , gosub);
 			ast_variables_destroy(vars);
 		} else {
 			astman_send_error(s, m, "Originate with 'Exten' requires 'Context' and 'Priority'");


### PR DESCRIPTION
manager.c: Add new parameter 'PreDialGoSub' to Originate AMI action

The action originate does not has the ability to run an subroutine at initial channel, like the Aplication Originate. This update give this ability for de action originate too.

For example, we can run a routine via Gosub on the channel to request an automatic answer, so the caller does not need to accept the call when using the originate command via manager, making the operation more efficient.

UserNote: When using the Originate AMI Action, we now can pass the PreDialGoSub parameter, instructing the asterisk to perform an subrouting at channel before call start. With this parameter an call initiated by AMI can request the channel to start the call automaticaly, adding a SIP header to using GoSUB, instructing to autoanswer the channel, and proceeding the outbuound extension executing. Exemple of an context to perform the previus indication:
    [addautoanswer]
    exten => _s,1,Set(PJSIP_HEADER(add,Call-Info)=answer-after=0)
    exten => _s,n,Set(PJSIP_HEADER(add,Alert-Info)=answer-after=0)
    exten => _s,n,Return()