### PR TITLE
res_pjsip: Implement Configurable TCP Keepalive Settings in PJSIP Transports

### DIFF
--- a/configs/samples/pjsip.conf.sample
+++ b/configs/samples/pjsip.conf.sample
@@ -171,6 +171,32 @@
 ;type=transport
 ;protocol=flow
 
+; Example IPv4 TCP transport with Keepalive options
+;
+;[transport-tcp]
+;type=transport
+;protocol=tcp
+;bind=0.0.0.0
+;tcp_keepalive_enable=yes        ; Enable TCP keepalive (yes/no)
+;tcp_keepalive_idle_time=30      ; Time in seconds the connection needs to remain idle before TCP starts sending keepalive probes
+;tcp_keepalive_interval_time=10  ; The time in seconds between individual keepalive probes
+;tcp_keepalive_probe_count=5     ; The maximum number of keepalive probes TCP should send before dropping the connection
+
+; Example IPv4 TLS transport with Keepalive options
+;
+;[transport-tls]
+;type=transport
+;protocol=tls
+;bind=0.0.0.0
+;cert_file=/path/to/mycert.crt
+;priv_key_file=/path/to/mykey.key
+;cipher=ADH-AES256-SHA,ADH-AES128-SHA
+;method=tlsv1
+;tcp_keepalive_enable=yes        ; Enable TCP keepalive (yes/no)
+;tcp_keepalive_idle_time=30      ; Time in seconds the connection needs to remain idle before TCP starts sending keepalive probes
+;tcp_keepalive_interval_time=10  ; The time in seconds between individual keepalive probes
+;tcp_keepalive_probe_count=5     ; The maximum number of keepalive probes TCP should send before dropping the connection
+
 ;===============OUTBOUND REGISTRATION WITH OUTBOUND AUTHENTICATION============
 ;
 ; This is a simple registration that works with some SIP trunking providers.

--- a/contrib/ast-db-manage/config/versions/8fce8496f03e_add_tcp_keepalive_settings_to_ps_.py
+++ b/contrib/ast-db-manage/config/versions/8fce8496f03e_add_tcp_keepalive_settings_to_ps_.py
@@ -1,0 +1,28 @@
+"""Add TCP keepalive settings to ps_transports
+
+Revision ID: 8fce8496f03e
+Revises: 74dc751dfe8e
+Create Date: 2024-03-18 17:00:17.148018
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '8fce8496f03e'
+down_revision = '74dc751dfe8e'
+
+from alembic import op
+import sqlalchemy as sa
+
+def upgrade():
+    with op.batch_alter_table('ps_transports') as batch_op:
+        batch_op.add_column(sa.Column('tcp_keepalive_enable', sa.Boolean(), nullable=True))
+        batch_op.add_column(sa.Column('tcp_keepalive_idle_time', sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column('tcp_keepalive_interval_time', sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column('tcp_keepalive_probe_count', sa.Integer(), nullable=True))
+
+def downgrade():
+    with op.batch_alter_table('ps_transports') as batch_op:
+        batch_op.drop_column('tcp_keepalive_enable')
+        batch_op.drop_column('tcp_keepalive_idle_time')
+        batch_op.drop_column('tcp_keepalive_interval_time')
+        batch_op.drop_column('tcp_keepalive_probe_count')

--- a/include/asterisk/res_pjsip.h
+++ b/include/asterisk/res_pjsip.h
@@ -299,6 +299,14 @@ struct ast_sip_transport {
 	int symmetric_transport;
 	/*! This is a flow to another target */
 	int flow;
+	/*! Enable TCP keepalive */
+	int tcp_keepalive_enable;
+	/*! Time in seconds the connection needs to remain idle before TCP starts sending keepalive probes */
+	int tcp_keepalive_idle_time;
+	/*! The time in seconds between individual keepalive probes */
+	int tcp_keepalive_interval_time;
+	/*! The maximum number of keepalive probes TCP should send before dropping the connection */
+	int tcp_keepalive_probe_count;
 };
 
 #define SIP_SORCERY_DOMAIN_ALIAS_TYPE "domain_alias"

--- a/res/res_pjsip/pjsip_config.xml
+++ b/res/res_pjsip/pjsip_config.xml
@@ -1798,6 +1798,30 @@
 				<configOption name="require_client_cert" default="false">
 					<synopsis>Require client certificate (TLS ONLY, not WSS)</synopsis>
 				</configOption>
+				<configOption name="tcp_keepalive_enable" default="no">
+					<synopsis>Enable TCP keepalive</synopsis>
+					<description><para>
+						When set to 'yes', TCP keepalive messages are sent to verify that the endpoint is still reachable. This can help detect dead TCP connections in environments where connections may be silently dropped (e.g., NAT timeouts).
+					</para></description>
+				</configOption>
+				<configOption name="tcp_keepalive_idle_time" default="30">
+					<synopsis>Idle time before the first TCP keepalive probe is sent</synopsis>
+					<description><para>
+						Specifies the amount of time in seconds that the connection must be idle before the first TCP keepalive probe is sent. An idle connection is defined as a connection in which no data has been sent or received by the application.
+					</para></description>
+				</configOption>
+				<configOption name="tcp_keepalive_interval_time" default="10">
+					<synopsis>Interval between TCP keepalive probes</synopsis>
+					<description><para>
+						Specifies the interval in seconds between individual TCP keepalive probes, once the first probe is sent. This interval is used for subsequent probes if the peer does not respond to the previous probe.
+					</para></description>
+				</configOption>
+				<configOption name="tcp_keepalive_probe_count" default="5">
+					<synopsis>Maximum number of TCP keepalive probes</synopsis>
+					<description><para>
+						Specifies the maximum number of TCP keepalive probes to send before considering the connection dead and notifying the application. If the peer does not respond after this many probes, the connection is considered broken.
+					</para></description>
+				</configOption>
 				<configOption name="type">
 					<synopsis>Must be of type 'transport'.</synopsis>
 				</configOption>

--- a/third-party/pjproject/patches/config_site.h
+++ b/third-party/pjproject/patches/config_site.h
@@ -35,6 +35,15 @@
 #define PJ_IOQUEUE_HAS_SAFE_UNREG 1
 #define PJ_IOQUEUE_MAX_EVENTS_IN_SINGLE_POLL (16)
 
+/*
+ * Increase the number of socket options available. This adjustment is necessary
+ * to accommodate additional TCP keepalive settings required for optimizing SIP
+ * transport stability, especially in environments prone to connection timeouts.
+ * The default limit is insufficient when configuring all desired keepalive
+ * parameters along with standard socket options.
+ */
+#define PJ_MAX_SOCKOPT_PARAMS 5
+
 #define PJ_SCANNER_USE_BITWISE	0
 #define PJ_OS_HAS_CHECK_STACK	0
 


### PR DESCRIPTION
This commit introduces configurable TCP keepalive settings for both TCP and TLS transports. The changes allow for finer control over TCP connection keepalives, enhancing stability and reliability in environments prone to connection timeouts or where intermediate devices may prematurely close idle connections. This has proven necessary and has already been tested in production in several specialized environments where access to the underlying transport is unreliable in ways invisible to the operating system directly, so these keepalive and timeout mechanisms are necessary.

Changes introduced here:

1. Added sample configurations in `pjsip.conf.sample` for TCP and TLS transports, demonstrating how to enable and configure TCP keepalive parameters.
2. Extended `struct ast_sip_transport` in `include/asterisk/res_pjsip.h` to include fields for `tcp_keepalive_enable`, `tcp_keepalive_idle_time`, `tcp_keepalive_interval_time`, and `tcp_keepalive_probe_count`.
3. Modified `res/res_pjsip/config_transport.c` to apply TCP keepalive settings based on these new configurations when transports are set up.
4. Updated `pjsip_config.xml` to document these new configuration options, ensuring they are correctly exposed to users for configuration through `pjsip.conf`.
5. Increased `PJ_MAX_SOCKOPT_PARAMS` to 5 in `third-party/pjproject/patches/config_site.h` to accommodate the additional socket options needed for configuring TCP keepalive alongside existing options.

These changes are likely fine to be enabled by default but I have default disabled all changed configurations here in the interest of hopefully getting this backported to Asterisk 20 release.

Fixes #657 