### PR TITLE
chan_dahdi: Don't retry opening nonexistent channels on restart.

### DIFF
--- a/channels/chan_dahdi.c
+++ b/channels/chan_dahdi.c
@@ -12543,7 +12543,8 @@ static struct dahdi_pvt *mkintf(int channel, const struct dahdi_chan_conf *conf,
 				snprintf(fn, sizeof(fn), "%d", channel);
 				/* Open non-blocking */
 				tmp->subs[SUB_REAL].dfd = dahdi_open(fn);
-				while (tmp->subs[SUB_REAL].dfd < 0 && reloading == 2 && count < 1000) { /* the kernel may not call dahdi_release fast enough for the open flagbit to be cleared in time */
+				/* Retry open on restarts, but don't keep retrying if the channel doesn't exist (e.g. not configured) */
+				while (tmp->subs[SUB_REAL].dfd < 0 && reloading == 2 && count < 1000 && errno != ENXIO) { /* the kernel may not call dahdi_release fast enough for the open flagbit to be cleared in time */
 					usleep(1);
 					tmp->subs[SUB_REAL].dfd = dahdi_open(fn);
 					count++;


### PR DESCRIPTION
Commit 729cb1d390b136ccc696430aa5c68d60ea4028be added logic to retry opening DAHDI channels on "dahdi restart" if they failed initially, up to 1,000 times in a loop, to address cases where the channel was still in use. However, this retry loop does not use the actual error, which means chan_dahdi will also retry opening nonexistent channels 1,000 times per channel, causing a flood of unnecessary warning logs for an operation that will never succeed, with tens or hundreds of thousands of open attempts being made.

The original patch would have been more targeted if it only retried on the specific relevant error (likely EBUSY, although it's hard to say since the original issue is no longer available).

To avoid the problem above while avoiding the possibility of breakage, this skips the retry logic if the error is ENXIO (No such device or address), since this will never succeed.

Resolves: #669