### PR TITLE
cli.c: `core show channels concise` is not really deprecated.

### DIFF
--- a/main/cli.c
+++ b/main/cli.c
@@ -1118,9 +1118,7 @@ static char *handle_chanlist(struct ast_cli_entry *e, int cmd, struct ast_cli_ar
 			"       'concise' is specified, the format is abridged and in a more easily\n"
 			"       machine parsable format. If 'verbose' is specified, the output includes\n"
 			"       more and longer fields. If 'count' is specified only the channel and call\n"
-			"       count is output.\n"
-			"	The 'concise' option is deprecated and will be removed from future versions\n"
-			"	of Asterisk.\n";
+			"       count is output.\n";
 		return NULL;
 
 	case CLI_GENERATE:


### PR DESCRIPTION
Fixes #675