### PR TITLE
Fix incorrect application and function documentation references

### DIFF
--- a/apps/app_mixmonitor.c
+++ b/apps/app_mixmonitor.c
@@ -187,7 +187,6 @@
 			<ref type="application">StopMixMonitor</ref>
 			<ref type="application">PauseMonitor</ref>
 			<ref type="application">UnpauseMonitor</ref>
-			<ref type="function">AUDIOHOOK_INHERIT</ref>
 		</see-also>
 	</application>
 	<application name="StopMixMonitor" language="en_US">

--- a/apps/app_stack.c
+++ b/apps/app_stack.c
@@ -202,7 +202,7 @@
 			returning to the dialplan with execution of a Return().</para>
 		</description>
 		<see-also>
-			<ref type="application">GoSub</ref>
+			<ref type="application">Gosub</ref>
 		</see-also>
 	</agi>
 	<managerEvent language="en_US" name="VarSet">
@@ -220,7 +220,7 @@
 				</parameter>
 			</syntax>
 			<see-also>
-				<ref type="application">GoSub</ref>
+				<ref type="application">Gosub</ref>
 				<ref type="agi">gosub</ref>
 				<ref type="function">LOCAL</ref>
 				<ref type="function">LOCAL_PEEK</ref>

--- a/channels/chan_iax2.c
+++ b/channels/chan_iax2.c
@@ -192,9 +192,6 @@
 		<description>
 			<para>Gets information associated with the specified IAX2 peer.</para>
 		</description>
-		<see-also>
-			<ref type="function">SIPPEER</ref>
-		</see-also>
 	</function>
 	<function name="IAXVAR" language="en_US">
 		<synopsis>

--- a/main/pbx_builtins.c
+++ b/main/pbx_builtins.c
@@ -153,7 +153,7 @@
 		<see-also>
 			<ref type="application">Congestion</ref>
 			<ref type="application">Progress</ref>
-			<ref type="application">Playtones</ref>
+			<ref type="application">PlayTones</ref>
 			<ref type="application">Hangup</ref>
 		</see-also>
 	</application>
@@ -173,7 +173,7 @@
 		<see-also>
 			<ref type="application">Busy</ref>
 			<ref type="application">Progress</ref>
-			<ref type="application">Playtones</ref>
+			<ref type="application">PlayTones</ref>
 			<ref type="application">Hangup</ref>
 		</see-also>
 	</application>
@@ -414,7 +414,7 @@
 			<ref type="application">Busy</ref>
 			<ref type="application">Congestion</ref>
 			<ref type="application">Ringing</ref>
-			<ref type="application">Playtones</ref>
+			<ref type="application">PlayTones</ref>
 		</see-also>
 	</application>
 	<application name="RaiseException" language="en_US">
@@ -429,7 +429,7 @@
 			dialplan function EXCEPTION(). If the <literal>e</literal> extension does not exist, the call will hangup.</para>
 		</description>
 		<see-also>
-			<ref type="function">Exception</ref>
+			<ref type="function">EXCEPTION</ref>
 		</see-also>
 	</application>
 	<application name="Ringing" language="en_US">
@@ -444,7 +444,7 @@
 			<ref type="application">Busy</ref>
 			<ref type="application">Congestion</ref>
 			<ref type="application">Progress</ref>
-			<ref type="application">Playtones</ref>
+			<ref type="application">PlayTones</ref>
 		</see-also>
 	</application>
 	<application name="SayAlpha" language="en_US">

--- a/res/res_fax.c
+++ b/res/res_fax.c
@@ -116,7 +116,7 @@
 		<description>
  			<para>This application is provided by res_fax, which is a FAX technology agnostic module
  			that utilizes FAX technology resource modules to complete a FAX transmission.</para>
- 			<para>Session arguments can be set by the FAXOPT function and to check results of the ReceiveFax() application.</para>
+ 			<para>Session arguments can be set by the FAXOPT function and to check results of the ReceiveFAX() application.</para>
 		</description>
 		<see-also>
 			<ref type="function">FAXOPT</ref>
@@ -155,7 +155,7 @@
 		<description>
  			<para>This application is provided by res_fax, which is a FAX technology agnostic module
  			that utilizes FAX technology resource modules to complete a FAX transmission.</para>
- 			<para>Session arguments can be set by the FAXOPT function and to check results of the SendFax() application.</para>
+ 			<para>Session arguments can be set by the FAXOPT function and to check results of the SendFAX() application.</para>
 		</description>
 		<see-also>
 			<ref type="function">FAXOPT</ref>
@@ -236,8 +236,8 @@
 		   	it can also be used to retrieve information about a FAX session that has finished eg. pages/status.</para>
 		</description>
 		<see-also>
-			<ref type="application">ReceiveFax</ref>
-			<ref type="application">SendFax</ref>
+			<ref type="application">ReceiveFAX</ref>
+			<ref type="application">SendFAX</ref>
 		</see-also>
 	</function>
 	<manager name="FAXSessions" language="en_US">
@@ -2272,7 +2272,7 @@ static int receivefax_exec(struct ast_channel *chan, const char *data)
 	}
 
 	if (report_receive_fax_status(chan, args.filename)) {
-		ast_log(AST_LOG_ERROR, "Error publishing ReceiveFax status message\n");
+		ast_log(AST_LOG_ERROR, "Error publishing ReceiveFAX status message\n");
 	}
 
 	/* If the channel hungup return -1; otherwise, return 0 to continue in the dialplan */


### PR DESCRIPTION
There were a few references in the embedded documentation XML
where the case didn't match or where the referenced app or function
simply didn't exist any more.  These were causing 404 responses
in docs.asterisk.org.
