### PR TITLE
res_stir_shaken:  Fix compilation for CentOS7 (openssl 1.0.2)

### DIFF
--- a/res/res_stir_shaken/common_config.h
+++ b/res/res_stir_shaken/common_config.h
@@ -351,7 +351,7 @@ struct verification_cfg_common {
 	enum load_system_certs_enum load_system_certs;
 
 	struct ast_acl_list *acl;
-	X509_STORE *tcs;
+	struct crypto_cert_store *tcs;
 };
 
 #define generate_vcfg_common_sorcery_handlers(object) \

--- a/res/res_stir_shaken/crypto_utils.h
+++ b/res/res_stir_shaken/crypto_utils.h
@@ -165,19 +165,26 @@ int crypto_extract_raw_privkey(EVP_PKEY *key, unsigned char **buffer);
 EVP_PKEY *crypto_load_privkey_from_file(const char *filename);
 
 /*!
+ * \brief ao2 object wrapper for X509_STORE that provides locking and refcounting
+ */
+struct crypto_cert_store {
+	X509_STORE *store;
+};
+
+/*!
  * \brief Free an X509 store
  *
  * \param store X509 Store to free
  *
  */
-void crypto_free_cert_store(X509_STORE *store);
+#define crypto_free_cert_store(store) ao2_cleanup(store)
 
 /*!
  * \brief Create an empty X509 store
  *
- * \returns X509_STORE* or NULL on error
+ * \returns crypto_cert_store * or NULL on error
  */
-X509_STORE *crypto_create_cert_store(void);
+struct crypto_cert_store *crypto_create_cert_store(void);
 
 /*!
  * \brief Dump a cert store to the asterisk CLI
@@ -187,7 +194,7 @@ X509_STORE *crypto_create_cert_store(void);
 
  * \retval Count of objects printed
  */
-int crypto_show_cli_store(X509_STORE *store, int fd);
+int crypto_show_cli_store(struct crypto_cert_store *store, int fd);
 
 /*!
  * \brief Load an X509 Store with either certificates or CRLs
@@ -201,7 +208,7 @@ int crypto_show_cli_store(X509_STORE *store, int fd);
  * \retval <= 0 failure
  * \retval 0 success
  */
-int crypto_load_cert_store(X509_STORE *store, const char *file,
+int crypto_load_cert_store(struct crypto_cert_store *store, const char *file,
 	const char *path);
 
 /*!
@@ -212,7 +219,7 @@ int crypto_load_cert_store(X509_STORE *store, const char *file,
  * \retval <= 0 failure
  * \retval 0 success
  */
-int crypto_lock_cert_store(X509_STORE *store);
+#define crypto_lock_cert_store(store) ao2_lock(store)
 
 /*!
  * \brief Unlocks an X509 Store
@@ -222,7 +229,7 @@ int crypto_lock_cert_store(X509_STORE *store);
  * \retval <= 0 failure
  * \retval 0 success
  */
-int crypto_unlock_cert_store(X509_STORE *store);
+#define crypto_unlock_cert_store(store) ao2_unlock(store)
 
 /*!
  * \brief Check if the reftime is within the cert's valid dates
@@ -245,7 +252,7 @@ int crypto_is_cert_time_valid(X509 *cert, time_t reftime);
  * \retval 1 Cert is trusted
  * \retval 0 Cert is not trusted
  */
-int crypto_is_cert_trusted(X509_STORE *store, X509 *cert, const char **err_msg);
+int crypto_is_cert_trusted(struct crypto_cert_store *store, X509 *cert, const char **err_msg);
 
 /*!
  * \brief Return a time_t for an ASN1_TIME

--- a/res/res_stir_shaken/verification_config.c
+++ b/res/res_stir_shaken/verification_config.c
@@ -129,7 +129,7 @@ int vs_copy_cfg_common(const char *id, struct verification_cfg_common *cfg_dst,
 		cfg_sf_copy_wrapper(id, cfg_dst, cfg_src, ca_path);
 		cfg_sf_copy_wrapper(id, cfg_dst, cfg_src, crl_file);
 		cfg_sf_copy_wrapper(id, cfg_dst, cfg_src, crl_path);
-		X509_STORE_up_ref(cfg_src->tcs);
+		ao2_bump(cfg_src->tcs);
 		cfg_dst->tcs = cfg_src->tcs;
 	}
 
@@ -230,12 +230,12 @@ int vs_check_common_config(const char *id,
 
 	if (vcfg_common->tcs) {
 		if (ENUM_BOOL(vcfg_common->load_system_certs, load_system_certs)) {
-			X509_STORE_set_default_paths(vcfg_common->tcs);
+			X509_STORE_set_default_paths(vcfg_common->tcs->store);
 		}
 
 		if (!ast_strlen_zero(vcfg_common->crl_file)
 			|| !ast_strlen_zero(vcfg_common->crl_path)) {
-			X509_STORE_set_flags(vcfg_common->tcs, X509_V_FLAG_CRL_CHECK | X509_V_FLAG_CRL_CHECK_ALL);
+			X509_STORE_set_flags(vcfg_common->tcs->store, X509_V_FLAG_CRL_CHECK | X509_V_FLAG_CRL_CHECK_ALL);
 		}
 	}
 


### PR DESCRIPTION
* OpenSSL 1.0.2 doesn't support X509_get0_pubkey so we now use
  X509_get_pubkey.  The difference is that X509_get_pubkey requires
  the caller to free the EVP_PKEY themselves so we now let
  RAII_VAR do that.
* OpenSSL 1.0.2 doesn't support upreffing an X509_STORE so we now
  wrap it in an ao2 object.
* OpenSSL 1.0.2 doesn't support X509_STORE_get0_objects to get all
  the certs from an X509_STORE and there's no easy way to polyfill
  it so the CLI commands that list profiles will show a "not
  supported" message instead of listing the certs in a store.

Resolves: #676
