### PR TITLE
callerid.c: Parse previously ignored Caller ID parameters.

### DIFF
--- a/funcs/func_callerid.c
+++ b/funcs/func_callerid.c
@@ -192,6 +192,8 @@
 					You are responsible for setting it if/when needed.</para>
 					<para>Supporting Caller ID units will display the LDC
 					(Long Distance Call) indicator when they receive this parameter.</para>
+					<para>For incoming calls on FXO ports, if the Call Qualifier parameter is received,
+					this variable will also be set to 1.</para>
 					<para>This option must be used with a channel driver
 					that allows Asterisk to generate the Caller ID spill,
 					which currently only includes <literal>chan_dahdi</literal>.</para>

--- a/include/asterisk/callerid.h
+++ b/include/asterisk/callerid.h
@@ -190,14 +190,28 @@ int callerid_feed_jp(struct callerid_state *cid, unsigned char *ubuf, int sample
  * \param cid Callerid state machine to act upon
  * \param number Pass the address of a pointer-to-char (will contain the phone number)
  * \param name Pass the address of a pointer-to-char (will contain the name)
- * \param flags Pass the address of an int variable(will contain the various callerid flags)
+ * \param flags Pass the address of an int variable (will contain the various callerid flags - presentation flags and call qualifier)
  *
  * \details
  * This function extracts a callerid string out of a callerid_state state machine.
  * If no number is found, *number will be set to NULL.  Likewise for the name.
- * Flags can contain any of the following:
+ * Flags can contain any of the following: CID_PRIVATE_NAME, CID_PRIVATE_NUMBER, CID_UNKNOWN_NAME, CID_UNKNOWN_NUMBER, CID_MSGWAITING, CID_NOMSGWAITING, CID_QUALIFIER
  */
 void callerid_get(struct callerid_state *cid, char **number, char **name, int *flags);
+
+/*! \brief Extract info out of callerID state machine.  Flags are listed above
+ * \param cid Callerid state machine to act upon
+ * \param[out] number Pass the address of a pointer-to-char (will contain the phone number)
+ * \param[out] name Pass the address of a pointer-to-char (will contain the name)
+ * \param[out] flags Pass the address of an int variable (will contain the various callerid flags)
+ * \param[out] redirecting Pass the address of an int variable (will contain the redirecting reason, if received - presentation flags and call qualifier)
+ *
+ * \details
+ * This function extracts a callerid string out of a callerid_state state machine.
+ * If no number is found, *number will be set to NULL.  Likewise for the name.
+ * Flags can contain any of the following: CID_PRIVATE_NAME, CID_PRIVATE_NUMBER, CID_UNKNOWN_NAME, CID_UNKNOWN_NUMBER, CID_MSGWAITING, CID_NOMSGWAITING, CID_QUALIFIER
+ */
+void callerid_get_with_redirecting(struct callerid_state *cid, char **name, char **number, int *flags, int *redirecting);
 
 /*!
  * \brief Get and parse DTMF-based callerid


### PR DESCRIPTION
Commit f2f397c1a8cc48913434ebb297f0ff50d96993db previously made it possible to send Caller ID parameters to FXS stations which, prior to that, could not be sent.

This change is complementary in that we now handle receiving all these parameters on FXO lines and provide these up to the dialplan, via chan_dahdi. In particular:

* If a redirecting reason is provided, the channel's redirecting reason is set. No redirecting number is set, since there is no parameter for this in the Caller ID protocol, but the reason can be checked to determine if and why a call was forwarded.
* If the Call Qualifier parameter is received, the Call Qualifier variable is set.
* Some comments have been added to explain why some of the code is the way it is, to assist other people looking at it.

With this change, Asterisk's Caller ID implementation is now reasonably complete for both FXS and FXO operation.

Resolves: #681