### PR TITLE
func_callerid: Emit warning if invalid redirecting reason set.

### DIFF
--- a/funcs/func_callerid.c
+++ b/funcs/func_callerid.c
@@ -1716,6 +1716,7 @@ static int redirecting_write(struct ast_channel *chan, const char *cmd, char *da
 			 * reason, so we can just set the reason string to what was given and set the
 			 * code to be unknown
 			 */
+			ast_log(LOG_WARNING, "Unknown redirecting reason '%s', defaulting to unknown\n", val);
 			redirecting.reason.code = AST_REDIRECTING_REASON_UNKNOWN;
 			redirecting.reason.str = val;
 			set_it(chan, &redirecting, NULL);


### PR DESCRIPTION
Emit a warning if REDIRECTING(reason) is set to an invalid reason, consistent with what happens when
REDIRECTING(orig-reason) is set to an invalid reason.

Resolves: #683