### PR TITLE
app_queue: Allow queue strategy to be manipulated externally.

### DIFF
--- a/apps/app_queue.c
+++ b/apps/app_queue.c
@@ -107,6 +107,8 @@
 #include "asterisk/bridge_basic.h"
 #include "asterisk/max_forwards.h"
 
+#include "asterisk/app_queue.h"
+
 /*!
  * \par Please read before modifying this file.
  * There are three locks which are regularly used
@@ -1540,6 +1542,7 @@ enum {
 	QUEUE_STRATEGY_LINEAR,
 	QUEUE_STRATEGY_WRANDOM,
 	QUEUE_STRATEGY_RRORDERED,
+	QUEUE_STRATEGY_EXTERNAL,
 };
 
 enum {
@@ -1568,6 +1571,7 @@ static const struct strategy {
 	{ QUEUE_STRATEGY_LINEAR, "linear" },
 	{ QUEUE_STRATEGY_WRANDOM, "wrandom"},
 	{ QUEUE_STRATEGY_RRORDERED, "rrordered"},
+	{ QUEUE_STRATEGY_EXTERNAL, "external"},
 };
 
 static const struct autopause {
@@ -1720,6 +1724,7 @@ struct callattempt {
 
 struct queue_ent {
 	struct call_queue *parent;             /*!< What queue is our parent */
+	struct ext_strategy_provider *ext_provider;	/*!< If strategy is external, a reference to the external strategy provider */
 	char moh[MAX_MUSICCLASS];              /*!< Name of musiconhold to be used */
 	char announce[PATH_MAX];               /*!< Announcement to play for member when call is answered */
 	char context[AST_MAX_CONTEXT];         /*!< Context when user exits queue */
@@ -1855,6 +1860,8 @@ struct call_queue {
 		AST_STRING_FIELD(sound_callerannounce);
 		/*! Sound file: "Hold time" (def. queue-reporthold) */
 		AST_STRING_FIELD(sound_reporthold);
+		/*! External strategy name if strategy is QUEUE_STRATEGY_EXTERNAL */
+		AST_STRING_FIELD(external_strategy_name);
 	);
 	/*! Sound files: Custom announce, no default */
 	struct ast_str *sound_periodicannounce[MAX_PERIODIC_ANNOUNCEMENTS];
@@ -1870,7 +1877,7 @@ struct call_queue {
 	unsigned int announceholdtime:2;
 	unsigned int announceposition:3;
 	unsigned int announceposition_only_up:1; /*!< Only announce position if it has improved */
-	int strategy:4;
+	int strategy:5; /* Since this is signed, we need 4 bits to fit all available strategies */
 	unsigned int realtime:1;
 	unsigned int found:1;
 	unsigned int relativeperiodicannounce:1;
@@ -3529,6 +3536,13 @@ static void queue_set_param(struct call_queue *q, const char *param, const char 
 			return;
 		}
 		q->strategy = strategy;
+	} else if (!strcasecmp(param, "externalstrategy")) {
+		/* If it's not a native app_queue strategy, store the name
+		 * of the external queue strategy for later use.
+		 * We can't actually validate it now since the providers
+		 * are dependent on app_queue and thus aren't loaded yet.
+		 * We instead check at call runtime. */
+		ast_string_field_set(q, external_strategy_name, val);
 	} else if (!strcasecmp(param, "joinempty")) {
 		parse_empty_options(val, &q->joinempty, 1);
 	} else if (!strcasecmp(param, "leavewhenempty")) {
@@ -4085,6 +4099,204 @@ static void update_realtime_members(struct call_queue *q)
 	ast_config_destroy(member_config);
 }
 
+struct ext_strategy_provider {
+	const char *name;
+	struct ast_queue_strategy_callbacks *callbacks;
+	void *mod;
+	int usecount;
+	AST_RWLIST_ENTRY(ext_strategy_provider) entry;
+	char data[];
+} ext_provider;
+
+static AST_RWLIST_HEAD_STATIC(ext_strat_providers, ext_strategy_provider);
+
+static void queue_caller_info_init(struct ast_queue_caller_info *caller, struct queue_ent *qe)
+{
+	caller->chan = qe->chan;
+	caller->queue_name = qe->parent->name;
+	caller->digits = qe->digits;
+	caller->prio = qe->prio;
+	caller->pending = qe->pending;
+	caller->pos = qe->pos;
+	caller->start = qe->start;
+	caller->expire = qe->expire;
+}
+
+static void queue_agent_info_init(struct ast_queue_agent_info *agent, struct call_queue *q, struct member *mem)
+{
+	ao2_lock(mem);
+	agent->interface = mem->interface;
+	agent->state_interface = mem->state_interface;
+	agent->member_name = mem->membername;
+	agent->queuepos = mem->queuepos;
+	agent->penalty = mem->penalty;
+	agent->paused = mem->paused;
+	agent->calls = mem->calls;
+	agent->dynamic = mem->dynamic;
+	agent->status = mem->status;
+	agent->available = is_member_available(q, mem);
+	ao2_unlock(mem);
+}
+
+/*!
+ * \brief Inform external queue strategy of new call
+ * \param qe
+ * \retval 0 on success
+ * \retval -1 No such external queue strategy, abort
+ */
+static int external_enter_queue(struct queue_ent *qe)
+{
+	struct ext_strategy_provider *p;
+	struct call_queue *q = qe->parent;
+
+	AST_RWLIST_WRLOCK(&ext_strat_providers); /* Guard usecount++ */
+	AST_RWLIST_TRAVERSE(&ext_strat_providers, p, entry) {
+		if (!strcmp(p->name, q->external_strategy_name)) {
+			break;
+		}
+	}
+
+	if (!p) {
+		ast_log(LOG_ERROR, "External queue strategy provider '%s' not currently registered, aborting\n", q->external_strategy_name);
+		AST_RWLIST_UNLOCK(&ext_strat_providers);
+		return -1;
+	}
+
+	p->usecount++; /* While the call is running, prevent this strategy provider from unregistering */
+	qe->ext_provider = p; /* Save reference for convenience */
+	AST_RWLIST_UNLOCK(&ext_strat_providers); /* Now safe to unlock */
+
+	if (qe->ext_provider->callbacks && qe->ext_provider->callbacks->enter_queue) {
+		struct ast_queue_caller_info caller;
+
+		ast_module_ref(qe->ext_provider->mod);
+		queue_caller_info_init(&caller, qe);
+		qe->ext_provider->callbacks->enter_queue(&caller);
+		ast_module_unref(qe->ext_provider->mod);
+	}
+	return 0;
+}
+
+/*! \brief Release reference to an external queue strategy */
+static void external_leave_queue(struct queue_ent *qe)
+{
+	/* If we were the only one in the queue,
+	 * then q->usecount is going to drop to 0 now.
+	 * If not, the other calls still in the queue
+	 * already bumped the use count, and it's safe
+	 * to release ours. */
+	AST_RWLIST_WRLOCK(&ext_strat_providers);
+	qe->ext_provider->usecount--;
+	qe->ext_provider = NULL;
+	AST_RWLIST_UNLOCK(&ext_strat_providers);
+}
+
+/*! \brief Query external module to see if it's our turn */
+static int external_is_our_turn(struct queue_ent *qe)
+{
+	int res = -1;
+
+	if (qe->ext_provider->callbacks && qe->ext_provider->callbacks->enter_queue) {
+		struct ast_queue_caller_info caller;
+
+		ast_module_ref(qe->ext_provider->mod);
+		queue_caller_info_init(&caller, qe);
+		res = qe->ext_provider->callbacks->is_our_turn(&caller);
+		ast_module_unref(qe->ext_provider->mod);
+	}
+	return res;
+}
+
+/*! \brief Query external module to compute agent metric */
+static int external_calc_metric(struct queue_ent *qe, struct call_queue *q, struct member *mem)
+{
+	int res = -1;
+
+	if (qe->ext_provider->callbacks && qe->ext_provider->callbacks->enter_queue) {
+		struct ast_queue_caller_info caller;
+		struct ast_queue_agent_info agent;
+
+		ast_module_ref(qe->ext_provider->mod);
+
+		queue_caller_info_init(&caller, qe);
+		queue_agent_info_init(&agent, q, mem);
+		res = qe->ext_provider->callbacks->calc_metric(&caller, &agent);
+		ast_module_unref(qe->ext_provider->mod);
+	}
+	return res;
+}
+
+int __ast_queue_register_external_strategy_provider(struct ast_queue_strategy_callbacks *callbacks, const char *name, void *mod)
+{
+	struct ext_strategy_provider *p;
+
+	if (!mod) {
+		ast_log(LOG_ERROR, "Module reference not provided");
+		return -1;
+	} else if (ast_strlen_zero(name)) {
+		ast_log(LOG_ERROR, "No provider name provided\n");
+		return -1;
+	}
+
+	AST_RWLIST_WRLOCK(&ext_strat_providers);
+	AST_RWLIST_TRAVERSE(&ext_strat_providers, p, entry) {
+		if (!strcmp(name, p->name)) {
+			break;
+		}
+	}
+	if (p) {
+		AST_RWLIST_UNLOCK(&ext_strat_providers);
+		ast_log(LOG_ERROR, "External queue strategy provider '%s' is already registered", name);
+		return -1;
+	}
+
+	p = ast_calloc(1, sizeof(*p) + strlen(name) + 1);
+	if (!p) {
+		AST_RWLIST_UNLOCK(&ext_strat_providers);
+		return -1;
+	}
+
+	strcpy(p->data, name); /* Safe */
+	p->name = p->data;
+	p->callbacks = callbacks;
+	p->mod = mod;
+
+	AST_RWLIST_INSERT_HEAD(&ext_strat_providers, p, entry);
+	AST_RWLIST_UNLOCK(&ext_strat_providers);
+	return 0;
+}
+
+int ast_queue_unregister_external_strategy_provider(struct ast_queue_strategy_callbacks *callbacks)
+{
+	struct ext_strategy_provider *p;
+
+	AST_RWLIST_WRLOCK(&ext_strat_providers);
+	AST_RWLIST_TRAVERSE_SAFE_BEGIN(&ext_strat_providers, p, entry) {
+		if (callbacks != p->callbacks) {
+			continue;
+		}
+		if (p->usecount) {
+			ast_log(LOG_ERROR, "External queue strategy provider '%s' is currently being used by %d call%s\n", p->name, p->usecount, ESS(p->usecount));
+			AST_RWLIST_UNLOCK(&ext_strat_providers);
+			return -1;
+		}
+		AST_RWLIST_REMOVE_CURRENT(entry);
+		ast_free(p);
+		break;
+	}
+	AST_RWLIST_TRAVERSE_SAFE_END;
+
+	if (!p) {
+		/* Can't happen unless a module has a registration bug */
+		ast_log(LOG_ERROR, "Requested external queue strategy provider not currently registered\n");
+		AST_RWLIST_UNLOCK(&ext_strat_providers);
+		return -1;
+	}
+
+	AST_RWLIST_UNLOCK(&ext_strat_providers);
+	return 0;
+}
+
 static int join_queue(char *queuename, struct queue_ent *qe, enum queue_result *reason, int position)
 {
 	struct call_queue *q;
@@ -4152,6 +4364,16 @@ static int join_queue(char *queuename, struct queue_ent *qe, enum queue_result *
 		q->count++;
 		if (q->count == 1) {
 			ast_devstate_changed(AST_DEVICE_RINGING, AST_DEVSTATE_CACHABLE, "Queue:%s", q->name);
+		}
+
+		if (q->strategy == QUEUE_STRATEGY_EXTERNAL) {
+			if (external_enter_queue(qe)) {
+				/* If this fails, we must abort. */
+				*reason = QUEUE_JOINUNAVAIL;
+				ao2_unlock(q);
+				queue_t_unref(q, "Done with realtime queue");
+				return -1;
+			}
 		}
 
 		res = 0;
@@ -4445,6 +4667,9 @@ static void leave_queue(struct queue_ent *qe)
 			current->pos = ++pos;
 			prev = current;
 		}
+	}
+	if (q->strategy == QUEUE_STRATEGY_EXTERNAL) {
+		external_leave_queue(qe);
 	}
 	ao2_unlock(q);
 
@@ -5777,6 +6002,7 @@ static int is_our_turn(struct queue_ent *qe)
 	int res;
 	int avl;
 	int idx = 0;
+	int ext_result = -1;
 	/* This needs a lock. How many members are available to be served? */
 	ao2_lock(qe->parent);
 
@@ -5793,7 +6019,6 @@ static int is_our_turn(struct queue_ent *qe)
 		ch = ch->next;
 	}
 
-	ao2_unlock(qe->parent);
 	/* If the queue entry is within avl [the number of available members] calls from the top ...
 	 * Autofill and position check added to support autofill=no (as only calls
 	 * from the front of the queue are valid when autofill is disabled)
@@ -5804,6 +6029,22 @@ static int is_our_turn(struct queue_ent *qe)
 	} else {
 		ast_debug(1, "It's not our turn (%s).\n", ast_channel_name(qe->chan));
 		res = 0;
+	}
+
+	/* This check is done after the above, so that we avoid making
+	 * external requests if this caller is not near the top of the queue. */
+	if (qe->parent->strategy == QUEUE_STRATEGY_EXTERNAL && res == 1) {
+		ext_result = external_is_our_turn(qe);
+		if (ext_result == 2) {
+			ast_debug(2, "%s force expired in queue", ast_channel_name(qe->chan));
+		}
+	}
+
+	ao2_unlock(qe->parent);
+
+	if (ext_result == 0 || ext_result == 1) {
+		/* External queue strategy told us what to do, override the default algorithm */
+		return ext_result;
 	}
 
 	/* Update realtime members if this is the first call and number of avalable members is 0 */
@@ -6077,6 +6318,17 @@ static int calc_metric(struct call_queue *q, struct member *mem, int pos, struct
 	unsigned char usepenalty = (membercount <= q->penaltymemberslimit) ? 0 : 1;
 	int penalty = mem->penalty;
 
+	if (q->strategy == QUEUE_STRATEGY_EXTERNAL) {
+		int external_result = external_calc_metric(qe, q, mem);
+		if (external_result == 0) {
+			/* Ignore agent for now */
+			return -1;
+		} else if (external_result > 0) {
+			tmp->metric = external_result;
+			return 0;
+		} /* else, fallthrough, use default algorithm */
+	}
+
 	if (usepenalty) {
 		if (qe->raise_penalty != INT_MAX && penalty < qe->raise_penalty) {
 			/* Low penalty is raised up to the current minimum */
@@ -6093,6 +6345,7 @@ static int calc_metric(struct call_queue *q, struct member *mem, int pos, struct
 
 	switch (q->strategy) {
 	case QUEUE_STRATEGY_RINGALL:
+	case QUEUE_STRATEGY_EXTERNAL:
 		/* Everyone equal, except for penalty */
 		tmp->metric = penalty * 1000000 * usepenalty;
 		break;
@@ -12009,7 +12262,7 @@ static struct member *find_member_by_queuename_and_interface(const char *queuena
 	return mem;
 }
 
-AST_MODULE_INFO(ASTERISK_GPL_KEY, AST_MODFLAG_LOAD_ORDER, "True Call Queueing",
+AST_MODULE_INFO(ASTERISK_GPL_KEY, AST_MODFLAG_LOAD_ORDER | AST_MODFLAG_GLOBAL_SYMBOLS, "True Call Queueing",
 	.support_level = AST_MODULE_SUPPORT_CORE,
 	.load = load_module,
 	.unload = unload_module,

--- a/apps/app_queue.exports.in
+++ b/apps/app_queue.exports.in
@@ -1,0 +1,7 @@
+{
+	global:
+		LINKER_SYMBOL_PREFIXast_queue_*;
+		LINKER_SYMBOL_PREFIX__ast_queue_*;
+	local:
+		*;
+};

--- a/configs/samples/queues.conf.sample
+++ b/configs/samples/queues.conf.sample
@@ -111,8 +111,16 @@ monitor-type = MixMonitor
 ;           a metric between 0 and 3000. Please note, if using this strategy, the member
 ;           penalty is not the same as when using other queue strategies. It is ONLY used
 ;           as a weight for calculating metric.
+; external - An external strategy with logic outside of app_queue.
+;            The external strategy name should be specified using 'externalstrategy'.
 ;
 ;strategy = ringall
+;
+; If strategy = external, the name of the external strategy provider to use
+; for this queue. A module providing this strategy must register it in order
+; for it to be used.
+;
+;externalstrategy = custom-external-strategy-1
 ;
 ; Second settings for service level (default 0)
 ; Used for service level statistics (calls answered within service level time frame)

--- a/configs/samples/res_queue_external_strategy.conf.sample
+++ b/configs/samples/res_queue_external_strategy.conf.sample
@@ -1,0 +1,23 @@
+[general]
+;
+; Reserved, but not currently used
+;
+
+; External strategy that facilitates using an HTTP API
+; to make queue logic decisions.
+;[curl]
+; HTTP endpoints to cURL for implementing external queue strategy callbacks
+; Request will be a POST request containing a JSON payload.
+;
+; HTTP endpoint to call when a call enters a queue
+;url_enter_queue=http://example.com/enter
+;
+; HTTP endpoint to call to determine if it's a call's turn.
+; Should return 2 to expire call, 1 if our turn, 0 if not our turn,
+; or -1 to let the default algorithm decide.
+;url_is_our_turn=http://example.com/is_our_turn
+;
+; HTTP endpoint to call to calculate agent metric.
+; Should return positive metric, 0 to ignore agent for now,
+; or -1 to let default algorithm compute.
+;url_calc_metric=http://example.com/calc_metric

--- a/include/asterisk/app_queue.h
+++ b/include/asterisk/app_queue.h
@@ -1,0 +1,86 @@
+/*
+ * Asterisk -- An open source telephony toolkit.
+ *
+ * Copyright (C) 2024, Naveen Albert
+ *
+ * Naveen Albert <asterisk@phreaknet.org>
+ *
+ * See http://www.asterisk.org for more information about
+ * the Asterisk project. Please do not directly contact
+ * any of the maintainers of this project for assistance;
+ * the project provides a web site, mailing lists and IRC
+ * channels for your use.
+ *
+ * This program is free software, distributed under the terms of
+ * the GNU General Public License Version 2. See the LICENSE file
+ * at the top of the source tree.
+ */
+
+/*! \brief Queue call */
+struct ast_queue_caller_info {
+	struct ast_channel *chan;
+	const char *context;
+	const char *queue_name;
+	const char *digits;
+	int prio;
+	int pending;
+	int pos;
+	int start;
+	int expire;
+};
+
+/*! \brief Queue agent */
+struct ast_queue_agent_info {
+	const char *interface;
+	const char *state_interface;
+	const char *member_name;
+	int queuepos;
+	int penalty;
+	int calls;
+	int status;
+	unsigned int paused:1;
+	unsigned int dynamic:1;
+	unsigned int available:1;
+};
+
+struct ast_queue_strategy_callbacks {
+	/*!
+	 * \brief Callback when a call enters a queue
+	 * \param caller
+	 */
+	void (*enter_queue)(struct ast_queue_caller_info *caller);
+	/*!
+	 * \brief Callback to check if a call can be handled, call once per second
+	 * \param caller
+	 * \retval 2 call has expired, remove call from queue
+	 * \retval 1 call can be handled
+	 * \retval 0 not our turn yet
+	 * \retval -1 Use default app_queue algorithm
+	 */
+	int (*is_our_turn)(struct ast_queue_caller_info *caller);
+	/*!
+	 * \brief Callback to calculate agent metric
+	 * \param caller
+	 * \param agent
+	 * \return positive metric to use
+	 * \retval 0 ignore agent for now
+	 * \retval -1 Use default app_queue algorithm
+	 */
+	int (*calc_metric)(struct ast_queue_caller_info *caller, struct ast_queue_agent_info *agent);
+};
+
+int __ast_queue_register_external_strategy_provider(struct ast_queue_strategy_callbacks *callbacks, const char *name, void *mod);
+
+/*!
+ * \brief Register external queue strategy provider
+ * \param callbacks
+ * \retval 0 on success, -1 on failure (provider already registered)
+ */
+#define ast_queue_register_external_strategy_provider(callbacks, name) __ast_queue_register_external_strategy_provider(callbacks, name, AST_MODULE_SELF)
+
+/*!
+ * \brief Unregister external queue strategy provider
+ * \param callbacks
+ * \retval 0 on success, -1 on failure (provider not currently registered)
+ */
+int ast_queue_unregister_external_strategy_provider(struct ast_queue_strategy_callbacks *callbacks);

--- a/res/res_queue_external_strategy.c
+++ b/res/res_queue_external_strategy.c
@@ -1,0 +1,366 @@
+/*
+ * Asterisk -- An open source telephony toolkit.
+ *
+ * Copyright (C) 2024, Naveen Albert
+ *
+ * Naveen Albert <asterisk@phreaknet.org>
+ *
+ * See http://www.asterisk.org for more information about
+ * the Asterisk project. Please do not directly contact
+ * any of the maintainers of this project for assistance;
+ * the project provides a web site, mailing lists and IRC
+ * channels for your use.
+ *
+ * This program is free software, distributed under the terms of
+ * the GNU General Public License Version 2. See the LICENSE file
+ * at the top of the source tree.
+ */
+
+/*! \file
+ *
+ * \brief External Queue Strategy Provider
+ *
+ * \author Naveen Albert <asterisk@phreaknet.org>
+ */
+
+/*** MODULEINFO
+	<depend>app_queue</depend>
+	<depend>res_curl</depend>
+	<depend>curl</depend>
+	<support_level>extended</support_level>
+ ***/
+
+#include "asterisk.h"
+
+#include <curl/curl.h>
+
+#include "asterisk/lock.h"
+#include "asterisk/file.h"
+#include "asterisk/channel.h"
+#include "asterisk/pbx.h"
+#include "asterisk/module.h"
+#include "asterisk/config.h"
+#include "asterisk/json.h"
+#include "asterisk/conversions.h"
+
+#include "asterisk/app_queue.h"
+
+/*** DOCUMENTATION
+	<configInfo name="res_queue_external_strategy" language="en_US">
+		<synopsis>External queue strategy interface</synopsis>
+		<configFile name="res_queue_external_strategy.conf">
+			<configObject name="general">
+			</configObject>
+			<configObject name="curl">
+				<synopsis>HTTP endpoints to which to send POST requests</synopsis>
+				<configOption name="enter_queue">
+					<synopsis>HTTP endpoint to call when a call enters a queue</synopsis>
+				</configOption>
+				<configOption name="is_our_turn">
+					<synopsis>HTTP endpoint to call to determine if it's a call's turn. Should return 2 to expire call, 1 if our turn, 0 if not our turn, or -1 to let the default algorithm decide.</synopsis>
+				</configOption>
+				<configOption name="calc_metric">
+					<synopsis>HTTP endpoint to call to calculate agent metric. Should return positive metric, 0 to ignore agent for now, or -1 to let default algorithm compute.</synopsis>
+				</configOption>
+			</configObject>
+		</configFile>
+	</configInfo>
+ ***/
+
+#define CONFIG_FILE "res_queue_external_strategy.conf"
+
+static char url_enter_queue[256] = "";
+static char url_is_our_turn[256] = "";
+static char url_calc_metric[256] = "";
+
+static size_t curl_write_string_callback(char *rawdata, size_t size, size_t nmemb, void *userdata)
+{
+	struct ast_str **buffer = userdata;
+	return ast_str_append(buffer, 0, "%.*s", (int) (size * nmemb), rawdata);
+}
+
+static struct ast_str *curl_post(const char *url, const char *header, const char *data)
+{
+	CURL **curl;
+	struct ast_str *str;
+	long int http_code;
+	struct curl_slist *slist = NULL;
+	char curl_errbuf[CURL_ERROR_SIZE + 1] = "";
+
+	str = ast_str_create(512);
+	if (!str) {
+		return NULL;
+	}
+
+	curl = curl_easy_init();
+	if (!curl) {
+		ast_free(str);
+		return NULL;
+	}
+
+	slist = curl_slist_append(slist, header);
+
+	curl_easy_setopt(curl, CURLOPT_USERAGENT, AST_CURL_USER_AGENT);
+	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curl_write_string_callback);
+	curl_easy_setopt(curl, CURLOPT_WRITEDATA, &str);
+	curl_easy_setopt(curl, CURLOPT_URL, url);
+	curl_easy_setopt(curl, CURLOPT_POSTFIELDS, data);
+	curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, -1L);
+	curl_easy_setopt(curl, CURLOPT_HTTPHEADER, slist);
+	curl_easy_setopt(curl, CURLOPT_POST, 1L); /* CURLOPT_HEADER and CURLOPT_NOBODY are implicit */
+	curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, 1000L);
+	curl_easy_setopt(curl, CURLOPT_TIMEOUT, 5L);
+	curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, curl_errbuf);
+
+	if (curl_easy_perform(curl) != CURLE_OK) {
+		curl_slist_free_all(slist);
+		if (*curl_errbuf) {
+			ast_log(LOG_WARNING, "%s\n", curl_errbuf);
+		}
+		ast_log(LOG_WARNING, "Failed to curl URL '%s'\n", url);
+		curl_easy_cleanup(curl);
+		ast_free(str);
+		return NULL;
+	}
+
+	curl_slist_free_all(slist);
+	curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+	curl_easy_cleanup(curl);
+
+	if (http_code / 100 != 2) {
+		ast_log(LOG_ERROR, "Failed to retrieve URL '%s': HTTP response code %ld\n", url, http_code);
+		ast_free(str);
+		return NULL;
+	}
+
+	ast_debug(3, "Response: %s\n", ast_str_buffer(str));
+	return str;
+}
+
+static struct ast_json *build_base_json(struct ast_queue_caller_info *caller)
+{
+	struct ast_json *root;
+
+	ast_channel_lock(caller->chan);
+	root = ast_json_pack(
+		"{s: s, s: s, s: s, s: s, s: s, s: i, s: i, s: i, s: i}",
+		"channel", ast_channel_name(caller->chan),
+		"uniqueid", ast_channel_uniqueid(caller->chan),
+		"context", ast_channel_context(caller->chan),
+		"queue_name", caller->queue_name,
+		"digits", S_OR(caller->digits, ""),
+		"prio", caller->prio,
+		"pos", caller->pos,
+		"start", caller->start,
+		"expire", caller->expire);
+	ast_channel_unlock(caller->chan);
+
+	return root;
+}
+
+static char *build_base_str(struct ast_queue_caller_info *caller)
+{
+	char *str = NULL;
+	struct ast_json *root = build_base_json(caller);
+	if (root) {
+		str = ast_json_dump_string(root);
+		ast_json_unref(root);
+	}
+	return str;
+}
+
+static struct ast_json *build_calc_metric_json(struct ast_queue_caller_info *caller, struct ast_queue_agent_info *agent)
+{
+	struct ast_json *root;
+
+	ast_channel_lock(caller->chan);
+	root = ast_json_pack(
+		"{s: s, s: s, s: s, s: s, s: s, s: i, s: i, s: i, s: i,"
+		", s: s, s: s, s: s, s: i, s: i, s: i, s: i, s: b, s: b, s: b}",
+		"channel", ast_channel_name(caller->chan),
+		"uniqueid", ast_channel_uniqueid(caller->chan),
+		"context", ast_channel_context(caller->chan),
+		"queue_name", caller->queue_name,
+		"digits", S_OR(caller->digits, ""),
+		"prio", caller->prio,
+		"pos", caller->pos,
+		"start", caller->start,
+		"expire", caller->expire,
+		/* Agent */
+		"interface", agent->interface,
+		"state_interface", agent->state_interface,
+		"member_name", agent->member_name,
+		"queuepos", agent->queuepos,
+		"penalty", agent->penalty,
+		"calls", agent->calls,
+		"status", agent->status,
+		"paused", agent->paused,
+		"dynamic", agent->dynamic,
+		"available", agent->available);
+	ast_channel_unlock(caller->chan);
+
+	return root;
+}
+
+static char *build_calc_metric_str(struct ast_queue_caller_info *caller, struct ast_queue_agent_info *agent)
+{
+	char *str = NULL;
+	struct ast_json *root = build_calc_metric_json(caller, agent);
+	if (root) {
+		str = ast_json_dump_string(root);
+		ast_json_unref(root);
+	}
+	return str;
+}
+
+static int return_result(const char *url, char *data, int expect_response)
+{
+	struct ast_str *str;
+
+	if (!data) {
+		return -1;
+	}
+
+	ast_debug(7, "CURL POST %s: %s", url, data);
+	str = curl_post(url, "Content-Type: application/json", data);
+	ast_json_free(data);
+
+	if (!expect_response) {
+		ast_free(str);
+		return -1;
+	}
+
+	if (str) {
+		int result;
+		int res = ast_str_to_int(ast_str_buffer(str), &result);
+		if (res) {
+			ast_log(LOG_WARNING, "Endpoint did not return numeric response ('%s')\n", ast_str_buffer(str));
+			ast_free(str);
+			return -1; /* Not valid int, so fall back to defaults */
+		}
+		ast_free(str);
+		return result;
+	}
+
+	return -1;
+}
+
+static void curlstrat_enter_queue(struct ast_queue_caller_info *caller)
+{
+	ast_autoservice_start(caller->chan);
+	if (!ast_strlen_zero(url_enter_queue)) {
+		return_result(url_enter_queue, build_base_str(caller), 0);
+	}
+	ast_autoservice_stop(caller->chan);
+}
+
+static int curlstrat_is_our_turn(struct ast_queue_caller_info *caller)
+{
+	int res;
+
+	if (ast_strlen_zero(url_is_our_turn)) {
+		return -1;
+	}
+
+	ast_autoservice_start(caller->chan);
+	res = return_result(url_is_our_turn, build_base_str(caller), 1);
+	ast_autoservice_stop(caller->chan);
+
+	return res;
+}
+
+static int curlstrat_calc_metric(struct ast_queue_caller_info *caller, struct ast_queue_agent_info *agent)
+{
+	int res;
+
+	if (agent->paused) {
+		/* If the agent is paused, then obviously not available */
+		return 0;
+	}
+
+	if (ast_strlen_zero(url_calc_metric)) {
+		return -1;
+	}
+
+	ast_autoservice_start(caller->chan);
+	res = return_result(url_calc_metric, build_calc_metric_str(caller, agent), 1);
+	ast_autoservice_stop(caller->chan);
+
+	return res;
+}
+
+static int load_config(int reload)
+{
+	const char *cat = NULL;
+	struct ast_config *cfg;
+	struct ast_flags config_flags = { reload ? CONFIG_FLAG_FILEUNCHANGED : 0 };
+	struct ast_variable *var;
+
+	if (!(cfg = ast_config_load(CONFIG_FILE, config_flags))) {
+		ast_log(LOG_WARNING, "Config file %s not found, declining to load\n", CONFIG_FILE);
+		return -1;
+	} else if (cfg == CONFIG_STATUS_FILEUNCHANGED) {
+		ast_debug(1, "Config file %s unchanged, skipping\n", CONFIG_FILE);
+		return 0;
+	} else if (cfg == CONFIG_STATUS_FILEINVALID) {
+		ast_log(LOG_ERROR, "Config file %s is in an invalid format. Aborting.\n", CONFIG_FILE);
+		return -1;
+	}
+
+	while ((cat = ast_category_browse(cfg, cat))) {
+		if (!strcasecmp(cat, "general")) {
+			continue;
+		}
+		if (strcasecmp(cat, "curl")) {
+			ast_log(LOG_WARNING, "Invalid config section: %s\n", cat);
+			continue;
+		}
+		/* curl strategy */
+		var = ast_variable_browse(cfg, cat);
+		while (var) {
+			if (!strcasecmp(var->name, "url_enter_queue") && !ast_strlen_zero(var->value)) {
+				ast_copy_string(url_enter_queue, var->value, sizeof(url_enter_queue));
+			} else if (!strcasecmp(var->name, "url_is_our_turn") && !ast_strlen_zero(var->value)) {
+				ast_copy_string(url_is_our_turn, var->value, sizeof(url_is_our_turn));
+			} else if (!strcasecmp(var->name, "url_calc_metric") && !ast_strlen_zero(var->value)) {
+				ast_copy_string(url_calc_metric, var->value, sizeof(url_calc_metric));
+			} else {
+				ast_log(LOG_WARNING, "Unknown setting at line %d: '%s'\n", var->lineno, var->name);
+			}
+			var = var->next;
+		}
+	}
+
+	ast_config_destroy(cfg);
+	return 0;
+}
+
+struct ast_queue_strategy_callbacks curlstrat_callbacks = {
+	.enter_queue = curlstrat_enter_queue,
+	.is_our_turn = curlstrat_is_our_turn,
+	.calc_metric = curlstrat_calc_metric,
+};
+
+static int unload_module(void)
+{
+	/* We must decline to unload if ast_queue_unregister_external_strategy_provider returns nonzero */
+	return ast_queue_unregister_external_strategy_provider(&curlstrat_callbacks);
+}
+
+static int load_module(void)
+{
+	if (load_config(0)) {
+		return AST_MODULE_LOAD_DECLINE;
+	}
+	if (ast_queue_register_external_strategy_provider(&curlstrat_callbacks, "curl")) {
+		return AST_MODULE_LOAD_DECLINE;
+	}
+	return AST_MODULE_LOAD_SUCCESS;
+}
+
+AST_MODULE_INFO(ASTERISK_GPL_KEY, AST_MODFLAG_DEFAULT, "External Queue Strategy Provider",
+	.support_level = AST_MODULE_SUPPORT_EXTENDED,
+	.load = load_module,
+	.unload = unload_module,
+	.requires = "app_queue,res_curl",
+);


### PR DESCRIPTION
This adds the concept of "queue strategy providers" to interface with app_queue, which allows queue strategy logic to be implemented external to app_queue. This adds some simple hooks to app_queue to facilitate this, so that all other logic can be done in a separate module that registers with app_queue.

Resolves: #685