### PR TITLE
rtp_engine and stun: call ast_register_atexit instead of ast_register_cleanup

### DIFF
--- a/main/rtp_engine.c
+++ b/main/rtp_engine.c
@@ -3624,6 +3624,11 @@ uintmax_t ast_debug_category_ice_id(void)
 	return debug_category_ice_id;
 }
 
+/*!
+ * \internal
+ * \brief Shutdown the RTP engine
+ * This function will not get called if any module fails to unload.
+ */
 static void rtp_engine_shutdown(void)
 {
 	int x;
@@ -3648,7 +3653,15 @@ static void rtp_engine_shutdown(void)
 	}
 	mime_types_len = 0;
 	ast_rwlock_unlock(&mime_types_lock);
+}
 
+/*!
+ * \internal
+ * \brief Unregister the debug categories
+ * This function will always get called even if any module fails to unload.
+ */
+static void rtp_engine_atexit(void)
+{
 	ast_debug_category_unregister(AST_LOG_CATEGORY_ICE);
 
 	ast_debug_category_unregister(AST_LOG_CATEGORY_DTLS_PACKET);
@@ -3793,6 +3806,16 @@ int ast_rtp_engine_init(void)
 	debug_category_dtls_id = ast_debug_category_register(AST_LOG_CATEGORY_DTLS);
 	debug_category_dtls_packet_id = ast_debug_category_register(AST_LOG_CATEGORY_DTLS_PACKET);
 	debug_category_ice_id = ast_debug_category_register(AST_LOG_CATEGORY_ICE);
+
+	/*
+	 * Normnally a core module should call ast_register_cleanup,
+	 * which doesn't run if any module fails to unload.  This
+	 * prevents resources being pulled out from under a running
+	 * module and possibly causing a segfault.  In this case however,
+	 * the only thing we're cleaning up are the registrations of the
+	 * debug categories.
+	 */
+	ast_register_atexit(rtp_engine_atexit);
 
 	return 0;
 }

--- a/main/stun.c
+++ b/main/stun.c
@@ -576,8 +576,17 @@ static void stun_shutdown(void)
 void ast_stun_init(void)
 {
 	ast_cli_register_multiple(cli_stun, sizeof(cli_stun) / sizeof(struct ast_cli_entry));
-	ast_register_cleanup(stun_shutdown);
-
 	debug_category_stun_id = ast_debug_category_register(AST_LOG_CATEGORY_STUN);
 	debug_category_stun_packet_id = ast_debug_category_register(AST_LOG_CATEGORY_STUN_PACKET);
+
+	/*
+	 * Normnally a core module should call ast_register_cleanup
+	 * which doesn't run if any module fails to unload.  This
+	 * prevents resources being pulled out from under a running
+	 * module and ppossibly causing a segfault.  In this case however,
+	 * the only thing we're cleaning up is the cli command and
+	 * the registers of the debug categories.
+	 */
+	ast_register_atexit(stun_shutdown);
+
 }


### PR DESCRIPTION
rtp_engine.c and stun.c were calling ast_register_cleanup which
is skipped if any loadable module can't be cleanly unloaded
when asterisk shuts down.  Since this will always be the case,
their cleanup functions never get run.  In a practical sense
this makes no difference since asterisk is shutting down but if
you're in development mode and trying to use the leak sanitizer,
the leaks from both of those modules clutter up the output.
