### PR TITLE
file.c, channel.c: Don't emit warnings if progress received.

### DIFF
--- a/main/channel.c
+++ b/main/channel.c
@@ -3311,6 +3311,7 @@ int ast_waitfordigit_full(struct ast_channel *c, int timeout_ms, const char *bre
 					ast_channel_clear_flag(c, AST_FLAG_END_DTMF_ONLY);
 					return res;
 				case AST_CONTROL_PVT_CAUSE_CODE:
+				case AST_CONTROL_PROGRESS:
 				case AST_CONTROL_RINGING:
 				case AST_CONTROL_ANSWER:
 				case AST_CONTROL_SRCUPDATE:

--- a/main/file.c
+++ b/main/file.c
@@ -1752,6 +1752,7 @@ static int waitstream_core(struct ast_channel *c,
 					ast_frfree(fr);
 					ast_channel_clear_flag(c, AST_FLAG_END_DTMF_ONLY);
 					return -1;
+				case AST_CONTROL_PROGRESS:
 				case AST_CONTROL_RINGING:
 				case AST_CONTROL_ANSWER:
 				case AST_CONTROL_VIDUPDATE:


### PR DESCRIPTION
Silently ignore AST_CONTROL_PROGRESS where appropriate, as most control frames already are.

Resolves: #696