### PR TITLE
app_queue.c: Properly handle invalid strategies from realtime.

### DIFF
--- a/apps/app_queue.c
+++ b/apps/app_queue.c
@@ -3487,7 +3487,7 @@ static void queue_set_param(struct call_queue *q, const char *param, const char 
 		if (strategy < 0) {
 			ast_log(LOG_WARNING, "'%s' isn't a valid strategy for queue '%s', using ringall instead\n",
 				val, q->name);
-			q->strategy = QUEUE_STRATEGY_RINGALL;
+			strategy = QUEUE_STRATEGY_RINGALL;
 		}
 		if (strategy == q->strategy) {
 			return;


### PR DESCRIPTION
The existing code sets the queue strategy to `ringall` but it is then immediately overwritten with an invalid one.

Fixes #707