### PR TITLE
tcptls/iostream:  Add support for setting SNI on client TLS connections

### DIFF
--- a/include/asterisk/iostream.h
+++ b/include/asterisk/iostream.h
@@ -107,6 +107,17 @@ void ast_iostream_set_timeout_sequence(struct ast_iostream *stream, struct timev
 void ast_iostream_set_exclusive_input(struct ast_iostream *stream, int exclusive_input);
 
 /*!
+ * \brief Set the iostream's SNI hostname for TLS client connections
+ *
+ * \param stream A pointer to an iostream
+ * \param sni_hostname The hostname to use for SNI when in client mode
+ *
+ * \retval 0 if the hostname was set successfully.
+ * \retval -1 if memory could not be allocated for the hostname.
+ */
+int ast_iostream_set_sni_hostname(struct ast_iostream *stream, const char *sni_hostname);
+
+/*!
  * \brief Get an iostream's file descriptor.
  *
  * \param stream A pointer to an iostream

--- a/main/tcptls.c
+++ b/main/tcptls.c
@@ -741,6 +741,13 @@ struct ast_tcptls_session_instance *ast_tcptls_client_create(struct ast_tcptls_s
 	/* Set current info */
 	ast_sockaddr_copy(&desc->old_address, &desc->remote_address);
 
+	if (!ast_strlen_zero(desc->hostname)) {
+		if (ast_iostream_set_sni_hostname(tcptls_session->stream, desc->hostname) != 0) {
+			ast_log(LOG_WARNING, "Unable to set SNI hostname '%s' on connection '%s'\n",
+				desc->hostname, desc->name);
+		}
+	}
+
 	return tcptls_session;
 
 error:


### PR DESCRIPTION
If the hostname field of the ast_tcptls_session_args structure is
set (which it is for websocket client connections), that hostname
will now automatically be used in an SNI TLS extension in the client
hello.

Resolves: #713

UserNote: Secure websocket client connections now send SNI in
the TLS client hello.
