### PR TITLE
stir_shaken:  Fix memory leak, typo in config, tn canonicalization

### DIFF
--- a/configs/samples/stir_shaken.conf.sample
+++ b/configs/samples/stir_shaken.conf.sample
@@ -413,7 +413,7 @@ Must be set to "profile"
 
 Default: none
 
--- endpoint_behhavior--------------------------------------------------
+-- endpoint_behavior--------------------------------------------------
 Actions to be performed for endpoints referencing this profile.
 Must be one of:
 - off -

--- a/res/res_pjsip_stir_shaken.c
+++ b/res/res_pjsip_stir_shaken.c
@@ -360,23 +360,7 @@ static char *get_dest_tn(pjsip_tx_data *tdata, const char *tag)
 			"%s: Failed to allocate memory for dest_tn\n", tag);
 	}
 
-	/* Remove everything except 0-9, *, and # in telephone number according to RFC 8224
-	 * (required by RFC 8225 as part of canonicalization) */
-	{
-		int i;
-		const char *s = uri->user.ptr;
-		char *new_tn = dest_tn;
-		/* We're only removing characters, if anything, so the buffer is guaranteed to be large enough */
-		for (i = 0; i < uri->user.slen; i++) {
-			if (isdigit(*s) || *s == '#' || *s == '*') { /* Only characters allowed */
-				*new_tn++ = *s;
-			}
-			s++;
-		}
-		*new_tn = '\0';
-		ast_trace(2, "Canonicalized telephone number " PJSTR_PRINTF_SPEC " -> %s\n",
-			PJSTR_PRINTF_VAR(uri->user), dest_tn);
-	}
+	ast_copy_pj_str(dest_tn, &uri->user, uri->user.slen + 1);
 
 	SCOPE_EXIT_RTN_VALUE(dest_tn, "%s: Done\n", tag);
 }

--- a/res/res_stir_shaken/common_config.h
+++ b/res/res_stir_shaken/common_config.h
@@ -564,5 +564,23 @@ int config_object_cli_show(void *obj, void *arg, void *data, int flags);
  */
 char *config_object_tab_complete_name(const char *word, struct ao2_container *container);
 
+/*!
+ * \brief Canonicalize a TN
+ *
+ * \param tn TN to canonicalize
+ * \param dest_tn Pointer to destination buffer to receive the new TN
+ *
+ * \retval dest_tn or NULL on failure
+ */
+char *canonicalize_tn(const char *tn, char *dest_tn);
+
+/*!
+ * \brief Canonicalize a TN into nre buffer
+ *
+ * \param tn TN to canonicalize
+ *
+ * \retval dest_tn (which must be freed with ast_free) or NULL on failure
+ */
+char *canonicalize_tn_alloc(const char *tn);
 
 #endif /* COMMON_CONFIG_H_ */

--- a/res/res_stir_shaken/tn_config.c
+++ b/res/res_stir_shaken/tn_config.c
@@ -122,6 +122,7 @@ struct tn_cfg *tn_get_etn(const char *id, struct profile_cfg *eprofile)
 	int rc = 0;
 
 	if (!tn || !eprofile || !etn) {
+		ao2_cleanup(etn);
 		return NULL;
 	}
 

--- a/res/res_stir_shaken/verification.c
+++ b/res/res_stir_shaken/verification.c
@@ -655,6 +655,8 @@ enum ast_stir_shaken_vs_response_code
 	RAII_VAR(struct ast_stir_shaken_vs_ctx *, ctx, NULL, ao2_cleanup);
 	RAII_VAR(struct profile_cfg *, profile, NULL, ao2_cleanup);
 	RAII_VAR(struct verification_cfg *, vs, NULL, ao2_cleanup);
+	RAII_VAR(char *, canon_caller_id , canonicalize_tn_alloc(caller_id), ast_free);
+
 	const char *t = S_OR(tag, S_COR(chan, ast_channel_name(chan), ""));
 	SCOPE_ENTER(3, "%s: Enter\n", t);
 
@@ -663,7 +665,7 @@ enum ast_stir_shaken_vs_response_code
 			LOG_ERROR, "%s: Must provide tag\n", t);
 	}
 
-	if (ast_strlen_zero(caller_id)) {
+	if (ast_strlen_zero(canon_caller_id)) {
 		SCOPE_EXIT_LOG_RTN_VALUE(AST_STIR_SHAKEN_VS_INVALID_ARGUMENTS,
 		LOG_ERROR, "%s: Must provide caller_id\n", t);
 	}
@@ -705,7 +707,7 @@ enum ast_stir_shaken_vs_response_code
 	}
 
 	ctx->chan = chan;
-	if (ast_string_field_set(ctx, caller_id, caller_id) != 0) {
+	if (ast_string_field_set(ctx, caller_id, canon_caller_id) != 0) {
 		SCOPE_EXIT_RTN_VALUE(AST_STIR_SHAKEN_VS_INTERNAL_ERROR);
 	}
 


### PR DESCRIPTION
* Fixed possible memory leak in tn_config:tn_get_etn() where we
weren't releasing etn if tn or eprofile were null.
* We now canonicalize TNs before using them for lookups or adding
them to Identity headers.
* Fixed a typo in stir_shaken.conf.sample.

Resolves: #716
