### PR TITLE
logger: Add unique verbose prefixes for levels 5-10.

### DIFF
--- a/include/asterisk/logger.h
+++ b/include/asterisk/logger.h
@@ -41,10 +41,16 @@ extern "C" {
 
 #define _A_ __FILE__, __LINE__, __FUNCTION__
 
-#define VERBOSE_PREFIX_1 " "
-#define VERBOSE_PREFIX_2 "  == "
-#define VERBOSE_PREFIX_3 "    -- "
-#define VERBOSE_PREFIX_4 "       > "
+#define VERBOSE_PREFIX_1  " "
+#define VERBOSE_PREFIX_2  "  == "
+#define VERBOSE_PREFIX_3  "    -- "
+#define VERBOSE_PREFIX_4  "       > "
+#define VERBOSE_PREFIX_5  "        > "
+#define VERBOSE_PREFIX_6  "         > "
+#define VERBOSE_PREFIX_7  "          > "
+#define VERBOSE_PREFIX_8  "           > "
+#define VERBOSE_PREFIX_9  "            > "
+#define VERBOSE_PREFIX_10 "             > "
 
 #define AST_CALLID_BUFFER_LENGTH 13
 
@@ -161,7 +167,7 @@ void __attribute__((format(printf, 5, 6))) ast_queue_log(const char *queuename, 
  * This will print the message to the console if the verbose level is set to a level >= 3
  *
  * Note the absence of a comma after the VERBOSE_PREFIX_3.  This is important.
- * VERBOSE_PREFIX_1 through VERBOSE_PREFIX_4 are defined.
+ * VERBOSE_PREFIX_1 through VERBOSE_PREFIX_10 are defined.
  *
  * \version 11 added level parameter
  */

--- a/main/asterisk.c
+++ b/main/asterisk.c
@@ -2164,7 +2164,19 @@ static void set_header(char *outbuf, int maxout, char level)
 		break;
 	case 3: cmp = VERBOSE_PREFIX_3;
 		break;
-	default: cmp = VERBOSE_PREFIX_4;
+	case 4: cmp = VERBOSE_PREFIX_4;
+		break;
+	case 5: cmp = VERBOSE_PREFIX_5;
+		break;
+	case 6: cmp = VERBOSE_PREFIX_6;
+		break;
+	case 7: cmp = VERBOSE_PREFIX_7;
+		break;
+	case 8: cmp = VERBOSE_PREFIX_8;
+		break;
+	case 9: cmp = VERBOSE_PREFIX_9;
+		break;
+	default: cmp = VERBOSE_PREFIX_10;
 		break;
 	}
 

--- a/main/logger.c
+++ b/main/logger.c
@@ -342,7 +342,19 @@ static int logger_add_verbose_magic(struct logmsg *logmsg, char *buf, size_t siz
 
 	/* For compatibility with modules still calling ast_verbose() directly instead of using ast_verb() */
 	if (logmsg->sublevel < 0) {
-		if (!strncmp(logmsg->message, VERBOSE_PREFIX_4, strlen(VERBOSE_PREFIX_4))) {
+		if (!strncmp(logmsg->message, VERBOSE_PREFIX_10, strlen(VERBOSE_PREFIX_10))) {
+			magic = -11;
+		} else if (!strncmp(logmsg->message, VERBOSE_PREFIX_9, strlen(VERBOSE_PREFIX_9))) {
+			magic = -10;
+		} else if (!strncmp(logmsg->message, VERBOSE_PREFIX_8, strlen(VERBOSE_PREFIX_8))) {
+			magic = -9;
+		} else if (!strncmp(logmsg->message, VERBOSE_PREFIX_7, strlen(VERBOSE_PREFIX_7))) {
+			magic = -8;
+		} else if (!strncmp(logmsg->message, VERBOSE_PREFIX_6, strlen(VERBOSE_PREFIX_6))) {
+			magic = -7;
+		} else if (!strncmp(logmsg->message, VERBOSE_PREFIX_5, strlen(VERBOSE_PREFIX_5))) {
+			magic = -6;
+		} else if (!strncmp(logmsg->message, VERBOSE_PREFIX_4, strlen(VERBOSE_PREFIX_4))) {
 			magic = -5;
 		} else if (!strncmp(logmsg->message, VERBOSE_PREFIX_3, strlen(VERBOSE_PREFIX_3))) {
 			magic = -4;


### PR DESCRIPTION
Add unique verbose prefixes for levels higher than 4, so that these can be visually differentiated from each other.

Resolves: #721