### PR TITLE
Revert "app_record: Add RECORD_TIME output variable."

### DIFF
--- a/apps/app_record.c
+++ b/apps/app_record.c
@@ -114,10 +114,6 @@
 					<value name="HANGUP">The channel was hung up.</value>
 					<value name="ERROR">An unrecoverable error occurred, which resulted in a WARNING to the logs.</value>
 				</variable>
-				<variable name="RECORD_TIME">
-					<para>Will be set to the duration of the recording, in milliseconds.</para>
-					<para>If the recording fails for whatever reason, this will still be set to 0.</para>
-				</variable>
 			</variablelist>
 		</description>
 	</application>
@@ -255,9 +251,6 @@ static int record_exec(struct ast_channel *chan, const char *data)
 	int ms;
 	struct timeval start;
 	const char *status_response = "ERROR";
-	char durationbuf[20];
-
-	pbx_builtin_setvar_helper(chan, "RECORD_TIME", "0"); /* Reset, in case already set */
 
 	/* The next few lines of code parse out the filename and header from the input string */
 	if (ast_strlen_zero(data)) { /* no data implies no filename or anything is present */
@@ -521,9 +514,6 @@ static int record_exec(struct ast_channel *chan, const char *data)
 		ast_channel_stop_silence_generator(chan, silgen);
 
 out:
-	snprintf(durationbuf, sizeof(durationbuf), "%ld", ast_tvdiff_ms(ast_tvnow(), start));
-	pbx_builtin_setvar_helper(chan, "RECORD_TIME", durationbuf);
-
 	if ((silence > 0) && rfmt) {
 		res = ast_set_read_format(chan, rfmt);
 		if (res) {


### PR DESCRIPTION
The original change was approved when it shouldn't have been based on further discussion after approval.

Reverts asterisk/asterisk#549