### PR TITLE
res/stasis/control.c: include signal.h

### DIFF
--- a/res/stasis/control.c
+++ b/res/stasis/control.c
@@ -41,6 +41,8 @@
 #include "asterisk/musiconhold.h"
 #include "asterisk/app.h"
 
+#include <signal.h>
+
 AST_LIST_HEAD(app_control_rules, stasis_app_control_rule);
 
 /*!


### PR DESCRIPTION
Include `signal.h` to avoid the following build failure with uclibc-ng raised since https://github.com/asterisk/asterisk/commit/2694792e13c7f3ab1911c4a69fba0df32c544177:

```
stasis/control.c: In function 'exec_command_on_condition': stasis/control.c:313:3: warning: implicit declaration of function 'pthread_kill'; did you mean 'pthread_yield'? [-Wimplicit-function-declaration]
  313 |   pthread_kill(control->control_thread, SIGURG);
      |   ^~~~~~~~~~~~
      |   pthread_yield
stasis/control.c:313:41: error: 'SIGURG' undeclared (first use in this function)
  313 |   pthread_kill(control->control_thread, SIGURG);
      |                                         ^~~~~~
```

Fixes:  #729