### PR TITLE
asterisk.c: Fix sending incorrect messages to systemd notify

### DIFF
--- a/main/asterisk.c
+++ b/main/asterisk.c
@@ -2050,7 +2050,7 @@ static void really_quit(int num, shutdown_nice_t niceness, int restart)
 		run_cleanups = 0;
 	}
 
-	if (!restart) {
+	if (!restart && !ast_opt_remote) {
 		ast_sd_notify("STOPPING=1");
 	}
 	if (ast_opt_console || (ast_opt_remote && !ast_opt_exec)) {

--- a/main/loader.c
+++ b/main/loader.c
@@ -1583,7 +1583,7 @@ enum ast_module_reload_result ast_module_reload(const char *name)
 		res = AST_MODULE_RELOAD_IN_PROGRESS;
 		goto module_reload_exit;
 	}
-	ast_sd_notify("RELOAD=1");
+	ast_sd_notify("RELOADING=1");
 	ast_lastreloadtime = ast_tvnow();
 
 	if (ast_opt_lock_confdir) {


### PR DESCRIPTION
Send "RELOADING=1" instead of "RELOAD=1" to follow the format expected by systemd (see sd_notify(3) man page).

Do not send STOPPING=1 in remote console mode:
attempting to execute ``asterisk -rx`` by the main process leads to a warning if NotifyAccess=main (the default) or to a forced termination if NotifyAccess=all.