### PR TITLE
configs: Fix a misleading IPv6 ACL example in Named ACLs

### DIFF
--- a/configs/samples/acl.conf.sample
+++ b/configs/samples/acl.conf.sample
@@ -73,7 +73,7 @@
 ;
 ; Named ACLs can use ipv6 addresses just like normal ACLs.
 ;[ipv6_example_1]
-;deny = ::
+;deny = ::/0
 ;permit = ::1/128
 ;
 ;[ipv6_example_2]


### PR DESCRIPTION
"deny=::" is equivalent to "::/128".
In order to mean "deny everything by default" it must be "::/0".