### PR TITLE
Enabling Real Time Text (RTT) for PJSIP library

### DIFF
--- a/channels/chan_pjsip.c
+++ b/channels/chan_pjsip.c
@@ -121,6 +121,7 @@ struct ast_channel_tech chan_pjsip_tech = {
 	.read_stream = chan_pjsip_read_stream,
 	.write = chan_pjsip_write,
 	.write_stream = chan_pjsip_write_stream,
+	.write_text = chan_pjsip_write,
 	.exception = chan_pjsip_read_stream,
 	.indicate = chan_pjsip_indicate,
 	.transfer = chan_pjsip_transfer,
@@ -1017,6 +1018,22 @@ static int chan_pjsip_write_stream(struct ast_channel *ast, int stream_num, stru
 		break;
 	case AST_FRAME_CNG:
 		break;
+	case AST_FRAME_TEXT:
+		if (!media) {
+			return 0;
+		}
+		else if (media->type != AST_MEDIA_TYPE_TEXT) {
+			ast_debug(3, "Channel %s stream %d is of type '%s', not text!\n",
+				ast_channel_name(ast), stream_num, ast_codec_media_type2str(media->type));
+			return 0;
+		}
+		else if (session->endpoint->media.red_enabled) {
+			ast_rtp_red_buffer(media->rtp, frame);
+		}
+		else if (media->write_callback) {
+			res = media->write_callback(session, media, frame);
+		}
+		break;
 	case AST_FRAME_RTCP:
 		/* We only support writing out feedback */
 		if (frame->subclass.integer != AST_RTP_RTCP_PSFB || !media) {
@@ -1039,6 +1056,9 @@ static int chan_pjsip_write_stream(struct ast_channel *ast, int stream_num, stru
 
 static int chan_pjsip_write(struct ast_channel *ast, struct ast_frame *frame)
 {
+	if (frame->frametype == AST_FRAME_TEXT && frame->stream_num != -1) {
+		return chan_pjsip_write_stream(ast, frame->stream_num, frame);
+	}
 	return chan_pjsip_write_stream(ast, -1, frame);
 }
 

--- a/channels/pjsip/dialplan_functions.c
+++ b/channels/pjsip/dialplan_functions.c
@@ -91,6 +91,9 @@ static int channel_read_rtp(struct ast_channel *chan, const char *type, const ch
 		media = session->active_media_state->default_session[AST_MEDIA_TYPE_AUDIO];
 	} else if (!strcmp(field, "video")) {
 		media = session->active_media_state->default_session[AST_MEDIA_TYPE_VIDEO];
+	}
+	else if (ast_strlen_zero(field) || !strcmp(field, "text")) {
+		media = session->active_media_state->default_session[AST_MEDIA_TYPE_TEXT];
 	} else {
 		ast_log(AST_LOG_WARNING, "Unknown media type field '%s' for 'rtp' information\n", field);
 		return -1;

--- a/include/asterisk/res_pjsip.h
+++ b/include/asterisk/res_pjsip.h
@@ -929,6 +929,12 @@ struct ast_sip_endpoint_media_configuration {
 	unsigned int tos_video;
 	/*! Priority for video streams */
 	unsigned int cos_video;
+	/*! DSCP TOS bits for text streams */
+	unsigned int tos_text;
+	/*! Priority for text streams */
+	unsigned int cos_text;
+	/*! DSCP indicate if text stream supports RED */
+	unsigned int red_enabled;
 	/*! Is g.726 packed in a non standard way */
 	unsigned int g726_non_standard;
 	/*! Bind the RTP instance to the media_address */
@@ -939,6 +945,8 @@ struct ast_sip_endpoint_media_configuration {
 	unsigned int max_audio_streams;
 	/*! Maximum number of video streams to offer/accept */
 	unsigned int max_video_streams;
+	/*! Maximum number of text streams to offer/accept */
+	unsigned int max_text_streams;
 	/*! Use BUNDLE */
 	unsigned int bundle;
 	/*! Enable webrtc settings and defaults */

--- a/main/channel.c
+++ b/main/channel.c
@@ -4776,6 +4776,7 @@ int ast_sendtext_data(struct ast_channel *chan, struct ast_msg_data *msg)
 		f.frametype = AST_FRAME_TEXT;
 		f.datalen = body_len;
 		f.mallocd = AST_MALLOCD_DATA;
+		f.stream_num = ast_stream_get_position(ast_channel_get_default_stream(chan, AST_MEDIA_TYPE_TEXT));
 		f.data.ptr = ast_strdup(body);
 		if (f.data.ptr) {
 			res = ast_channel_tech(chan)->write_text(chan, &f);

--- a/main/frame.c
+++ b/main/frame.c
@@ -313,7 +313,7 @@ struct ast_frame *__ast_frdup(const struct ast_frame *f, const char *file, int l
 #endif
 
 	/* Start with standard stuff */
-	len = sizeof(*out) + AST_FRIENDLY_OFFSET + f->datalen;
+	len = sizeof(*out) + AST_FRIENDLY_OFFSET + f->datalen + 1;
 	/* If we have a source, add space for it */
 	/*
 	 * XXX Watch out here - if we receive a src which is not terminated
@@ -374,13 +374,16 @@ struct ast_frame *__ast_frdup(const struct ast_frame *f, const char *file, int l
 	if (out->datalen || f->frametype == AST_FRAME_TEXT) {
 		out->data.ptr = buf + sizeof(*out) + AST_FRIENDLY_OFFSET;
 		memcpy(out->data.ptr, f->data.ptr, out->datalen);
+		if (f->frametype == AST_FRAME_TEXT) {
+			((char*)out->data.ptr)[out->datalen] = '\0';
+		}
 	} else {
 		out->data.uint32 = f->data.uint32;
 	}
 	if (srclen > 0) {
 		/* This may seem a little strange, but it's to avoid a gcc (4.2.4) compiler warning */
 		char *src;
-		out->src = buf + sizeof(*out) + AST_FRIENDLY_OFFSET + f->datalen;
+		out->src = buf + sizeof(*out) + AST_FRIENDLY_OFFSET + f->datalen + 1;
 		src = (char *) out->src;
 		/* Must have space since we allocated for it */
 		strcpy(src, f->src);

--- a/res/res_pjsip/pjsip_configuration.c
+++ b/res/res_pjsip/pjsip_configuration.c
@@ -1072,6 +1072,8 @@ static int tos_handler(const struct aco_option *opt,
 		endpoint->media.tos_audio = value;
 	} else if (!strcmp(var->name, "tos_video")) {
 		endpoint->media.tos_video = value;
+	} else if (!strcmp(var->name, "tos_text")) {
+		endpoint->media.tos_text = value;
 	} else {
 		/* If we reach this point, someone called the tos_handler when they shouldn't have. */
 		ast_assert(0);
@@ -1096,6 +1098,16 @@ static int tos_video_to_str(const void *obj, const intptr_t *args, char **buf)
 
 	if (ast_asprintf(buf, "%u", endpoint->media.tos_video) == -1) {
 		return -1;
+	}
+	return 0;
+}
+
+static int tos_text_to_str(const void* obj, const intptr_t * args, char** buf)
+{
+	const struct ast_sip_endpoint* endpoint = obj;
+	
+	if (ast_asprintf(buf, "%u", endpoint->media.tos_text) == -1) {
+		return -1;	
 	}
 	return 0;
 }
@@ -2234,8 +2246,10 @@ int ast_res_pjsip_initialize_configuration(void)
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "sdp_session", "Asterisk", OPT_STRINGFIELD_T, 0, STRFLDSET(struct ast_sip_endpoint, media.sdpsession));
 	ast_sorcery_object_field_register_custom(sip_sorcery, "endpoint", "tos_audio", "0", tos_handler, tos_audio_to_str, NULL, 0, 0);
 	ast_sorcery_object_field_register_custom(sip_sorcery, "endpoint", "tos_video", "0", tos_handler, tos_video_to_str, NULL, 0, 0);
+	ast_sorcery_object_field_register_custom(sip_sorcery, "endpoint", "tos_text", "0", tos_handler, tos_text_to_str, NULL, 0, 0);
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "cos_audio", "0", OPT_UINT_T, 0, FLDSET(struct ast_sip_endpoint, media.cos_audio));
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "cos_video", "0", OPT_UINT_T, 0, FLDSET(struct ast_sip_endpoint, media.cos_video));
+	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "cos_text", "5", OPT_UINT_T, 0, FLDSET(struct ast_sip_endpoint, media.cos_text));
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "allow_subscribe", "yes", OPT_BOOL_T, 1, FLDSET(struct ast_sip_endpoint, subscription.allow));
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "sub_min_expiry", "0", OPT_UINT_T, 0, FLDSET(struct ast_sip_endpoint, subscription.minexpiry));
 	ast_sorcery_object_field_register_custom(sip_sorcery, "endpoint", "from_user", "", from_user_handler, from_user_to_str, NULL, 0, 0);
@@ -2276,6 +2290,7 @@ int ast_res_pjsip_initialize_configuration(void)
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "notify_early_inuse_ringing", "no", OPT_BOOL_T, 1, FLDSET(struct ast_sip_endpoint, notify_early_inuse_ringing));
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "max_audio_streams", "1", OPT_UINT_T, 0, FLDSET(struct ast_sip_endpoint, media.max_audio_streams));
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "max_video_streams", "1", OPT_UINT_T, 0, FLDSET(struct ast_sip_endpoint, media.max_video_streams));
+	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "max_text_streams", "1", OPT_UINT_T, 0, FLDSET(struct ast_sip_endpoint, media.max_text_streams));
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "bundle", "no", OPT_BOOL_T, 1, FLDSET(struct ast_sip_endpoint, media.bundle));
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "webrtc", "no", OPT_YESNO_T, 1, FLDSET(struct ast_sip_endpoint, media.webrtc));
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "incoming_mwi_mailbox", "", OPT_STRINGFIELD_T, 0, STRFLDSET(struct ast_sip_endpoint, incoming_mwi_mailbox));

--- a/res/res_pjsip_sdp_rtp.c
+++ b/res/res_pjsip_sdp_rtp.c
@@ -67,6 +67,7 @@ static struct ast_sockaddr address_rtp;
 
 static const char STR_AUDIO[] = "audio";
 static const char STR_VIDEO[] = "video";
+static const char STR_TEXT[] = "text";
 
 static int send_keepalive(const void *data)
 {
@@ -290,6 +291,10 @@ static int create_rtp(struct ast_sip_session *session, struct ast_sip_session_me
 			(session->endpoint->media.tos_audio || session->endpoint->media.cos_audio)) {
 		ast_rtp_instance_set_qos(session_media->rtp, session->endpoint->media.tos_audio,
 				session->endpoint->media.cos_audio, "SIP RTP Audio");
+	} else if (session_media->type == AST_MEDIA_TYPE_TEXT) {
+		if (session->endpoint->media.tos_text || session->endpoint->media.cos_text) {
+			ast_rtp_instance_set_qos(session_media->rtp, session->endpoint->media.tos_text,
+				session->endpoint->media.cos_text, "SIP RTP Text");
 	} else if (session_media->type == AST_MEDIA_TYPE_VIDEO) {
 		ast_rtp_instance_set_prop(session_media->rtp, AST_RTP_PROPERTY_RETRANS_RECV, session->endpoint->media.webrtc);
 		ast_rtp_instance_set_prop(session_media->rtp, AST_RTP_PROPERTY_RETRANS_SEND, session->endpoint->media.webrtc);
@@ -365,6 +370,32 @@ static void get_codecs(struct ast_sip_session *session, const struct pjmedia_sdp
 				struct ast_format *format_parsed;
 
 				ast_copy_pj_str(fmt_param, &fmtp.fmt_param, sizeof(fmt_param));
+
+				if (strncasecmp(name, "RED", 3) == 0)
+					 {
+					int red_data_pt[10];		/* For T.140 RED */
+					char red_cp_data[30];
+					char* red_cp = red_cp_data;
+					char* rest = NULL;
+					int red_num_gen = -1;
+
+					strcpy(red_cp, fmt_param);
+					red_cp = strtok_r(red_cp, "/", &rest);
+					while (red_cp && (red_num_gen)++ < AST_RED_MAX_GENERATION) {
+						sscanf(red_cp, "%30u", (unsigned*)&red_data_pt[red_num_gen]);
+						red_cp = strtok_r(NULL, "/", &rest);	
+					}
+						if (red_num_gen > 0) {
+						session->endpoint->media.red_enabled = 1;
+						ast_rtp_red_init(session_media->rtp, 300, red_data_pt, red_num_gen);
+					}
+					else {
+						session->endpoint->media.red_enabled = 0;				
+					}
+						}
+				else {
+					session->endpoint->media.red_enabled = 0;
+				}
 
 				format_parsed = ast_format_parse_sdp_fmtp(format, fmt_param);
 				if (format_parsed) {
@@ -538,8 +569,6 @@ static int set_caps(struct ast_sip_session *session,
 			ast_codec_media_type2str(session_media->type),
 			ast_format_cap_get_names(caps, &usbuf),
 			ast_format_cap_get_names(peer, &thembuf));
-	} else {
-		ast_rtp_codecs_set_preferred_format(&codecs, ast_format_cap_get_format(joint, 0));
 	}
 
 	if (is_offer) {
@@ -561,7 +590,7 @@ static int set_caps(struct ast_sip_session *session,
 			AST_MEDIA_TYPE_UNKNOWN);
 		ast_format_cap_remove_by_type(caps, media_type);
 
-		if (session->endpoint->preferred_codec_only) {
+		if (session->endpoint->preferred_codec_only){
 			struct ast_format *preferred_fmt = ast_format_cap_get_format(joint, 0);
 			ast_format_cap_append(caps, preferred_fmt, 0);
 			ao2_ref(preferred_fmt, -1);
@@ -640,42 +669,6 @@ static pjmedia_sdp_attr* generate_rtpmap_attr(struct ast_sip_session *session, p
 
 	rtpmap.pt = media->desc.fmt[media->desc.fmt_count - 1];
 	rtpmap.clock_rate = ast_rtp_lookup_sample_rate2(asterisk_format, format, code);
-	pj_strdup2(pool, &rtpmap.enc_name, ast_rtp_lookup_mime_subtype2(asterisk_format, format, code, options));
-	if (!pj_stricmp2(&rtpmap.enc_name, "opus")) {
-		pj_cstr(&rtpmap.param, "2");
-	} else {
-		pj_cstr(&rtpmap.param, NULL);
-	}
-
-	pjmedia_sdp_rtpmap_to_attr(pool, &rtpmap, &attr);
-
-	return attr;
-}
-
-
-static pjmedia_sdp_attr* generate_rtpmap_attr2(struct ast_sip_session *session, pjmedia_sdp_media *media, pj_pool_t *pool,
-					      int rtp_code, int asterisk_format, struct ast_format *format, int code, int sample_rate)
-{
-#ifndef HAVE_PJSIP_ENDPOINT_COMPACT_FORM
-	extern pj_bool_t pjsip_use_compact_form;
-#else
-	pj_bool_t pjsip_use_compact_form = pjsip_cfg()->endpt.use_compact_form;
-#endif
-	pjmedia_sdp_rtpmap rtpmap;
-	pjmedia_sdp_attr *attr = NULL;
-	char tmp[64];
-	enum ast_rtp_options options = session->endpoint->media.g726_non_standard ?
-		AST_RTP_OPT_G726_NONSTANDARD : 0;
-
-	snprintf(tmp, sizeof(tmp), "%d", rtp_code);
-	pj_strdup2(pool, &media->desc.fmt[media->desc.fmt_count++], tmp);
-
-	if (rtp_code <= AST_RTP_PT_LAST_STATIC && pjsip_use_compact_form) {
-		return NULL;
-	}
-
-	rtpmap.pt = media->desc.fmt[media->desc.fmt_count - 1];
-	rtpmap.clock_rate = sample_rate;
 	pj_strdup2(pool, &rtpmap.enc_name, ast_rtp_lookup_mime_subtype2(asterisk_format, format, code, options));
 	if (!pj_stricmp2(&rtpmap.enc_name, "opus")) {
 		pj_cstr(&rtpmap.param, "2");
@@ -1787,13 +1780,6 @@ static int create_outgoing_sdp_stream(struct ast_sip_session *session, struct as
 	pj_sockaddr ip;
 	int direct_media_enabled = !ast_sockaddr_isnull(&session_media->direct_media_addr) &&
 		ast_format_cap_count(session->direct_media_cap);
-
-	/* Keep track of the sample rates for offered codecs so we can build matching
-	   RFC 2833/4733 payload offers. */
-	AST_VECTOR(, int) sample_rates;
-	/* In case we can't init the sample rates, still try to do the rest. */
-	int build_dtmf_sample_rates = 1;
-
 	SCOPE_ENTER(1, "%s Type: %s %s\n", ast_sip_session_get_name(session),
 		ast_codec_media_type2str(media_type), ast_str_tmp(128, ast_stream_to_str(stream, &STR_TMP)));
 
@@ -1945,12 +1931,6 @@ static int create_outgoing_sdp_stream(struct ast_sip_session *session, struct as
 		ast_format_cap_append_from_cap(caps, ast_stream_get_formats(stream), media_type);
 	}
 
-	/* Init the sample rates before we start adding them. Assume we will have at least one. */
-	if (AST_VECTOR_INIT(&sample_rates, 1)) {
-		ast_log(LOG_ERROR, "Unable to add dtmf formats to SDP!\n");
-		build_dtmf_sample_rates = 0;
-	}
-
 	for (index = 0; index < ast_format_cap_count(caps); ++index) {
 		struct ast_format *format = ast_format_cap_get_format(caps, index);
 
@@ -1989,24 +1969,7 @@ static int create_outgoing_sdp_stream(struct ast_sip_session *session, struct as
 		}
 
 		if ((attr = generate_rtpmap_attr(session, media, pool, rtp_code, 1, format, 0))) {
-			int newrate = ast_rtp_lookup_sample_rate2(1, format, 0);
-			int i, added = 0;
 			media->attr[media->attr_count++] = attr;
-
-			if (build_dtmf_sample_rates) {
-				for (i = 0; i < AST_VECTOR_SIZE(&sample_rates); i++) {
-					/* Only add if we haven't already processed this sample rate. For instance
-						A-law and u-law 'share' one 8K DTMF payload type. */
-					if (newrate == AST_VECTOR_GET(&sample_rates, i)) {
-						added = 1;
-						break;
-					}
-				}
-
-				if (!added) {
-					AST_VECTOR_APPEND(&sample_rates, newrate);
-				}
-			}
 		}
 
 		if ((attr = generate_fmtp_attr(pool, format, rtp_code))) {
@@ -2031,38 +1994,20 @@ static int create_outgoing_sdp_stream(struct ast_sip_session *session, struct as
 			if (!(noncodec & index)) {
 				continue;
 			}
+			rtp_code = ast_rtp_codecs_payload_code(
+				ast_rtp_instance_get_codecs(session_media->rtp), 0, NULL, index);
+			if (rtp_code == -1) {
+				continue;
+			}
 
+			if ((attr = generate_rtpmap_attr(session, media, pool, rtp_code, 0, NULL, index))) {
+				media->attr[media->attr_count++] = attr;
+			}
 
-			if (index != AST_RTP_DTMF) {
-				rtp_code = ast_rtp_codecs_payload_code(
-								ast_rtp_instance_get_codecs(session_media->rtp), 0, NULL, index);
-				if (rtp_code == -1) {
-					continue;
-				} else if ((attr = generate_rtpmap_attr(session, media, pool, rtp_code, 0, NULL, index))) {
-					media->attr[media->attr_count++] = attr;
-				}
-			} else if (build_dtmf_sample_rates) {
-				/*
-				 * Walk through the possible bitrates for the RFC 2833/4733 digits and generate the rtpmap
-				 * attributes.
-				 */
-				int i;
-				for (i = 0; i < AST_VECTOR_SIZE(&sample_rates); i++) {
-					rtp_code = ast_rtp_codecs_payload_code_sample_rate(
-									ast_rtp_instance_get_codecs(session_media->rtp), 0, NULL, index, AST_VECTOR_GET(&sample_rates, i));
-
-					if (rtp_code == -1) {
-						continue;
-					}
-
-					if ((attr = generate_rtpmap_attr2(session, media, pool, rtp_code, 0, NULL, index, AST_VECTOR_GET(&sample_rates, i)))) {
-						media->attr[media->attr_count++] = attr;
-						snprintf(tmp, sizeof(tmp), "%d 0-16", (rtp_code));
-						attr = pjmedia_sdp_attr_create(pool, "fmtp", pj_cstr(&stmp, tmp));
-						media->attr[media->attr_count++] = attr;
-
-					}
-				}
+			if (index == AST_RTP_DTMF) {
+				snprintf(tmp, sizeof(tmp), "%d 0-16", rtp_code);
+				attr = pjmedia_sdp_attr_create(pool, "fmtp", pj_cstr(&stmp, tmp));
+				media->attr[media->attr_count++] = attr;
 			}
 
 			if (media->desc.fmt_count == PJMEDIA_MAX_SDP_FMT) {
@@ -2071,8 +2016,6 @@ static int create_outgoing_sdp_stream(struct ast_sip_session *session, struct as
 		}
 	}
 
-	/* we are done with the sample rates */
-	AST_VECTOR_FREE(&sample_rates);
 
 	/* If no formats were actually added to the media stream don't add it to the SDP */
 	if (!media->desc.fmt_count) {
@@ -2415,6 +2358,17 @@ static struct ast_sip_session_sdp_handler video_sdp_handler = {
 	.stream_destroy = stream_destroy,
 };
 
+/*! \brief SDP handler for 'text' media stream */
+static struct ast_sip_session_sdp_handler text_sdp_handler = {
+	.id = STR_TEXT,
+	.negotiate_incoming_sdp_stream = negotiate_incoming_sdp_stream,
+	.create_outgoing_sdp_stream = create_outgoing_sdp_stream,
+	.apply_negotiated_sdp_stream = apply_negotiated_sdp_stream,
+	.change_outgoing_sdp_stream_media_address = change_outgoing_sdp_stream_media_address,
+	.stream_stop = stream_stop,
+	.stream_destroy = stream_destroy,
+};
+
 static int video_info_incoming_request(struct ast_sip_session *session, struct pjsip_rx_data *rdata)
 {
 	struct pjsip_transaction *tsx;
@@ -2448,6 +2402,7 @@ static int unload_module(void)
 	ast_sip_session_unregister_supplement(&video_info_supplement);
 	ast_sip_session_unregister_sdp_handler(&video_sdp_handler, STR_VIDEO);
 	ast_sip_session_unregister_sdp_handler(&audio_sdp_handler, STR_AUDIO);
+	ast_sip_session_unregister_sdp_handler(&text_sdp_handler, STR_TEXT);
 
 	if (sched) {
 		ast_sched_context_destroy(sched);
@@ -2491,6 +2446,11 @@ static int load_module(void)
 
 	if (ast_sip_session_register_sdp_handler(&video_sdp_handler, STR_VIDEO)) {
 		ast_log(LOG_ERROR, "Unable to register SDP handler for %s stream type\n", STR_VIDEO);
+		goto end;
+	}
+
+	if (ast_sip_session_register_sdp_handler(&text_sdp_handler, STR_TEXT)) {
+		ast_log(LOG_ERROR, "Unable to register SDP handler for %s stream type\n", STR_TEXT);
 		goto end;
 	}
 

--- a/res/res_pjsip_session.c
+++ b/res/res_pjsip_session.c
@@ -608,8 +608,9 @@ static int is_stream_limitation_reached(enum ast_media_type type, const struct a
 	case AST_MEDIA_TYPE_IMAGE:
 		/* We don't have an option for image (T.38) streams so cap it to one. */
 		return (type_streams[type] > 0);
-	case AST_MEDIA_TYPE_UNKNOWN:
 	case AST_MEDIA_TYPE_TEXT:
+		return !(type_streams[type] < endpoint->media.max_text_streams);
+	case AST_MEDIA_TYPE_UNKNOWN:
 	default:
 		/* We don't want any unknown or "other" streams on our endpoint,
 		 * so always just say we've reached the limit


### PR DESCRIPTION
Implement changes based on archived issue: https://issues-archive.asterisk.org/ASTERISK-28654

Changes are:
1. chan_pjsip - added write_text function to the pjsip_tech driver
Added case for AST_FRAME_TEXT in chan_pjsip_write_stream
Added case to handle text in chan_pjsip_write
2. pjsip/dialplan_functions.c: added logic to handle media for TEXT
3.  res_pjsip.h: added variables to deal with endpoint media
4. channel.c: added  logic to add a stream_num for a frame
5.  frame.c: added code to handle and fix issues with red.
6. res_pjsip_sdp_rtp.c: added logic to setup SDP.
Added logic to handle tos and cos text
Added logic to RED for red enabled
7. res_pjsip_session.c: aded logic for max_text_streams
8. res_rtp_asterisk.c: Added logic to hanle Red and dealing with
a repeating RTP issue
9. pjsip_configuration.c: Added logic to handle text for PJSIP library

NB! I am not the ORIGINAL AUTHOR of these changes, I have only implemented the changes as these are missing from the source code and can be a lot of value for someone interested in RTT. (i.e me).

Original code-review can be found here:
http://lists.digium.com/pipermail/asterisk-code-review/2019-December/094886.html
