### PR TITLE
asterisk.c: Don't log an error if .asterisk_history does not exist.

### DIFF
--- a/main/asterisk.c
+++ b/main/asterisk.c
@@ -3182,7 +3182,12 @@ static int ast_el_read_history(const char *filename)
 		ast_el_initialize();
 	}
 
-	return history(el_hist, &ev, H_LOAD, filename);
+	if (access(filename, F_OK) == 0) {
+		return history(el_hist, &ev, H_LOAD, filename);
+	}
+
+	/* If the history file doesn't exist, failing to read it is unremarkable. */
+	return 0;
 }
 
 static void process_histfile(int (*readwrite)(const char *filename))


### PR DESCRIPTION
Fixes #751