### PR TITLE
Show configured cache dir

### DIFF
--- a/main/asterisk.c
+++ b/main/asterisk.c
@@ -596,6 +596,7 @@ static char *handle_show_settings(struct ast_cli_entry *e, int cmd, struct ast_c
 	ast_cli(a->fd, "  ASTDB:                       %s\n", ast_config_AST_DB);
 	ast_cli(a->fd, "  IAX2 Keys directory:         %s\n", ast_config_AST_KEY_DIR);
 	ast_cli(a->fd, "  AGI Scripts directory:       %s\n", ast_config_AST_AGI_DIR);
+	ast_cli(a->fd, "  Cache directory:             %s\n", ast_config_AST_CACHE_DIR);
 	ast_cli(a->fd, "\n\n");
 	return CLI_SUCCESS;
 }


### PR DESCRIPTION
Since Asterisk 19 it is possible to cache recorded files into another directory [1] [2].
Show configured location of cache dir in CLI's core show settings.

[1] ASTERISK-29143
[2] b08427134fd51bb549f198e9f60685f2680c68d7