### PR TITLE
app_queue:  Add option to not log Restricted Caller ID to queue_log

### DIFF
--- a/configs/samples/queues.conf.sample
+++ b/configs/samples/queues.conf.sample
@@ -51,6 +51,13 @@ monitor-type = MixMonitor
 ;
 ;log_membername_as_agent = no
 ;
+; log-restricted-caller-id controls whether the Restricted Caller ID will be stored
+; in the queue log.
+; If log-restricted-caller-id=no then the Caller ID will be stripped if the Caller ID
+; is restricted.
+; Default is 'yes', which means the Caller ID is always stored.
+;log-restricted-caller-id = yes
+;
 ; force_longest_waiting_caller will cause app_queue to make sure callers are offered
 ; in order (longest waiting first), even for callers across multiple queues.
 ; Before a call is offered to an agent, an additional check is made to see if the agent

--- a/contrib/ast-db-manage/config/versions/2b7c507d7d12_add_queue_log_option_log_restricted_.py
+++ b/contrib/ast-db-manage/config/versions/2b7c507d7d12_add_queue_log_option_log_restricted_.py
@@ -1,0 +1,34 @@
+"""add queue_log option log-restricted-caller-id
+
+Revision ID: 2b7c507d7d12
+Revises: bd9c5159c7ea
+Create Date: 2024-06-12 17:00:16.841343
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '2b7c507d7d12'
+down_revision = 'bd9c5159c7ea'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import ENUM
+
+AST_BOOL_NAME = 'ast_bool_values'
+AST_BOOL_VALUES = [ '0', '1',
+                    'off', 'on',
+                    'false', 'true',
+                    'no', 'yes' ]
+
+
+def upgrade():
+    # Create the new enum
+    ast_bool_values = ENUM(*AST_BOOL_VALUES, name=AST_BOOL_NAME, create_type=False)
+    if op.get_context().bind.dialect.name == 'postgresql':
+        ast_bool_values.create(op.get_bind(), checkfirst=False)
+
+    op.add_column('queues', sa.Column('log_restricted_caller_id', ast_bool_values))
+
+
+def downgrade():
+    op.drop_column('queues', 'log_restricted_caller_id')


### PR DESCRIPTION
Add a queue option log-restricted-caller-id to strip the Caller ID when storing the ENTERQUEUE event
in the queue log if the Caller ID is restricted.

Resolves: #765

UpgradeNote: Add a new column to the queues table:
queue_log_option_log_restricted ENUM('0','1','off','on','false','true','no','yes')
to control whether the Restricted Caller ID will be stored in the queue log.

UserNote: Add a Queue option log-restricted-caller-id to control whether the Restricted Caller ID
will be stored in the queue log.
If log-restricted-caller-id=no then the Caller ID will be stripped if the Caller ID is restricted.
