### PR TITLE
pbx.c: expand fields width of "core show hints"

### DIFF
--- a/main/pbx.c
+++ b/main/pbx.c
@@ -5198,7 +5198,7 @@ static char *handle_show_hints(struct ast_cli_entry *e, int cmd, struct ast_cli_
 			ast_get_extension_name(hint->exten),
 			ast_get_context_name(ast_get_extension_context(hint->exten)));
 
-		ast_cli(a->fd, "%-20.20s: %-20.20s  State:%-15.15s Presence:%-15.15s Watchers %2d\n",
+		ast_cli(a->fd, "%-30.30s: %-60.60s  State:%-15.15s Presence:%-15.15s Watchers %2d\n",
 			buf,
 			ast_get_extension_app(hint->exten),
 			ast_extension_state2str(hint->laststate),
@@ -5299,7 +5299,7 @@ static char *handle_show_hint(struct ast_cli_entry *e, int cmd, struct ast_cli_a
 			sprintf(buf, "%s@%s",
 				ast_get_extension_name(hint->exten),
 				ast_get_context_name(ast_get_extension_context(hint->exten)));
-			ast_cli(a->fd, "%-20.20s: %-20.20s  State:%-15.15s Presence:%-15.15s Watchers %2d\n",
+			ast_cli(a->fd, "%-30.30s: %-60.60s  State:%-15.15s Presence:%-15.15s Watchers %2d\n",
 				buf,
 				ast_get_extension_app(hint->exten),
 				ast_extension_state2str(hint->laststate),


### PR DESCRIPTION
The current width for "extension" is 20 and "device state id" is 20, which is too small.
The "extension" field contains "ext"@"context", so 20 characters is not enough.
The "device state id" field, for example for Queue pause state contains Queue:"queue_name"_pause_PSJIP/"endpoint", so the 20 characters is not enough.

Increase the width of "extension" field to 30 characters and the width of the "device state id" field to 60 characters.

Resolves: https://github.com/asterisk/asterisk/issues/770

UserNote: The fields width of "core show hints" were increased.
The width of "extension" field to 30 characters and
the width of the "device state id" field to 60 characters.