### PR TITLE
res_pjsip_sdp_rtp: Add support for default/mismatched 8K RFC 4733/2833 digits

### DIFF
--- a/include/asterisk/rtp_engine.h
+++ b/include/asterisk/rtp_engine.h
@@ -106,6 +106,9 @@ extern "C" {
  */
 #define MAX_CHANNEL_ID 152
 
+/*!< DTMF samples per second */
+#define DEFAULT_DTMF_SAMPLE_RATE_MS    8000
+
 struct ast_rtp_instance;
 struct ast_rtp_glue;
 


### PR DESCRIPTION
After change made in 624f509 to add support for non 8K RFC 4733/2833 digits,
Asterisk would only accept RFC 4733/2833 offers that matched the sample rate of
the negotiated codec(s).

This change allows Asterisk to accept 8K RFC 4733/2833 offers if the UAC
offfers 8K RFC 4733/2833 but negotiates for a non 8K bitrate codec.

A number of corresponding tests in tests/channels/pjsip/dtmf_sdp also needed to
be re-written to allow for these scenarios.

Fixes: #776
