### PR TITLE
logger.h: Include SCOPE_CALL_WITH_INT_RESULT() in non-dev-mode builds.

### DIFF
--- a/include/asterisk/logger.h
+++ b/include/asterisk/logger.h
@@ -1020,6 +1020,9 @@ unsigned long _ast_trace_dec_indent(void);
 #define SCOPE_CALL_WITH_RESULT(level, __var, __funcname, ...) \
 	__var = __funcname(__VA_ARGS__)
 
+#define SCOPE_CALL_WITH_INT_RESULT(level, __funcname, ...) \
+	__funcname(__VA_ARGS__)
+
 #define SCOPE_EXIT(...) \
 	ast_debug(__scope_level, " " __VA_ARGS__)
 


### PR DESCRIPTION
Fixes #785