### PR TITLE
security_agreement.c: Always add the Require and Proxy-Require headers

### DIFF
--- a/res/res_pjsip/security_agreements.c
+++ b/res/res_pjsip/security_agreements.c
@@ -290,6 +290,8 @@ int ast_sip_add_security_headers(struct ast_sip_security_mechanism_vector *secur
 	int mech_cnt;
 	int i;
 	int add_qvalue = 1;
+	static const pj_str_t proxy_require = { "Proxy-Require", 13 };
+	static const pj_str_t require = { "Require", 7 };
 
 	if (!security_mechanisms || !tdata) {
 		return EINVAL;
@@ -313,6 +315,13 @@ int ast_sip_add_security_headers(struct ast_sip_security_mechanism_vector *secur
 		}
 		ast_sip_add_header(tdata, header_name, buf);
 		ast_free(buf);
+	}
+
+	if (pjsip_msg_find_hdr_by_name(tdata->msg, &require, NULL) == NULL) {
+		ast_sip_add_header(tdata, "Require", "mediasec");
+	}
+	if (pjsip_msg_find_hdr_by_name(tdata->msg, &proxy_require, NULL) == NULL) {
+		ast_sip_add_header(tdata, "Proxy-Require", "mediasec");
 	}
 	return 0;
 }

--- a/res/res_pjsip_outbound_registration.c
+++ b/res/res_pjsip_outbound_registration.c
@@ -651,8 +651,6 @@ out:
 static void add_security_headers(struct sip_outbound_registration_client_state *client_state,
 	pjsip_tx_data *tdata)
 {
-	int add_require_header = 1;
-	int add_proxy_require_header = 1;
 	int add_sec_client_header = 0;
 	struct sip_outbound_registration *reg = NULL;
 	struct ast_sip_endpoint *endpt = NULL;
@@ -661,8 +659,6 @@ static void add_security_headers(struct sip_outbound_registration_client_state *
 	struct ast_sip_security_mechanism_vector *sec_mechs = NULL;
 	static const pj_str_t security_verify = { "Security-Verify", 15 };
 	static const pj_str_t security_client = { "Security-Client", 15 };
-	static const pj_str_t proxy_require = { "Proxy-Require", 13 };
-	static const pj_str_t require = { "Require", 7 };
 
 	if (client_state->security_negotiation != AST_SIP_SECURITY_NEG_MEDIASEC) {
 		return;
@@ -696,20 +692,10 @@ static void add_security_headers(struct sip_outbound_registration_client_state *
 			/* necessary if a retry occures */
 			add_sec_client_header = (pjsip_msg_find_hdr_by_name(tdata->msg, &security_client, NULL) == NULL) ? 1 : 0;
 		}
-		add_require_header =
-			(pjsip_msg_find_hdr_by_name(tdata->msg, &require, NULL) == NULL) ? 1 : 0;
-		add_proxy_require_header =
-			(pjsip_msg_find_hdr_by_name(tdata->msg, &proxy_require, NULL) == NULL) ? 1 : 0;
 	} else {
 		ast_sip_add_security_headers(&client_state->security_mechanisms, "Security-Client", 0, tdata);
 	}
 
-	if (add_require_header) {
-		ast_sip_add_header(tdata, "Require", "mediasec");
-	}
-	if (add_proxy_require_header) {
-		ast_sip_add_header(tdata, "Proxy-Require", "mediasec");
-	}
 	if (add_sec_client_header) {
 		ast_sip_add_security_headers(&client_state->security_mechanisms, "Security-Client", 0, tdata);
 	}


### PR DESCRIPTION
The `Require: mediasec` and `Proxy-Require: mediasec` headers need
to be sent whenever we send `Security-Client` or `Security-Verify`
headers but the logic to do that was only in add_security_headers()
in res_pjsip_outbound_register.  So while we were sending them on
REGISTER requests, we weren't sending them on INVITE requests.

This commit moves the logic to send the two headers out of
res_pjsip_outbound_register:add_security_headers() and into
security_agreement:ast_sip_add_security_headers().  This way
they're always sent when we send `Security-Client` or
`Security-Verify`.

Resolves: #789
