### PR TITLE
ast-db-manage: Remove duplicate enum creation

### DIFF
--- a/contrib/ast-db-manage/config/versions/2b7c507d7d12_add_queue_log_option_log_restricted_.py
+++ b/contrib/ast-db-manage/config/versions/2b7c507d7d12_add_queue_log_option_log_restricted_.py
@@ -20,15 +20,11 @@ AST_BOOL_VALUES = [ '0', '1',
                     'false', 'true',
                     'no', 'yes' ]
 
-
 def upgrade():
-    # Create the new enum
+    # ast_bool_values have already been created, so use postgres enum object
+    # type to get around "already created" issue - works okay with mysql
     ast_bool_values = ENUM(*AST_BOOL_VALUES, name=AST_BOOL_NAME, create_type=False)
-    if op.get_context().bind.dialect.name == 'postgresql':
-        ast_bool_values.create(op.get_bind(), checkfirst=False)
-
     op.add_column('queues', sa.Column('log_restricted_caller_id', ast_bool_values))
-
 
 def downgrade():
     op.drop_column('queues', 'log_restricted_caller_id')


### PR DESCRIPTION
Remove duplicate creation of ast_bool_values from
2b7c507d7d12_add_queue_log_option_log_restricted_.py.  This was
causing alembic upgrades to fail since the enum was already created
in fe6592859b85_fix_mwi_subscribe_replaces_.py back in 2018.

Resolves: #797
