### PR TITLE
res_pjsip_notify: add dialplan application

### DIFF
--- a/channels/pjsip/dialplan_functions_doc.xml
+++ b/channels/pjsip/dialplan_functions_doc.xml
@@ -55,6 +55,46 @@
 		</description>
 	</application>
 
+	<application name="PJSIPNotify" language="en_US">
+		<synopsis>
+			Send a NOTIFY to either an arbitrary URI, or inside a SIP dialog.
+		</synopsis>
+		<syntax>
+			<parameter name="to" required="false">
+				<para>Abritrary URI to which to send the NOTIFY.  If none is specified, send inside
+				the SIP dialog for the current channel.</para>
+			</parameter>
+			<parameter name="content" required="true">
+				<para>Either an option pre-configured in pjsip_notify.conf or a list of headers and body content to send in the NOTIFY.</para>
+			</parameter>
+		</syntax>
+		<description>
+			<para>
+			Sends a NOTIFY to a specified URI, or if none provided, within the current SIP dialog for the
+			current channel.  The content can either be set to either an entry configured in pjsip_notify.conf
+			or specified as a list of key value pairs.
+			</para>
+			<warning><para>
+			To send a NOTIFY to a specified URI, a default_outbound_endpoint must be configured.  This
+			endpoint determines the message contact.
+			</para></warning>
+			<para>
+			</para>
+			<example title="Send a NOTIFY with Event and X-Data headers in current dialog">
+			same = n,PJSIPNotify(,&amp;Event=Test&amp;X-Data=Fun)
+			</example>
+			<example title="Send a preconfigured NOTIFY force-answer defined in pjsip_notify.conf in current dialog">
+			same = n,PJSIPNotify(,force-answer)
+			</example>
+			<example title="Send a NOTIFY to &lt;sip:bob@127.0.0.1:5260&gt; with Test Event and X-Data headers">
+			same = n,PJSIPNotify(&lt;sip:bob@127.0.0.1:5260&gt;,&amp;Event=Test&amp;X-Data=Fun)
+			</example>
+			<example title="Send a NOTIFY to &lt;sip:bob@127.0.0.1:5260&gt; with Custom Event and message body">
+			same = n,PJSIPNotify(&lt;sip:bob@127.0.0.1:5260&gt;,&amp;Event=Custom&amp;Content-type=application&#47;voicemail&amp;Content=check-messages&amp;Content=)
+			</example>
+		</description>
+	</application>
+
 	<manager name="PJSIPHangup" language="en_US">
 		<synopsis>
 			Hangup an incoming PJSIP channel with a SIP response code

--- a/configs/samples/extensions.conf.sample
+++ b/configs/samples/extensions.conf.sample
@@ -828,3 +828,53 @@ exten => _X.,40000(ani),NoOp(ANI: ${EXTEN})
 ; "core show functions" will list all dialplan functions
 ; "core show function <COMMAND>" will show you more information about
 ; one function. Remember that function names are UPPER CASE.
+
+; Examples using PJSIPNotify application.
+;[generate-notify]
+;
+; Send a NOTIFY with the following headers inside the SIP dialog for the current channel:
+;
+;	Event: Test
+;	X-Data: Fun
+;
+;exten => 6880,1,noOp()
+;    same => n,Answer()
+;    same => n,PJSIPNotify(,&Event=Test&X-Data=Fun)
+;    same => n,Wait(1)
+;    same => n,Hangup()
+;
+; Send a NOTIFY with the following headers to bob's custom uri. This requries a
+; default outbound endpoint to be configured in pjsip.conf.
+;
+;	Event: Test
+;	X-Data: Over
+;
+;exten => 6881,1,noOp()
+;    same => n,Answer()
+;    same => n,PJSIPNotify(<sip:bob@127.0.0.1:5260>,&Event=Test&X-Data=Over)
+;    same => n,Wait(1)
+;    same => n,Hangup()
+;
+; Send a NOTIFY with the the custom headers defined in pjsip_notify.conf under
+; 'custom-notify-1' inside the SIP dialog for the current channel.
+;
+;exten => 6882,1,noOp()
+;    same => n,Answer()
+;    same => n,PJSIPNotify(,custom-notify-1)
+;    same => n,Wait(1)
+;    same => n,Hangup()
+; Send a NOTIFY with the following headers and body to bob's custom uri. This
+; requries a default outbound endpoint to be configured in pjsip.conf.
+;
+;	Event: Custom
+;
+;	Content-Type: application/voicemail
+;	Content-Length:    14
+;
+;	check-messages
+;
+;exten => 6882,1,noOp()
+;    same => n,Answer()
+;    same => n,PJSIPNotify(,&Event=Custom&Content-type=application/voicemail&Content=check-messages&Content=)
+;    same => n,Wait(1)
+;    same => n,Hangup()

--- a/configs/samples/pjsip.conf.sample
+++ b/configs/samples/pjsip.conf.sample
@@ -432,6 +432,16 @@
 ;type=aor
 ;max_contacts=2
 
+;===============DEFAULT ENDPOINT FOR OUTBOUND REQUESTS TO URI===================
+;
+; This is an example default outbound endpoint.  The global setting:
+; default_outbound_endpoint needs to be set to such an endpoint in order to be
+; able to send an outbound request to a URI without a specified endpoint.
+;
+;[default_outbound_endpoint]
+;type=endpoint
+;context=none-invalid
+
 
 ;============EXAMPLE ACL CONFIGURATION==========================================
 ;

--- a/configs/samples/pjsip_notify.conf.sample
+++ b/configs/samples/pjsip_notify.conf.sample
@@ -55,3 +55,17 @@ Event=>check-sync\;reboot=true
 
 [cisco-check-cfg]
 Event=>check-sync
+
+; custom examples to use for PJSIPNotify application
+
+; tell an endpoint to check messages
+[custom-notify-1]
+Event=>custom
+Content-type=>application/voicemail
+Content=>check-messages
+Content=>
+
+; tell an endpoint to force a remote hangup via custom header
+[custom-notify-2]
+Event=>custom
+X-Data=>force-hangup


### PR DESCRIPTION
Add dialplan application PJSIPNOTIFY to send either pre-configured
NOTIFY messages from pjsip_notify.conf or with headers defined in
dialplan.

Also adds the ability to send pre-configured NOTIFY commands to a
channel via the CLI.

Resolves: #799

UserNote: The new CLI command syntax is
pjsip send notify <option> channel <channel>
