### PR TITLE
res_stasis: fix intermittent delays on adding channel to bridge

### DIFF
--- a/res/res_stasis.c
+++ b/res/res_stasis.c
@@ -1548,11 +1548,7 @@ int stasis_app_exec(struct ast_channel *chan, const char *app_name, int argc,
 			continue;
 		}
 
-		/* Set this thread's id as the control thread id so that any
-		   new commands can signal out of this wait */
-		control_set_thread(control, pthread_self());
 		r = ast_waitfor(chan, MAX_WAIT_MS);
-		control_set_thread(control, AST_PTHREADT_NULL);
 
 		if (r < 0) {
 			ast_debug(3, "%s: Poll error\n",

--- a/res/stasis/control.c
+++ b/res/stasis/control.c
@@ -95,10 +95,6 @@ struct stasis_app_control {
 	 */
 	char *next_app;
 	/*!
-	 * The thread currently blocking on the channel.
-	 */
-	pthread_t control_thread;
-	/*!
 	 * The list of arguments to pass to StasisStart when moving to another app.
 	 */
 	AST_VECTOR(, char *) next_app_args;
@@ -162,8 +158,6 @@ struct stasis_app_control *control_create(struct ast_channel *channel, struct st
 	control->next_app = NULL;
 	AST_VECTOR_INIT(&control->next_app_args, 0);
 
-	control_set_thread(control, AST_PTHREADT_NULL);
-
 	return control;
 }
 
@@ -190,13 +184,6 @@ static void app_control_unregister_rule(
 		}
 	}
 	AST_RWLIST_TRAVERSE_SAFE_END;
-	ao2_unlock(control->command_queue);
-}
-
-void control_set_thread(struct stasis_app_control *control, pthread_t threadid)
-{
-	ao2_lock(control->command_queue);
-	control->control_thread = threadid;
 	ao2_unlock(control->command_queue);
 }
 
@@ -309,10 +296,10 @@ static struct stasis_app_command *exec_command_on_condition(
 	ao2_link_flags(control->command_queue, command, OBJ_NOLOCK);
 	ast_cond_signal(&control->wait_cond);
 
-	if (control->control_thread != AST_PTHREADT_NULL) {
-		/* if the control thread is waiting on the channel, send the SIGURG
-		   to let it know there is a new command */
-		pthread_kill(control->control_thread, SIGURG);
+	if (control->channel) {
+		/* Queue a null frame so that if and when the channel is waited on,
+		   return immediately to process the new command */
+		ast_queue_frame(control->channel, &ast_null_frame);
 	}
 
 	ao2_unlock(control->command_queue);

--- a/res/stasis/control.h
+++ b/res/stasis/control.h
@@ -49,15 +49,6 @@ struct stasis_app_control *control_create(struct ast_channel *channel, struct st
 void control_flush_queue(struct stasis_app_control *control);
 
 /*!
- * \brief set the control's thread id
- * \since 18
- *
- * \param control Control object on which to set the thread id.
- * \param threadid id to set
- */
-void control_set_thread(struct stasis_app_control *control, pthread_t threadid);
-
-/*!
  * \brief Dispatch all commands enqueued to this control.
  *
  * \param control Control object to dispatch.


### PR DESCRIPTION
Previously, on command execution, the control thread was awoken by
sending a SIGURG. It was found that this still resulted in some
instances where the thread was not immediately awoken.

This change instead sends a null frame to awaken the control thread,
which awakens the thread more consistently.

Resolves: #801
