### PR TITLE
res_agi.c: In the speech recognition module, set fr to NULL after ast_frfree(fr).

### DIFF
--- a/res/res_agi.c
+++ b/res/res_agi.c
@@ -3650,8 +3650,10 @@ static int handle_speechrecognize(struct ast_channel *chan, AGI *agi, int argc, 
 			time(&current);
 			if ((current - start) >= timeout) {
 				reason = "timeout";
-				if (fr)
+				if (fr) {
 					ast_frfree(fr);
+					fr = NULL;
+				}
 				break;
 			}
 		}
@@ -3708,6 +3710,7 @@ static int handle_speechrecognize(struct ast_channel *chan, AGI *agi, int argc, 
 				reason = "hangup";
 			}
 			ast_frfree(fr);
+			fr = NULL;
 		}
 	}
 


### PR DESCRIPTION
res_agi.c:  After the speech recognition module obtains and reads the voice data, it sets fr = NULL.

When using the speech recognition module, occasional crashes occur. The core file indicates that the crash is due to: "double free or corruption (out)". To address this issue, we have modified the code to explicitly set fr = NULL after executing ast_frfree(fr) following the loop that reads the voice data. This modification helps prevent issues related to repeated deallocation under special circumstances.

Resolves:  #772 
