### PR TITLE
bridge_softmix: Fix queueing VIDUPDATE control frames

### DIFF
--- a/bridges/bridge_softmix.c
+++ b/bridges/bridge_softmix.c
@@ -1243,7 +1243,7 @@ static int softmix_bridge_write_control(struct ast_bridge *bridge, struct ast_br
 	case AST_CONTROL_VIDUPDATE:
 		if (!bridge->softmix.video_mode.video_update_discard ||
 			ast_tvdiff_ms(ast_tvnow(), softmix_data->last_video_update) > bridge->softmix.video_mode.video_update_discard) {
-			ast_bridge_queue_everyone_else(bridge, NULL, frame);
+			ast_bridge_queue_everyone_else(bridge, bridge_channel, frame);
 			softmix_data->last_video_update = ast_tvnow();
 		}
 		break;


### PR DESCRIPTION
softmix_bridge_write_control() now calls ast_bridge_queue_everyone_else()
with the bridge_channel so the VIDUPDATE control frame isn't echoed back.

softmix_bridge_write_control() was setting bridge_channel to NULL
when calling ast_bridge_queue_everyone_else() for VIDUPDATE control
frames.  This was causing the frame to be echoed back to the
channel it came from.  In certain cases, like when two channels or
bridges are being recorded, this can cause a ping-pong effect that
floods the system with VIDUPDATE control frames.

Resolves: #780
