### PR TITLE
func_hangupcause.c: add access to Reason headers via HANGUPCAUSE()

### DIFF
--- a/include/asterisk/channel.h
+++ b/include/asterisk/channel.h
@@ -4369,6 +4369,23 @@ struct ast_str *ast_channel_dialed_causes_channels(const struct ast_channel *cha
 struct ast_control_pvt_cause_code *ast_channel_dialed_causes_find(const struct ast_channel *chan, const char *chan_name);
 
 /*!
+ * \brief Retrieve a ref-counted cause code information structure iterator
+ *
+ * \details
+ * This function makes use of datastore operations on the channel, so
+ * it is important to lock the channel before calling this function.
+ * This function increases the ref count of the returned object, so the
+ * calling function must decrease the reference count when it is finished
+ * with the object.
+ *
+ * \param chan The channel from which to retrieve information
+ * \param chan_name The name of the channel about which to retrieve information
+ * \retval NULL on search failure
+ * \retval Pointer to a ao2_iterator object containing the desired information
+ */
+struct ao2_iterator *ast_channel_dialed_causes_find_multiple(const struct ast_channel *chan, const char *chan_name);
+
+/*!
  * \since 11
  * \brief Add cause code information to the channel
  *

--- a/include/asterisk/frame.h
+++ b/include/asterisk/frame.h
@@ -413,6 +413,7 @@ enum ast_control_transfer {
 struct ast_control_pvt_cause_code {
 	char chan_name[AST_CHANNEL_NAME];	/*!< Name of the channel that originated the cause information */
 	unsigned int emulate_sip_cause:1;	/*!< Indicates whether this should be used to emulate SIP_CAUSE support */
+	unsigned int cause_extended:1;		/*!< Indicates whether this cause code was retrieved from supplementary sources */
 	int ast_cause;				/*!< Asterisk cause code associated with this message */
 	char code[1];				/*!< Tech-specific cause code information, beginning with the name of the tech */
 };

--- a/res/res_pjsip_rfc3326.c
+++ b/res/res_pjsip_rfc3326.c
@@ -46,9 +46,11 @@ static void rfc3326_use_reason_header(struct ast_sip_session *session, struct pj
 	for (; header;
 		header = pjsip_msg_find_hdr_by_name(rdata->msg_info.msg, &str_reason, header->next)) {
 		int cause_q850, cause_sip;
+		struct ast_control_pvt_cause_code *cause_code;
+		int data_size = sizeof(*cause_code);
+
 		ast_copy_pj_str(buf, &header->hvalue, sizeof(buf));
 		cause = ast_skip_blanks(buf);
-
 		cause_q850 = !strncasecmp(cause, "Q.850", 5);
 		cause_sip = !strncasecmp(cause, "SIP", 3);
 		if ((cause_q850 || cause_sip) && (cause = strstr(cause, "cause="))) {
@@ -56,6 +58,24 @@ static void rfc3326_use_reason_header(struct ast_sip_session *session, struct pj
 			if (sscanf(cause, "cause=%30d", code) != 1) {
 				*code = 0;
 			}
+
+			/* Safe */
+			/* Build and send the tech-specific cause information */
+			/* size of the string making up the cause code is "SIP " + reason length */
+			data_size += 4 + strlen(cause) + 1;
+			cause_code = ast_alloca(data_size);
+			memset(cause_code, 0, data_size);
+			ast_copy_string(cause_code->chan_name, ast_channel_name(session->channel), AST_CHANNEL_NAME);
+			snprintf(cause_code->code, data_size, "SIP %s", cause);
+
+			cause_code->cause_extended = 1;
+			if (code_q850) {
+				cause_code->ast_cause = *code & 0x7;
+			} else if (code_sip) {
+				cause_code->ast_cause = ast_sip_hangup_sip2cause(*code);
+			}
+			ast_queue_control_data(session->channel, AST_CONTROL_PVT_CAUSE_CODE, cause_code, data_size);
+			ast_channel_hangupcause_hash_set(session->channel, cause_code, data_size);
 		}
 	}
 


### PR DESCRIPTION
As soon as SIP call may be end with several Reason headers, we
want to make all of them available through the HAGUPCAUSE() function.

This implementation use same ao2 hash for cause codes storage
and add a flag to make difference between last processed sip
message and content of reason headers.
