### PR TITLE
res_pjsip_sdp_rtp.c: Fix DTMF Handling in Re-INVITE with dtmf_mode Set to Auto

### DIFF
--- a/res/res_pjsip_sdp_rtp.c
+++ b/res/res_pjsip_sdp_rtp.c
@@ -384,9 +384,14 @@ static void get_codecs(struct ast_sip_session *session, const struct pjmedia_sdp
 		}
 	}
 
-	if (!tel_event && (session->dtmf == AST_SIP_DTMF_AUTO)) {
-		ast_rtp_instance_dtmf_mode_set(session_media->rtp, AST_RTP_DTMF_MODE_INBAND);
-		ast_rtp_instance_set_prop(session_media->rtp, AST_RTP_PROPERTY_DTMF, 0);
+	if (session->dtmf == AST_SIP_DTMF_AUTO) {
+		if (tel_event) {
+			ast_rtp_instance_dtmf_mode_set(session_media->rtp, AST_RTP_DTMF_MODE_RFC2833);
+			ast_rtp_instance_set_prop(session_media->rtp, AST_RTP_PROPERTY_DTMF, 1);
+		} else {
+			ast_rtp_instance_dtmf_mode_set(session_media->rtp, AST_RTP_DTMF_MODE_INBAND);
+			ast_rtp_instance_set_prop(session_media->rtp, AST_RTP_PROPERTY_DTMF, 0);
+		}
 	}
 
 	if (session->dtmf == AST_SIP_DTMF_AUTO_INFO) {


### PR DESCRIPTION
res_pjsip_sdp_rtp.c: Fix DTMF Handling in Re-INVITE with dtmf_mode set to Auto

When the endpoint dtmf_mode is set to auto, a SIP request is sent to the UAC, and the SIP SDP from the UAC does not include the telephone-event. Later, the UAC sends an INVITE, and the SIP SDP includes the telephone-event. In this case, DTMF should be sent by RFC2833 rather than using inband signaling.

Resolves: asterisk#826