### PR TITLE
configure:  Use . file rather than source file.

### DIFF
--- a/configure
+++ b/configure
@@ -15774,7 +15774,7 @@ else
 	PBX_JANSSON=1
 fi
 
-source ./third-party/versions.mak
+. ./third-party/versions.mak
 # Find required JWT support if bundled is not enabled.
 if test "$LIBJWT_BUNDLED" = "no" ; then
 

--- a/configure.ac
+++ b/configure.ac
@@ -746,7 +746,7 @@ else
 	PBX_JANSSON=1
 fi
 
-source ./third-party/versions.mak
+. ./third-party/versions.mak
 # Find required JWT support if bundled is not enabled.
 if test "$LIBJWT_BUNDLED" = "no" ; then
 	AST_PKG_CONFIG_CHECK([LIBJWT], [libjwt >= $LIBJWT_VERSION])


### PR DESCRIPTION
source is a bash concept, so when /bin/sh points to another shell the existing construct won't work.

Reference: https://bugs.gentoo.org/927055