### PR TITLE
chan_mobile: decrease CHANNEL_FRAME_SIZE to prevent delay

### DIFF
--- a/addons/chan_mobile.c
+++ b/addons/chan_mobile.c
@@ -80,7 +80,7 @@
 
 #define DEVICE_FRAME_SIZE 48
 #define DEVICE_FRAME_FORMAT ast_format_slin
-#define CHANNEL_FRAME_SIZE 320
+#define CHANNEL_FRAME_SIZE 80
 
 static int discovery_interval = 60;			/* The device discovery interval, default 60 seconds. */
 static pthread_t discovery_thread = AST_PTHREADT_NULL;	/* The discovery thread */


### PR DESCRIPTION
On modern Bluetooth devices or lower-powered asterisk servers, decreasing the channel frame size significantly improves latency and delay on outbound calls with only a mild sacrifice to the quality of the call (the frame size before was massive overkill to begin with)
Before changing this line, outgoing calls through chan_mobile had around a 15-20 second delay in transmission of the asterisk phone's voice to the mobile phone when playing outgoing calls, but after the patch has close to no latency in transmission.