### PR TITLE
security_agreements.c: Refactor the to_str functions and fix a few other bugs

### DIFF
--- a/res/res_pjsip/pjsip_configuration.c
+++ b/res/res_pjsip/pjsip_configuration.c
@@ -2434,6 +2434,7 @@ static void endpoint_destructor(void* obj)
 	ast_free(endpoint->contact_user);
 	ast_free_acl_list(endpoint->contact_acl);
 	ast_free_acl_list(endpoint->acl);
+	ast_sip_security_mechanisms_vector_destroy(&endpoint->security_mechanisms);
 }
 
 static int init_subscription_configuration(struct ast_sip_endpoint_subscription_configuration *subscription)

--- a/res/res_pjsip_outbound_registration.c
+++ b/res/res_pjsip_outbound_registration.c
@@ -615,14 +615,14 @@ static int contact_has_security_mechanisms(void *obj, void *arg, int flags)
 	struct ast_sip_contact_status *contact_status = ast_sip_get_contact_status(contact);
 
 	if (!contact_status) {
-		return -1;
+		return 0;
 	}
 	if (!AST_VECTOR_SIZE(&contact_status->security_mechanisms)) {
 		ao2_cleanup(contact_status);
-		return -1;
+		return 0;
 	}
 	*ret = contact_status;
-	return 0;
+	return CMP_MATCH | CMP_STOP;
 }
 
 static int contact_add_security_headers_to_status(void *obj, void *arg, int flags)
@@ -632,7 +632,7 @@ static int contact_add_security_headers_to_status(void *obj, void *arg, int flag
 	struct ast_sip_contact_status *contact_status = ast_sip_get_contact_status(contact);
 
 	if (!contact_status) {
-		return -1;
+		return 0;
 	}
 	if (AST_VECTOR_SIZE(&contact_status->security_mechanisms)) {
 		goto out;
@@ -671,7 +671,7 @@ static void add_security_headers(struct sip_outbound_registration_client_state *
 		/* Retrieve all contacts associated with aors from this endpoint
 		 * and find the first one that has security mechanisms.
 		 */
-		ao2_callback(contact_container, 0, contact_has_security_mechanisms, &contact_status);
+		ao2_callback(contact_container, OBJ_NODATA, contact_has_security_mechanisms, &contact_status);
 		if (contact_status) {
 			ao2_lock(contact_status);
 			sec_mechs = &contact_status->security_mechanisms;


### PR DESCRIPTION
* A static array of security mechanism type names was created.

* ast_sip_str_to_security_mechanism_type() was refactored to do
  a lookup in the new array instead of using fixed "if/else if"
  statments.

* security_mechanism_to_str() and ast_sip_security_mechanisms_to_str()
  were refactored to use ast_str instead of a fixed length buffer
  to store the result.

* ast_sip_security_mechanism_type_to_str was removed in favor of
  just referencing the new type name array.  Despite starting with
  "ast_sip_", it was a static function so removing it doesn't affect
  ABI.

* Speaking of "ast_sip_", several other static functions that
  started with "ast_sip_" were renamed to avoid confusion about
  their public availability.

* A few VECTOR free loops were replaced with AST_VECTOR_RESET().

* Fixed a meomry leak in pjsip_configuration.c endpoint_destructor
  caused by not calling ast_sip_security_mechanisms_vector_destroy().

* Fixed a memory leak in res_pjsip_outbound_registration.c
  add_security_headers() caused by not specifying OBJ_NODATA in
  an ao2_callback.

* Fixed a few ao2_callback return code misuses.

Resolves: #845
