### PR TITLE
res_pjsip_sdp_rtp fix leaking astobj2 ast_format

### DIFF
--- a/main/rtp_engine.c
+++ b/main/rtp_engine.c
@@ -1011,6 +1011,7 @@ void ast_rtp_codecs_payloads_destroy(struct ast_rtp_codecs *codecs)
 	AST_VECTOR_FREE(&codecs->payload_mapping_tx);
 
 	ao2_t_cleanup(codecs->preferred_format, "destroying ast_rtp_codec preferred format");
+	codecs->preferred_format = NULL;
 
 	ast_rwlock_destroy(&codecs->codecs_lock);
 }

--- a/res/res_pjsip_sdp_rtp.c
+++ b/res/res_pjsip_sdp_rtp.c
@@ -544,7 +544,10 @@ static int set_caps(struct ast_sip_session *session,
 			ast_format_cap_get_names(caps, &usbuf),
 			ast_format_cap_get_names(peer, &thembuf));
 	} else {
-		ast_rtp_codecs_set_preferred_format(&codecs, ast_format_cap_get_format(joint, 0));
+		struct ast_format *preferred_fmt = ast_format_cap_get_format(joint, 0);
+
+		ast_rtp_codecs_set_preferred_format(&codecs, preferred_fmt);
+		ao2_ref(preferred_fmt, -1);
 	}
 
 	if (is_offer) {


### PR DESCRIPTION
PR #700 added a preferred_format for the struct ast_rtp_codecs,
but when set the preferred_format it leaks an astobj2 ast_format.
In the next code
ast_rtp_codecs_set_preferred_format(&codecs, ast_format_cap_get_format(joint, 0));
both functions ast_rtp_codecs_set_preferred_format
and ast_format_cap_get_format increases the ao2 reference count.

Fixes: #856
