### PR TITLE
app_chanspy.c: resolving the issue with audiohook direction read

### DIFF
--- a/apps/app_broadcast.c
+++ b/apps/app_broadcast.c
@@ -249,7 +249,7 @@ static int start_spying(struct ast_autochan *autochan, const char *spychan_name,
 	ast_debug(1, "Attaching spy channel %s to %s\n", spychan_name, ast_channel_name(autochan->chan));
 
 	if (ast_test_flag(flags, OPTION_READONLY)) {
-		ast_set_flag(audiohook, AST_AUDIOHOOK_MUTE_WRITE);
+		ast_set_flag(audiohook, AST_AUDIOHOOK_MUTE_WRITE | AST_AUDIOHOOK_SKIP_WRITE);
 	} else {
 		ast_set_flag(audiohook, AST_AUDIOHOOK_TRIGGER_SYNC);
 	}

--- a/include/asterisk/audiohook.h
+++ b/include/asterisk/audiohook.h
@@ -66,6 +66,8 @@ enum ast_audiohook_flags {
 	AST_AUDIOHOOK_COMPATIBLE    = (1 << 7), /*!< is the audiohook native slin compatible */
 
 	AST_AUDIOHOOK_SUBSTITUTE_SILENCE = (1 << 8), /*!< Substitute silence for missing audio */
+
+	AST_AUDIOHOOK_SKIP_WRITE = (1 << 9), /*!< audiohook should be skip frames write */
 };
 
 enum ast_audiohook_init_flags {

--- a/main/audiohook.c
+++ b/main/audiohook.c
@@ -166,6 +166,9 @@ int ast_audiohook_set_frame_feed_direction(struct ast_audiohook *audiohook, enum
 
 int ast_audiohook_write_frame(struct ast_audiohook *audiohook, enum ast_audiohook_direction direction, struct ast_frame *frame)
 {
+	if (direction == AST_AUDIOHOOK_DIRECTION_WRITE && ast_test_flag(audiohook, AST_AUDIOHOOK_SKIP_WRITE)) {
+		return 0;
+	}
 	struct ast_slinfactory *factory = (direction == AST_AUDIOHOOK_DIRECTION_READ ? &audiohook->read_factory : &audiohook->write_factory);
 	struct ast_slinfactory *other_factory = (direction == AST_AUDIOHOOK_DIRECTION_READ ? &audiohook->write_factory : &audiohook->read_factory);
 	struct timeval *rwtime = (direction == AST_AUDIOHOOK_DIRECTION_READ ? &audiohook->read_time : &audiohook->write_time), previous_time = *rwtime;


### PR DESCRIPTION
ChanSpy(${channel}, qEoS): When chanspy spy the direction read, reading frame is often failed when reading direction read audiohook. because chanspy only read audiohook direction read; write_factory_ms will greater than 100ms soon, then ast_slinfactory_flush will being called, then direction read will fail.

Resolves: #861