### PR TITLE
app_chanspy.c: resolving the issue with audiohook direction read

### DIFF
--- a/apps/app_broadcast.c
+++ b/apps/app_broadcast.c
@@ -249,6 +249,7 @@ static int start_spying(struct ast_autochan *autochan, const char *spychan_name,
 	ast_debug(1, "Attaching spy channel %s to %s\n", spychan_name, ast_channel_name(autochan->chan));
 
 	if (ast_test_flag(flags, OPTION_READONLY)) {
+		ast_audiohook_set_frame_feed_direction(audiohook, AST_AUDIOHOOK_DIRECTION_READ);
 		ast_set_flag(audiohook, AST_AUDIOHOOK_MUTE_WRITE);
 	} else {
 		ast_set_flag(audiohook, AST_AUDIOHOOK_TRIGGER_SYNC);

--- a/apps/app_chanspy.c
+++ b/apps/app_chanspy.c
@@ -570,6 +570,7 @@ static int start_spying(struct ast_autochan *autochan, const char *spychan_name,
 		spychan_name, ast_channel_name(autochan->chan));
 
 	if (ast_test_flag(flags, OPTION_READONLY)) {
+		ast_audiohook_set_frame_feed_direction(audiohook, AST_AUDIOHOOK_DIRECTION_READ);
 		ast_set_flag(audiohook, AST_AUDIOHOOK_MUTE_WRITE);
 	} else {
 		ast_set_flag(audiohook, AST_AUDIOHOOK_TRIGGER_SYNC);


### PR DESCRIPTION
ChanSpy(${channel}, qEoS): When chanspy spy the direction read, reading frame is often failed when reading direction read audiohook. because chanspy only read audiohook direction read; write_factory_ms will greater than 100ms soon, then ast_slinfactory_flush will being called, then direction read will fail.

Resolves: #861