### PR TITLE
app_voicemail: Fix sql insert mismatch caused by cherry-pick

### DIFF
--- a/apps/app_voicemail.c
+++ b/apps/app_voicemail.c
@@ -4692,10 +4692,10 @@ struct insert_data {
 
 #define STORE_SQL_FMT_CAT "INSERT INTO %s (dir, msgnum, recording, context, macrocontext, callerid, " \
 	"origtime, duration, mailboxuser, mailboxcontext, flag, msg_id, category) " \
-	"VALUES (?,?,?,?,?,?,?,?,?,?,?,?)"
+	"VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)"
 #define STORE_SQL_FMT "INSERT INTO %s (dir, msgnum, recording, context, macrocontext, callerid, "\
 	"origtime, duration, mailboxuser, mailboxcontext, flag, msg_id) "\
-	"VALUES (?,?,?,?,?,?,?,?,?,?,?)"
+	"VALUES (?,?,?,?,?,?,?,?,?,?,?,?)"
 
 static SQLHSTMT odbc_insert_data_cb(struct odbc_obj *obj, void *vdata)
 {
@@ -6268,13 +6268,14 @@ static int messagecount(const char *mailbox_id, const char *folder)
 	}
 
 	if (!strcmp(folder, "INBOX")) {
-		gps.sql = ast_alloca(sizeof(MSGCOUNT_SQL_FMT_INBOX) + odbc_table_len + (strlen(VM_SPOOL_DIR) + strlen(context) + strlen(mailbox) * 2));
-		sprintf(gps.sql, MSGCOUNT_SQL_FMT_INBOX, odbc_table, VM_SPOOL_DIR, context, mailbox, VM_SPOOL_DIR, context, mailbox); /* Safe */
+		res = ast_asprintf(&gps.sql, MSGCOUNT_SQL_FMT_INBOX, odbc_table, VM_SPOOL_DIR, context, mailbox, VM_SPOOL_DIR, context, mailbox);
 	} else {
-		gps.sql = ast_alloca(sizeof(MSGCOUNT_SQL_FMT) + odbc_table_len + strlen(VM_SPOOL_DIR) + strlen(context) + strlen(mailbox) + strlen(folder));
-		sprintf(gps.sql, MSGCOUNT_SQL_FMT, odbc_table, VM_SPOOL_DIR, context, mailbox, folder); /* Safe */
+		res = ast_asprintf(&gps.sql, MSGCOUNT_SQL_FMT, odbc_table, VM_SPOOL_DIR, context, mailbox, folder);
 	}
-
+	if (res <= 0) {
+		SCOPE_EXIT_LOG_RTN_VALUE(0, AST_LOG_WARNING, "Failed to allocate memory for SQL statement for '%s'!\n", odbc_database);
+	}
+	ast_trace(-1, "SQL: %s\n", gps.sql);
 	stmt = ast_odbc_prepare_and_execute(obj, generic_prepare, &gps);
 	if (!stmt) {
 		ast_log(AST_LOG_WARNING, "SQL Execute error!\n[%s]\n\n", gps.sql);
@@ -6297,6 +6298,7 @@ bail_with_handle:
 
 bail:
 	ast_odbc_release_obj(obj);
+	ast_free(gps.sql);
 	SCOPE_EXIT_RTN_VALUE(nummsgs, "Messages: %d\n", nummsgs);
 }
 #undef MSGCOUNT_SQL_FMT


### PR DESCRIPTION
When commit e8c9cb80 was cherry-picked in from master, the
fact that the 20 and 18 branches still had the old "macrocontext"
column wasn't taken into account so the number of named parameters
didn't match the number of '?' placeholders.  They do now.

We also now use ast_asprintf to create the full mailbox query SQL
statement instead of trying to calculate the proper length ourselves.

Resolves: #831
