### PR TITLE
res_resolver_unbound: Test for NULL ub_result in unbound_resolver_callback

### DIFF
--- a/main/dns_core.c
+++ b/main/dns_core.c
@@ -598,7 +598,9 @@ static void sort_result(int rr_type, struct ast_dns_result *result)
 
 void ast_dns_resolver_completed(struct ast_dns_query *query)
 {
-	sort_result(ast_dns_query_get_rr_type(query), query->result);
+	if (query->result) {
+		sort_result(ast_dns_query_get_rr_type(query), query->result);
+	}
 
 	query->callback(query);
 }


### PR DESCRIPTION
The ub_result pointer passed to unbound_resolver_callback by
libunbound can be NULL if the query was for something malformed
like `.1` or `[.1]`.  If it is, we now set a 'ns_r_formerr' result
and return instead of crashing with a SEGV.  This causes pjproject
to simply cancel the transaction with a "No answer record in the DNS
response" error.  The existing "off nominal" unit test was also
updated to check this condition.

Although not necessary for this fix, we also made
ast_dns_resolver_completed() tolerant of a NULL result.

Resolves: GHSA-v428-g3cw-7hv9
