### PR TITLE
res_stir_shaken: Remove stale include for jansson.h in verification.c

### DIFF
--- a/res/res_stir_shaken/verification.c
+++ b/res/res_stir_shaken/verification.c
@@ -19,7 +19,6 @@
 #include <sys/stat.h>
 
 #include <jwt.h>
-#include <jansson.h>
 #include <regex.h>
 
 #include "asterisk.h"


### PR DESCRIPTION
verification.c had an include for jansson.h left over from previous
versions of the module.  Since res_stir_shaken no longer has a
dependency on jansson, the bundled version wasn't added to GCC's
include path so if you didn't also have a jansson development package
installed, the compile would fail.  Removing the stale include
was the only thing needed.

Resolves: #889
