### PR TITLE
cel_custom: Allow absolute filenames.

### DIFF
--- a/cel/cel_custom.c
+++ b/cel/cel_custom.c
@@ -103,7 +103,11 @@ static int load_config(void)
 			}
 
 			ast_string_field_build(sink, format, "%s\n", var->value);
-			ast_string_field_build(sink, filename, "%s/%s/%s", ast_config_AST_LOG_DIR, name, var->name);
+			if (var->name[0] == '/') {
+				ast_string_field_build(sink, filename, "%s", var->name);
+			} else {
+				ast_string_field_build(sink, filename, "%s/%s/%s", ast_config_AST_LOG_DIR, name, var->name);
+			}
 			ast_mutex_init(&sink->lock);
 
 			ast_verb(3, "Added CEL CSV mapping for '%s'.\n", sink->filename);


### PR DESCRIPTION
If a filename starts with a '/' in cel_custom [mappings] assume it is a absolute file path and not relative filename/path to AST_LOG_DIR/cel_custom/