### PR TITLE
channel: Value CHANNEL(userfield) is lost by BRIDGE_ENTER/BRIDGE_LEAVE.

### DIFF
--- a/main/channel.c
+++ b/main/channel.c
@@ -7216,6 +7216,9 @@ static void channel_do_masquerade(struct ast_channel *original, struct ast_chann
 	/* copy over accuntcode and set peeraccount across the bridge */
 	ast_channel_accountcode_set(original, S_OR(ast_channel_accountcode(clonechan), ""));
 
+	/* copy over userfield */
+	ast_channel_userfield_set(original, ast_channel_userfield(clonechan));
+
 	ast_debug(1, "Putting channel %s in %s/%s formats\n", ast_channel_name(original),
 		ast_format_get_name(wformat), ast_format_get_name(rformat));
 


### PR DESCRIPTION
When a channel masquerade occurs, the value of CHANNEL(userfield) is not copied to the new ast_channel. A channel masquerade occurs when 2 existing channels are bridged using a simple bridge. Or when a simple bridge is broken and both channels continue independently.

Fixes: #882