### PR TITLE
astfd.c: Avoid calling fclose with NULL argument.

### DIFF
--- a/main/astfd.c
+++ b/main/astfd.c
@@ -280,7 +280,8 @@ int __ast_fdleak_fclose(FILE *ptr)
 {
 	int fd, res;
 	if (!ptr) {
-		return fclose(ptr);
+		errno = EINVAL;
+		return -1;
 	}
 
 	fd = fileno(ptr);


### PR DESCRIPTION
Don't pass through a NULL argument to fclose, which is undefined behavior, and instead return -1 and set errno appropriately. This avoids a compiler warning with gcc 13.2.0.

Resolves: #900