### PR TITLE
stir_shaken: Fix propagation of attest_level and a few other values

### DIFF
--- a/res/res_stir_shaken/common_config.c
+++ b/res/res_stir_shaken/common_config.c
@@ -100,6 +100,7 @@ const char *param_name ## _to_str( \
 }
 
 generate_enum_string_functions(attest_level, UNKNOWN,
+	{attest_level_NOT_SET, "not_set"},
 	{attest_level_A, "A"},
 	{attest_level_B, "B"},
 	{attest_level_C, "C"},

--- a/res/res_stir_shaken/common_config.h
+++ b/res/res_stir_shaken/common_config.h
@@ -110,10 +110,10 @@ generate_enum_string_prototypes(endpoint_behavior,
 
 generate_enum_string_prototypes(attest_level,
 	attest_level_UNKNOWN = -1,
-	attest_level_A = 0,
+	attest_level_NOT_SET = 0,
+	attest_level_A,
 	attest_level_B,
 	attest_level_C,
-	attest_level_NOT_SET,
 );
 
 /*

--- a/res/res_stir_shaken/tn_config.c
+++ b/res/res_stir_shaken/tn_config.c
@@ -28,11 +28,11 @@
 
 #define CONFIG_TYPE "tn"
 
-#define DEFAULT_check_tn_cert_public_url check_tn_cert_public_url_NO
+#define DEFAULT_check_tn_cert_public_url check_tn_cert_public_url_NOT_SET
 #define DEFAULT_private_key_file NULL
 #define DEFAULT_public_cert_url NULL
 #define DEFAULT_attest_level attest_level_NOT_SET
-#define DEFAULT_send_mky send_mky_NO
+#define DEFAULT_send_mky send_mky_NOT_SET
 
 struct tn_cfg *tn_get_cfg(const char *id)
 {
@@ -45,14 +45,7 @@ static struct ao2_container *get_tn_all(void)
 		AST_RETRIEVE_FLAG_MULTIPLE | AST_RETRIEVE_FLAG_ALL, NULL);
 }
 
-generate_sorcery_enum_from_str(tn_cfg, acfg_common., check_tn_cert_public_url, UNKNOWN)
-generate_sorcery_enum_to_str(tn_cfg, acfg_common., check_tn_cert_public_url)
-
-generate_sorcery_enum_from_str(tn_cfg, acfg_common., attest_level, UNKNOWN)
-generate_sorcery_enum_to_str(tn_cfg, acfg_common., attest_level)
-
-generate_sorcery_enum_from_str(tn_cfg, acfg_common., send_mky, UNKNOWN)
-generate_sorcery_enum_to_str(tn_cfg, acfg_common., send_mky)
+generate_acfg_common_sorcery_handlers(tn_cfg);
 
 static void tn_destructor(void *obj)
 {


### PR DESCRIPTION
attest_level, send_mky and check_tn_cert_public_url weren't
propagating correctly from the attestation object to the profile
and tn.

* In the case of attest_level, the enum needed to be changed
so the "0" value (the default) was "NOT_SET" instead of "A".  This
now allows the merging of the attestation object, profile and tn
to detect when a value isn't set and use the higher level value.

* For send_mky and check_tn_cert_public_url, the tn default was
forced to "NO" which always overrode the profile and attestation
objects.  Their defaults are now "NOT_SET" so the propagation
happens correctly.

* Just to remove some redundant code in tn_config.c, a bunch of calls to
generate_sorcery_enum_from_str() and generate_sorcery_enum_to_str() were
replaced with a single call to generate_acfg_common_sorcery_handlers().

Resolves: #904
