### PR TITLE
res_pjsip_refer.c: crash that lead to deadlock during transfer

### DIFF
--- a/res/res_pjsip_refer.c
+++ b/res/res_pjsip_refer.c
@@ -726,9 +726,11 @@ static void refer_blind_callback(struct ast_channel *chan, struct transfer_chann
 
 			ao2_cleanup(refer->progress);
 		} else {
+			ao2_bump(refer->progress->bridge_sub);
 			stasis_subscription_accept_message_type(refer->progress->bridge_sub, ast_channel_entered_bridge_type());
 			stasis_subscription_accept_message_type(refer->progress->bridge_sub, stasis_subscription_change_type());
 			stasis_subscription_set_filter(refer->progress->bridge_sub, STASIS_SUBSCRIPTION_FILTER_SELECTIVE);
+			ao2_cleanup(refer->progress->bridge_sub);
 		}
 	}
 


### PR DESCRIPTION
Deadlock is during the call transfer. pjsip subscribes to stasis “bridge:all“ structure with callback function “refer_progress_bridge” and applied allowed message types and filters. When applying process is in progress function “refer_progress_bridge“ executed in separate thread where start to unsubscribe and remove subscription that lead to unlocking of null pointer.

1. Create subscription to “bridge:all“ with callback (res/res_pjsip_refer.c:703) (thread 1)
2. Start updating this subscription. (res/res_pjsip_refer.c:723-725) (thread 1)
3. Lock sub->topic (“bridge:all“ structure) (main/stasis.c:1043 && main/stasis.c:1086) (thread 1)
4. Fire the callback function (res/res_pjsip_refer.c:181) (thread 2)
5. Unsubscribe, sub->topic = null (res/res_pjsip_refer.c:217) (thread 2)
6. Unlock sub->topic that is null (main/stasis.c:1050 && main/stasis.c:1090) (thread 1)
7. Thread 1 crashes
8. “bridge:all” is locked by crashed thread and will never be unlocked we have deadlock

Fixes issue:
https://github.com/asterisk/asterisk/issues/930