### PR TITLE
res_rtp_asterisk.c: Set mark on rtp when timestamp skew is too big

### DIFF
--- a/res/res_rtp_asterisk.c
+++ b/res/res_rtp_asterisk.c
@@ -5206,6 +5206,11 @@ static int rtp_raw_write(struct ast_rtp_instance *instance, struct ast_frame *fr
 	}
 
 	if (ast_test_flag(frame, AST_FRFLAG_HAS_TIMING_INFO)) {
+		if (abs(frame->ts * rate - (int)rtp->lastts) > MAX_TIMESTAMP_SKEW) {
+			ast_verbose("(%p) RTP audio difference is %d set mark\n",
+				instance, abs(frame->ts * rate - (int)rtp->lastts));
+			mark = 1;
+		}
 		rtp->lastts = frame->ts * rate;
 	}
 


### PR DESCRIPTION
We faced with no audio issue when media source changed during the call (e.g. call transfer, audio prompt and then some sip endpoint, etc.). Issue related to big timestamp skew. Solution here is to set Mark when we detect such case.

Fixes: #927