### PR TITLE
main, res, tests: Fix compilation errors on FreeBSD.

### DIFF
--- a/main/asterisk.c
+++ b/main/asterisk.c
@@ -4340,7 +4340,7 @@ static void asterisk_daemon(int isroot, const char *runuser, const char *rungrou
 	if (ast_opt_console) {
 		/* Console stuff now... */
 		/* Register our quit function */
-		char title[256];
+		char title[296];
 		char hostname[MAXHOSTNAMELEN] = "";
 
 		if (gethostname(hostname, sizeof(hostname) - 1)) {

--- a/main/config.c
+++ b/main/config.c
@@ -44,6 +44,7 @@
 #include <libgen.h>
 #include <time.h>
 #include <sys/stat.h>
+#include <sys/wait.h>
 
 #include <math.h>	/* HUGE_VAL */
 #include <regex.h>

--- a/main/manager.c
+++ b/main/manager.c
@@ -10112,7 +10112,7 @@ static int __init_manager(int reload, int by_external_config)
 	struct ast_manager_user *user = NULL;
 	struct ast_variable *var;
 	struct ast_flags config_flags = { (reload && !by_external_config) ? CONFIG_FLAG_FILEUNCHANGED : 0 };
-	char a1[256];
+	char a1[337];
 	char a1_hash[256];
 	struct ast_sockaddr ami_desc_local_address_tmp;
 	struct ast_sockaddr amis_desc_local_address_tmp;

--- a/res/res_timing_kqueue.c
+++ b/res/res_timing_kqueue.c
@@ -466,7 +466,7 @@ AST_TEST_DEFINE(test_kqueue_timing)
 
 		}
 		diff = ast_tvdiff_us(ast_tvnow(), start);
-		ast_test_status_update(test, "diff is %llu\n", diff);
+		ast_test_status_update(test, "diff is %" PRIu64 "\n", diff);
 	} while (0);
 	kqueue_timer_close(kt);
 	return res;

--- a/tests/test_crypto.c
+++ b/tests/test_crypto.c
@@ -41,7 +41,7 @@
 
 #include <assert.h>
 #include <sys/stat.h>
-#include <linux/limits.h>
+#include <limits.h>
 #include <openssl/evp.h>
 
 static const char *keypair1 = "rsa_key1";


### PR DESCRIPTION
asterisk.c, manager.c: Increase buffer sizes to avoid truncation warnings.
config.c: Include header file for WIFEXITED/WEXITSTATUS macros.
res_timing_kqueue: Use more portable format specifier.
test_crypto: Use non-linux limits.h header file.

Resolves: #916