### PR TITLE
feat: add redirecting as a channel state

### DIFF
--- a/channels/sig_analog.c
+++ b/channels/sig_analog.c
@@ -3628,6 +3628,7 @@ winkflashdone:
 				case AST_STATE_BUSY:				/*!< Line is busy */
 				case AST_STATE_DIALING_OFFHOOK:		/*!< Digits (or equivalent) have been dialed while offhook */
 				case AST_STATE_PRERING:				/*!< Channel has detected an incoming call and is waiting for ring */
+				case AST_STATE_REDIRECTING:		/*!< Channel is being redirected */
 				default:
 					if (p->answeronpolarityswitch || p->hanguponpolarityswitch) {
 						ast_debug(1, "Ignoring Polarity switch on channel %d, state %u\n", p->channel, ast_channel_state(ast));

--- a/include/asterisk/channelstate.h
+++ b/include/asterisk/channelstate.h
@@ -43,6 +43,7 @@ enum ast_channel_state {
 	AST_STATE_BUSY,			/*!< Line is busy */
 	AST_STATE_DIALING_OFFHOOK,	/*!< Digits (or equivalent) have been dialed while offhook */
 	AST_STATE_PRERING,		/*!< Channel has detected an incoming call and is waiting for ring */
+	AST_STATE_REDIRECTING,		/*!< Channel is being redirected */
 
 	AST_STATE_MUTE = (1 << 16),	/*!< Do not transmit voice data */
 };

--- a/main/channel.c
+++ b/main/channel.c
@@ -658,6 +658,8 @@ const char *ast_state2str(enum ast_channel_state state)
 		return "Dialing Offhook";
 	case AST_STATE_PRERING:
 		return "Pre-ring";
+	case AST_STATE_REDIRECTING:
+		return "Redirecting";
 	case AST_STATE_MUTE:
 		return "Mute";
 	default:
@@ -9148,7 +9150,7 @@ void ast_channel_set_redirecting(struct ast_channel *chan, const struct ast_part
 	ast_channel_lock(chan);
 	ast_party_redirecting_set(ast_channel_redirecting(chan), redirecting, update);
 	ast_channel_snapshot_invalidate_segment(chan, AST_CHANNEL_SNAPSHOT_INVALIDATE_CALLER);
-	ast_channel_publish_snapshot(chan);
+	ast_setstate(chan, AST_STATE_REDIRECTING);
 	ast_channel_unlock(chan);
 }
 

--- a/main/devicestate.c
+++ b/main/devicestate.c
@@ -185,6 +185,7 @@ static const struct chan2dev {
 	{ AST_STATE_BUSY,            AST_DEVICE_BUSY },
 	{ AST_STATE_DIALING_OFFHOOK, AST_DEVICE_INUSE },
 	{ AST_STATE_PRERING,         AST_DEVICE_RINGING },
+	{ AST_STATE_REDIRECTING,      AST_DEVICE_RINGING },
 };
 
 /*! \brief  A device state provider (not a channel) */

--- a/rest-api/api-docs/channels.json
+++ b/rest-api/api-docs/channels.json
@@ -398,7 +398,6 @@
 							"reason": "Channel with given unique ID already exists."
 						}
 					]
-
 				},
 				{
 					"httpMethod": "DELETE",
@@ -2152,6 +2151,7 @@
 							"Busy",
 							"Dialing Offhook",
 							"Pre-ring",
+							"Redirecting",
 							"Unknown"
 						]
 					}

--- a/tests/test_devicestate.c
+++ b/tests/test_devicestate.c
@@ -831,6 +831,7 @@ AST_TEST_DEFINE(devstate_conversions)
 	ast_test_validate(test, ast_state_chan2dev(AST_STATE_BUSY) == AST_DEVICE_BUSY);
 	ast_test_validate(test, ast_state_chan2dev(AST_STATE_DIALING_OFFHOOK) == AST_DEVICE_INUSE);
 	ast_test_validate(test, ast_state_chan2dev(AST_STATE_PRERING) == AST_DEVICE_RINGING);
+	ast_test_validate(test, ast_state_chan2dev(AST_STATE_REDIRECTING) == AST_DEVICE_RINGING);
 
 	return AST_TEST_PASS;
 }


### PR DESCRIPTION
We need to disallow certain redirects at work, and we are unfortunately not able to rely on SIP diversion-limit headers due to incomplete support between different operators.

From the commit message body:

"Redirecting" has been added as an allowable value in the ARI Channel state property. Users will now be notified of a redirecting channel through the ARI ChannelStateChange event.

I could try to add a test-case in asterisk/testsuite if wished for by the maintainers.