### PR TITLE
pjproject_bundled:  Tweaks to support out-of-tree development

### DIFF
--- a/third-party/pjproject/Makefile
+++ b/third-party/pjproject/Makefile
@@ -58,6 +58,7 @@ ifeq ($(SPECIAL_TARGETS),)
         -include source/build.mak
         CF := $(filter-out -W%,$(CC_CFLAGS))
         CF := $(filter-out -I%,$(CF))
+        ifeq ($(PJPROJECT_BUNDLED_OOT),)
         ifeq ($(AST_DEVMODE),yes)
             apps := source/pjsip-apps/bin/pjsua-$(TARGET_NAME) source/pjsip-apps/bin/pjsystest-$(TARGET_NAME)
             TARGETS += $(apps)
@@ -65,6 +66,7 @@ ifeq ($(SPECIAL_TARGETS),)
                 TARGETS += source/pjsip-apps/src/python/_pjsua.so
             endif
             CF += -DPJPROJECT_BUNDLED_ASSERTIONS=yes
+        endif
         endif
         MALLOC_DEBUG_LIBS = source/pjsip-apps/lib/libasterisk_malloc_debug.a
         ifneq ($(findstring darwin,$(OSARCH)),)

--- a/third-party/pjproject/Makefile.rules
+++ b/third-party/pjproject/Makefile.rules
@@ -36,6 +36,7 @@ PJPROJECT_CONFIG_OPTS = $(PJPROJECT_CONFIGURE_OPTS) --prefix=/opt/pjproject \
 	--disable-openh264 \
 	--disable-ipp \
 	--disable-libwebrtc \
+	--disable-libsrtp \
 	--disable-upnp \
 	--without-external-pa \
 	--without-external-srtp

--- a/third-party/pjproject/README-hacking.md
+++ b/third-party/pjproject/README-hacking.md
@@ -174,9 +174,8 @@ applied.  Since you're probably working off the pjproject master branch,
 the patches aren't needed.  Also, applying the patches would contaminate
 the pjproject repo and you wouldn't be able to do a clean commit there.
 
-You'll see compile and/or link warnings you wouldn't see with a normal
+You may see compile and/or link warnings you wouldn't see with a normal
 bundled build.
-
 
 ## How it works
 
@@ -190,24 +189,24 @@ When a `make` is done, either from top-level asterisk or from the
 third-party/pjproject directory, it checks `PJPROJECT_BUNDLED_OOT`
 and if set to yes it...
 
-    * Alters the behavior of `clean` and `distclean` to just run
-    pjproject's `clean` or `distclean` targets and to NOT remove the
-    `source` directory or symlink as it would normally do.
+* Alters the behavior of `clean` and `distclean` to just run
+pjproject's `clean` or `distclean` targets and to NOT remove the
+`source` directory or symlink as it would normally do.
 
-    * Generates `astdep` dependency files in the pjproject source tree
-    if they don't already exist.  These are git-ignored by the edit
-    to pjproject's `.git/info/exclude` done above.  You'll
-    see new progress messages during the make as the astdep files are
-    built.
+* Generates `astdep` dependency files in the pjproject source tree
+if they don't already exist.  These are git-ignored by the edit
+to pjproject's `.git/info/exclude` done above.  You'll
+see new progress messages during the make as the astdep files are
+built.
 
-    * Copies asterisk_malloc_debug.c, asterisk_malloc_debug.h and
-    config_site.h from the patches directory into the pjproject source
-    tree.  These are also git-ignored by the edit to pjproject's
-    `.git/info/exclude` file.
+* Copies asterisk_malloc_debug.c, asterisk_malloc_debug.h and
+config_site.h from the patches directory into the pjproject source
+tree.  These are also git-ignored by the edit to pjproject's
+`.git/info/exclude` file.
 
-    * Compiles only the out-of-date source files into their respective
-    libpj libraries.  That in turn triggers the asterisk top-level
-    make to re-link main/libasteriskpj.so.
+* Compiles only the out-of-date source files into their respective
+libpj libraries.  That in turn triggers the asterisk top-level
+make to re-link main/libasteriskpj.so.
 
 
 


### PR DESCRIPTION
* pjproject is now configured with --disable-libsrtp so it will
  build correctly when doing "out-of-tree" development.  Asterisk
  doesn't use pjproject for handling media so pjproject doesn't
  need libsrtp itself.

* The pjsua app (which we used to use for the testsuite) no longer
  builds in pjproject's master branch so we just skip it.  The
  testsuite no longer needs it anyway.

See third-party/pjproject/README-hacking.md for more info on building
pjproject "out-of-tree".
