### PR TITLE
config.c Make ast_variable_update update last match.

### DIFF
--- a/main/config.c
+++ b/main/config.c
@@ -1534,13 +1534,19 @@ int ast_variable_delete(struct ast_category *category, const char *variable, con
 int ast_variable_update(struct ast_category *category, const char *variable,
 						const char *value, const char *match, unsigned int object)
 {
-	struct ast_variable *cur, *prev=NULL, *newer=NULL;
+	struct ast_variable *cur, *prev=NULL, *newer=NULL, *matchvar = NULL;
 
 	for (cur = category->root; cur; prev = cur, cur = cur->next) {
 		if (strcasecmp(cur->name, variable) ||
 			(!ast_strlen_zero(match) && strcasecmp(cur->value, match)))
 			continue;
+		matchvar = cur;
+	}
 
+	for (cur = category->root; cur; prev = cur, cur = cur->next) {
+		if (cur != matchvar) {
+			continue;
+		}
 		if (!(newer = ast_variable_new(variable, value, cur->file)))
 			return -1;
 


### PR DESCRIPTION
ast_variable_update currently sets the first match for a variable, as opposed to the last one. This issue is complementary to that raised in #244.

This is incorrect and results in the wrong (or no) action being taken in cases where a section inherits from a template section. When the traversal occurs to update the setting, the existing code erroneously would use the first of possibly multiple matches in its update logic, which is wrong. Now, explicitly use the last match in the traversal, which will ensure that the actual setting is updated properly, and not skipped or ignored because a template from which the setting's section inherits was used for comparison.

Resolves: #960

UpgradeNote: Config variables, when set/updated, such as via AMI, will now have the corresponding setting updated, even if their sections inherit from template sections.