### PR TITLE
Add res_pjsip_config_sangoma external module.

### DIFF
--- a/res/res.xml
+++ b/res/res.xml
@@ -12,3 +12,10 @@
 		</downloader>
 	</member_data>
 </member>
+<member name="res_pjsip_config_sangoma" displayname="Download the Sangoma PJSIP Configuration Module for Asterisk. See https://downloads.digium.com/pub/telephony/res_pjsip_config_sangoma.">
+	<support_level>external</support_level>
+	<conflict>no_binary_modules</conflict>
+	<depend>xmlstarlet</depend>
+	<depend>bash</depend>
+	<defaultenabled>no</defaultenabled>
+</member>


### PR DESCRIPTION
Adds res_pjsip_config_sangoma as an external module that can be
downloaded via menuselect. It lives under the Resource Modules section.
