### PR TITLE
res_pjsip: Move tenantid to end of ast_sip_endpoint

### DIFF
--- a/include/asterisk/res_pjsip.h
+++ b/include/asterisk/res_pjsip.h
@@ -987,8 +987,6 @@ struct ast_sip_endpoint {
 		AST_STRING_FIELD(incoming_mwi_mailbox);
 		/*! STIR/SHAKEN profile to use */
 		AST_STRING_FIELD(stir_shaken_profile);
-		/*! Tenant ID for the endpoint */
-		AST_STRING_FIELD(tenantid);
 	);
 	/*! Configuration for extensions */
 	struct ast_sip_endpoint_extensions extensions;
@@ -1072,6 +1070,8 @@ struct ast_sip_endpoint {
 	enum ast_sip_100rel_mode rel100;
 	/*! Send Advice-of-Charge messages */
 	unsigned int send_aoc;
+	/*! Tenant ID for the endpoint */
+	AST_STRING_FIELD_EXTENDED(tenantid);
 };
 
 /*! URI parameter for symmetric transport */

--- a/res/res_pjsip/pjsip_configuration.c
+++ b/res/res_pjsip/pjsip_configuration.c
@@ -2458,7 +2458,7 @@ void *ast_sip_endpoint_alloc(const char *name)
 	if (!endpoint) {
 		return NULL;
 	}
-	if (ast_string_field_init(endpoint, 64)) {
+	if (ast_string_field_init(endpoint, 128)) {
 		ao2_cleanup(endpoint);
 		return NULL;
 	}
@@ -2469,6 +2469,10 @@ void *ast_sip_endpoint_alloc(const char *name)
 		return NULL;
 	}
 	if (ast_string_field_init_extended(endpoint, overlap_context)) {
+		ao2_cleanup(endpoint);
+		return NULL;
+	}
+	if (ast_string_field_init_extended(endpoint, tenantid)) {
 		ao2_cleanup(endpoint);
 		return NULL;
 	}


### PR DESCRIPTION
The tenantid field was originally added to the ast_sip_endpoint
structure at the end of the AST_DECLARE_STRING_FIELDS block.  This
caused everything after it in the structure to move down in memory
and break ABI compatibility.  It's now at the end of the structure
as an AST_STRING_FIELD_EXTENDED.  Given the number of string fields
in the structure now, the initial string field allocation was
also increased from 64 to 128 bytes.

Resolves: #982
