### PR TITLE
res_pjsip: Move tenantid to end of ast_sip_endpoint (cert-18.9 only)

### DIFF
--- a/include/asterisk/res_pjsip.h
+++ b/include/asterisk/res_pjsip.h
@@ -911,8 +911,6 @@ struct ast_sip_endpoint {
 		AST_STRING_FIELD(incoming_mwi_mailbox);
 		/*! STIR/SHAKEN profile to use */
 		AST_STRING_FIELD(stir_shaken_profile);
-		/*! Tenant ID for the endpoint */
-		AST_STRING_FIELD(tenantid);
 	);
 	/*! Configuration for extensions */
 	struct ast_sip_endpoint_extensions extensions;
@@ -986,6 +984,8 @@ struct ast_sip_endpoint {
 	AST_STRING_FIELD_EXTENDED(geoloc_incoming_call_profile);
 	/*! The name of the geoloc profile to apply when Asterisk sends a call to this endpoint */
 	AST_STRING_FIELD_EXTENDED(geoloc_outgoing_call_profile);
+	/*! Tenant ID for the endpoint */
+	AST_STRING_FIELD_EXTENDED(tenantid);
 };
 
 /*! URI parameter for symmetric transport */

--- a/res/res_pjsip/pjsip_configuration.c
+++ b/res/res_pjsip/pjsip_configuration.c
@@ -2383,13 +2383,17 @@ void *ast_sip_endpoint_alloc(const char *name)
 	if (!endpoint) {
 		return NULL;
 	}
-	if (ast_string_field_init(endpoint, 64)) {
+	if (ast_string_field_init(endpoint, 128)) {
 		ao2_cleanup(endpoint);
 		return NULL;
 	}
 
 	if (ast_string_field_init_extended(endpoint, geoloc_incoming_call_profile) ||
 		ast_string_field_init_extended(endpoint, geoloc_outgoing_call_profile)) {
+		ao2_cleanup(endpoint);
+		return NULL;
+	}
+	if (ast_string_field_init_extended(endpoint, tenantid)) {
 		ao2_cleanup(endpoint);
 		return NULL;
 	}


### PR DESCRIPTION
The tenantid field was originally added to the ast_sip_endpoint
structure at the end of the AST_DECLARE_STRING_FIELDS block.  This
caused everything after it in the structure to move down in memory
and break ABI compatibility.  It's now at the end of the structure
as an AST_STRING_FIELD_EXTENDED.  Given the number of string fields
in the structure now, the initial string field allocation was
also increased from 64 to 128 bytes.

Resolves: #982
