### PR TITLE
sig_analog: Fix regression with FGD and E911 signaling.

### DIFF
--- a/channels/sig_analog.c
+++ b/channels/sig_analog.c
@@ -1890,6 +1890,11 @@ static void *__analog_ss_thread(void *data)
 					if (p->sig == ANALOG_SIG_E911) {
 						analog_off_hook(p);
 					}
+					if (p->sig != ANALOG_SIG_FGC_CAMAMF) {
+						/* CAMA signaling (CAMA and CAMAMF) are handled in an if block below.
+						 * Everything else, process here. */
+						res = analog_my_getsigstr(chan, dtmfbuf + strlen(dtmfbuf), "#", 3000);
+					}
 				}
 				if (res < 1) {
 					analog_dsp_reset_and_flush_digits(p);


### PR DESCRIPTION
Commit 466eb4a52b69e6dead7ebba13a83f14ef8a559c1 introduced a regression which completely broke Feature Group D and E911 signaling, by removing the call to analog_my_getsigstr, which affected multiple switch cases. Restore the original behavior for all protocols except Feature Group C CAMA (MF), which is all that patch was attempting to target.

Resolves: #993