### PR TITLE
res_pjsip: Change suppress_moh_on_sendonly to OPT_BOOL_T

### DIFF
--- a/contrib/ast-db-manage/config/versions/4f91fc18c979_add_suppress_moh_on_sendonly.py
+++ b/contrib/ast-db-manage/config/versions/4f91fc18c979_add_suppress_moh_on_sendonly.py
@@ -14,17 +14,17 @@ from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import ENUM
 
-YESNO_NAME = 'yesno_values'
-YESNO_VALUES = ['yes', 'no']
-
+AST_BOOL_NAME = 'ast_bool_values'
+AST_BOOL_VALUES = [ '0', '1',
+                    'off', 'on',
+                    'false', 'true',
+                    'no', 'yes' ]
 
 def upgrade():
-    yesno_values = ENUM(*YESNO_VALUES, name=YESNO_NAME, create_type=False)
-
-    op.add_column('ps_endpoints', sa.Column('suppress_moh_on_sendonly', yesno_values))
-
+    ast_bool_values = ENUM(*AST_BOOL_VALUES, name=AST_BOOL_NAME, create_type=False)
+    op.add_column('ps_endpoints', sa.Column('suppress_moh_on_sendonly', ast_bool_values))
 
 def downgrade():
     if op.get_context().bind.dialect.name == 'mssql':
-        op.drop_constraint('ck_ps_endpoints_suppress_moh_on_sendonly_yesno_values', 'ps_endpoints')
+        op.drop_constraint('ck_ps_endpoints_suppress_moh_on_sendonly_ast_bool_values', 'ps_endpoints')
     op.drop_column('ps_endpoints', 'suppress_moh_on_sendonly')

--- a/res/res_pjsip/pjsip_configuration.c
+++ b/res/res_pjsip/pjsip_configuration.c
@@ -2305,7 +2305,7 @@ int ast_res_pjsip_initialize_configuration(void)
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "send_aoc", "no", OPT_BOOL_T, 1, FLDSET(struct ast_sip_endpoint, send_aoc));
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "tenantid", "", OPT_STRINGFIELD_T, 0, STRFLDSET(struct ast_sip_endpoint, tenantid));
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "suppress_moh_on_sendonly",
-		"no", OPT_YESNO_T, 1, FLDSET(struct ast_sip_endpoint, suppress_moh_on_sendonly));
+		"no", OPT_BOOL_T, 1, FLDSET(struct ast_sip_endpoint, suppress_moh_on_sendonly));
 
 	if (ast_sip_initialize_sorcery_transport()) {
 		ast_log(LOG_ERROR, "Failed to register SIP transport support with sorcery\n");


### PR DESCRIPTION
The suppress_moh_on_sendonly endpoint option should have been
defined as OPT_BOOL_T in pjsip_configuration.c and AST_BOOL_VALUES
in the alembic script instead of OPT_YESNO_T and YESNO_VALUES.

Also updated contrib/ast-db-manage/README.md to indicate that
AST_BOOL_VALUES should always be used and provided an example.

Resolves: #995
