### PR TITLE
Enabling Real Time Text (RTT) for PJSIP library

### DIFF
--- a/channels/pjsip/dialplan_functions.c
+++ b/channels/pjsip/dialplan_functions.c
@@ -91,6 +91,8 @@ static int channel_read_rtp(struct ast_channel *chan, const char *type, const ch
 		media = session->active_media_state->default_session[AST_MEDIA_TYPE_AUDIO];
 	} else if (!strcmp(field, "video")) {
 		media = session->active_media_state->default_session[AST_MEDIA_TYPE_VIDEO];
+	} else if (!strcmp(field, "text")) {
+		media = session->active_media_state->default_session[AST_MEDIA_TYPE_TEXT];
 	} else {
 		ast_log(AST_LOG_WARNING, "Unknown media type field '%s' for 'rtp' information\n", field);
 		return -1;

--- a/include/asterisk/res_pjsip.h
+++ b/include/asterisk/res_pjsip.h
@@ -924,6 +924,12 @@ struct ast_sip_endpoint_media_configuration {
 	unsigned int tos_video;
 	/*! Priority for video streams */
 	unsigned int cos_video;
+	/*! DSCP TOS bits for text streams */
+	unsigned int tos_text;
+	/*! Priority for text streams */
+	unsigned int cos_text;
+	/*! DSCP indicate if text stream supports RED */
+	unsigned int red_enabled;
 	/*! Is g.726 packed in a non standard way */
 	unsigned int g726_non_standard;
 	/*! Bind the RTP instance to the media_address */
@@ -934,6 +940,8 @@ struct ast_sip_endpoint_media_configuration {
 	unsigned int max_audio_streams;
 	/*! Maximum number of video streams to offer/accept */
 	unsigned int max_video_streams;
+	/*! Maximum number of text streams to offer/accept */
+	unsigned int max_text_streams;
 	/*! Use BUNDLE */
 	unsigned int bundle;
 	/*! Enable webrtc settings and defaults */

--- a/main/channel.c
+++ b/main/channel.c
@@ -4795,6 +4795,7 @@ int ast_sendtext_data(struct ast_channel *chan, struct ast_msg_data *msg)
 		f.frametype = AST_FRAME_TEXT;
 		f.datalen = body_len;
 		f.mallocd = AST_MALLOCD_DATA;
+		f.stream_num = ast_stream_get_position(ast_channel_get_default_stream(chan, AST_MEDIA_TYPE_TEXT));
 		f.data.ptr = ast_strdup(body);
 		if (f.data.ptr) {
 			res = ast_channel_tech(chan)->write_text(chan, &f);

--- a/main/frame.c
+++ b/main/frame.c
@@ -313,7 +313,7 @@ struct ast_frame *__ast_frdup(const struct ast_frame *f, const char *file, int l
 #endif
 
 	/* Start with standard stuff */
-	len = sizeof(*out) + AST_FRIENDLY_OFFSET + f->datalen;
+	len = sizeof(*out) + AST_FRIENDLY_OFFSET + f->datalen + 1;
 	/* If we have a source, add space for it */
 	/*
 	 * XXX Watch out here - if we receive a src which is not terminated
@@ -374,13 +374,16 @@ struct ast_frame *__ast_frdup(const struct ast_frame *f, const char *file, int l
 	if (out->datalen || f->frametype == AST_FRAME_TEXT) {
 		out->data.ptr = buf + sizeof(*out) + AST_FRIENDLY_OFFSET;
 		memcpy(out->data.ptr, f->data.ptr, out->datalen);
+		if (f->frametype == AST_FRAME_TEXT) {
+			((char*)out->data.ptr)[out->datalen] = '\0';
+		}
 	} else {
 		out->data.uint32 = f->data.uint32;
 	}
 	if (srclen > 0) {
 		/* This may seem a little strange, but it's to avoid a gcc (4.2.4) compiler warning */
 		char *src;
-		out->src = buf + sizeof(*out) + AST_FRIENDLY_OFFSET + f->datalen;
+		out->src = buf + sizeof(*out) + AST_FRIENDLY_OFFSET + f->datalen + 1;
 		src = (char *) out->src;
 		/* Must have space since we allocated for it */
 		strcpy(src, f->src);

--- a/res/res_pjsip/pjsip_configuration.c
+++ b/res/res_pjsip/pjsip_configuration.c
@@ -1067,6 +1067,8 @@ static int tos_handler(const struct aco_option *opt,
 		endpoint->media.tos_audio = value;
 	} else if (!strcmp(var->name, "tos_video")) {
 		endpoint->media.tos_video = value;
+	} else if (!strcmp(var->name, "tos_text")) {
+		endpoint->media.tos_text = value;
 	} else {
 		/* If we reach this point, someone called the tos_handler when they shouldn't have. */
 		ast_assert(0);
@@ -1090,6 +1092,16 @@ static int tos_video_to_str(const void *obj, const intptr_t *args, char **buf)
 	const struct ast_sip_endpoint *endpoint = obj;
 
 	if (ast_asprintf(buf, "%u", endpoint->media.tos_video) == -1) {
+		return -1;
+	}
+	return 0;
+}
+
+static int tos_text_to_str(const void *obj, const intptr_t *args, char **buf)
+{
+	const struct ast_sip_endpoint *endpoint = obj;
+
+	if (ast_asprintf(buf, "%u", endpoint->media.tos_text) == -1) {
 		return -1;
 	}
 	return 0;
@@ -2229,8 +2241,10 @@ int ast_res_pjsip_initialize_configuration(void)
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "sdp_session", "Asterisk", OPT_STRINGFIELD_T, 0, STRFLDSET(struct ast_sip_endpoint, media.sdpsession));
 	ast_sorcery_object_field_register_custom(sip_sorcery, "endpoint", "tos_audio", "0", tos_handler, tos_audio_to_str, NULL, 0, 0);
 	ast_sorcery_object_field_register_custom(sip_sorcery, "endpoint", "tos_video", "0", tos_handler, tos_video_to_str, NULL, 0, 0);
+	ast_sorcery_object_field_register_custom(sip_sorcery, "endpoint", "tos_text", "0", tos_handler, tos_text_to_str, NULL, 0, 0);
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "cos_audio", "0", OPT_UINT_T, 0, FLDSET(struct ast_sip_endpoint, media.cos_audio));
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "cos_video", "0", OPT_UINT_T, 0, FLDSET(struct ast_sip_endpoint, media.cos_video));
+	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "cos_text", "5", OPT_UINT_T, 0, FLDSET(struct ast_sip_endpoint, media.cos_text));
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "allow_subscribe", "yes", OPT_BOOL_T, 1, FLDSET(struct ast_sip_endpoint, subscription.allow));
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "sub_min_expiry", "0", OPT_UINT_T, 0, FLDSET(struct ast_sip_endpoint, subscription.minexpiry));
 	ast_sorcery_object_field_register_custom(sip_sorcery, "endpoint", "from_user", "", from_user_handler, from_user_to_str, NULL, 0, 0);
@@ -2271,6 +2285,7 @@ int ast_res_pjsip_initialize_configuration(void)
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "notify_early_inuse_ringing", "no", OPT_BOOL_T, 1, FLDSET(struct ast_sip_endpoint, notify_early_inuse_ringing));
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "max_audio_streams", "1", OPT_UINT_T, 0, FLDSET(struct ast_sip_endpoint, media.max_audio_streams));
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "max_video_streams", "1", OPT_UINT_T, 0, FLDSET(struct ast_sip_endpoint, media.max_video_streams));
+	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "max_text_streams", "1", OPT_UINT_T, 0, FLDSET(struct ast_sip_endpoint, media.max_text_streams));
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "bundle", "no", OPT_BOOL_T, 1, FLDSET(struct ast_sip_endpoint, media.bundle));
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "webrtc", "no", OPT_YESNO_T, 1, FLDSET(struct ast_sip_endpoint, media.webrtc));
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "incoming_mwi_mailbox", "", OPT_STRINGFIELD_T, 0, STRFLDSET(struct ast_sip_endpoint, incoming_mwi_mailbox));

--- a/res/res_pjsip_session.c
+++ b/res/res_pjsip_session.c
@@ -608,8 +608,9 @@ static int is_stream_limitation_reached(enum ast_media_type type, const struct a
 	case AST_MEDIA_TYPE_IMAGE:
 		/* We don't have an option for image (T.38) streams so cap it to one. */
 		return (type_streams[type] > 0);
-	case AST_MEDIA_TYPE_UNKNOWN:
 	case AST_MEDIA_TYPE_TEXT:
+		return !(type_streams[type] < endpoint->media.max_text_streams);
+	case AST_MEDIA_TYPE_UNKNOWN:
 	default:
 		/* We don't want any unknown or "other" streams on our endpoint,
 		 * so always just say we've reached the limit


### PR DESCRIPTION
Implement changes based on archived issue: https://issues-archive.asterisk.org/ASTERISK-28654

I'm the original author and I've signed CLA.

Changes are:

    chan_pjsip - added write_text function to the pjsip_tech driver
    Added case for AST_FRAME_TEXT in chan_pjsip_write_stream
    Added case to handle text in chan_pjsip_write
    pjsip/dialplan_functions.c: added logic to handle media for TEXT
    res_pjsip.h: added variables to deal with endpoint media
    channel.c: added logic to add a stream_num for a frame
    frame.c: added code to handle and fix issues with red.
    res_pjsip_sdp_rtp.c: added logic to setup SDP.
    Added logic to handle tos and cos text
    Added logic to RED for red enabled
    res_pjsip_session.c: aded logic for max_text_streams
    res_rtp_asterisk.c: Added logic to hanle Red and dealing with
    a repeating RTP issue
    pjsip_configuration.c: Added logic to handle text for PJSIP library

Original code-review can be found here:
http://lists.digium.com/pipermail/asterisk-code-review/2019-December/094886.html