### PR TITLE
manager.c: Add Processed Call Count to CoreStatus output

### DIFF
--- a/main/manager.c
+++ b/main/manager.c
@@ -6443,13 +6443,15 @@ static int action_corestatus(struct mansession *s, const struct message *m)
 			"CoreReloadDate: %s\r\n"
 			"CoreReloadTime: %s\r\n"
 			"CoreCurrentCalls: %d\r\n"
+			"CoreProcessedCalls: %d\r\n"
 			"\r\n",
 			idText,
 			startupdate,
 			startuptime,
 			reloaddate,
 			reloadtime,
-			ast_active_channels()
+			ast_active_channels(),
+			ast_processed_calls()
 			);
 	return 0;
 }


### PR DESCRIPTION
This update adds the processed call count to the CoreStatus AMI Action responsie. This output is similar to the values returned by "core show channels" or "core show calls" in the CLI.

UserNote: The current processed call count is now returned as CoreProcessedCalls from the CoreStatus AMI Action.