### PR TITLE
format_gsm.c: Added mime type

### DIFF
--- a/formats/format_gsm.c
+++ b/formats/format_gsm.c
@@ -174,6 +174,7 @@ static off_t gsm_tell(struct ast_filestream *fs)
 static struct ast_format_def gsm_f = {
 	.name = "gsm",
 	.exts = "gsm",
+	.mime_types = "audio/gsm",
 	.write = gsm_write,
 	.seek =	gsm_seek,
 	.trunc = gsm_trunc,


### PR DESCRIPTION
Because URL parser does not work properly and has been removed(https://github.com/asterisk/asterisk/commit/6428124b06bc0147ce6c6379a96da4c8ac559af7), i added mime type to format_gsm to parse file extensions from content-type:

```
Connected to Asterisk 20.11.0 currently running on asterisk20 (pid = 3316)
asterisk20*CLI> media cache show http://asterisk.khabulyak.su/gsm/your
URI: http://asterisk.khabulyak.su/gsm/your
----------------------------------------
                        Path: /var/cache/asterisk/bucket-TjDHtf.gsm
                        etag: "674dc5f6-420"
               last-modified: Mon, 02 Dec 2024 14:36:38 GMT
                         ext: .gsm
                content-type: audio/x-gsm
            __actual_expires:                     1733152296
```

Without this change asterisk can't determine file extension in this case and can't play a file.

```
    -- Executing [123@main:1] answer("PJSIP/6001-00000003", "")
       > 0x7fa710032300 -- Strict RTP learning after remote address set to: 10.34.134.8:4004
    -- Executing [123@main:1] playback("PJSIP/6001-00000003", "http://asterisk.khabulyak.su/gsm/your")
       > 0x7fa710032300 -- Strict RTP learning after remote address set to: 10.34.134.8:4004
    -- <PJSIP/6001-00000003> Playing 'http://asterisk.khabulyak.su/gsm/your.gsm' (language 'en')
       > 0x7fa710032300 -- Strict RTP switching to RTP target address 10.34.134.8:4004 as source
    -- Auto fallthrough, channel 'PJSIP/6001-00000003' status is 'UNKNOWN'
```