### PR TITLE
Allow C++ source files (as extension .cc) in the main directory

### DIFF
--- a/main/Makefile
+++ b/main/Makefile
@@ -31,7 +31,8 @@ ifeq ($(PJPROJECT_BUNDLED),yes)
 SRC:=$(filter-out libasteriskpj.c,$(SRC))
 endif
 OBJSFILTER:=$(MOD_OBJS) fskmodem_int.o fskmodem_float.o cygload.o buildinfo.o
-OBJS=$(filter-out $(OBJSFILTER),$(SRC:.c=.o))
+SRC_CC:=$(wildcard *.cc)
+OBJS=$(filter-out $(OBJSFILTER),$(SRC:.c=.o) $(SRC_CC:.cc=.oo))
 
 # we need to link in the objects statically, not as a library, because
 # otherwise modules will not have them available if none of the static


### PR DESCRIPTION
Although C++ files (as extension .cc) have been handled in the module
directories for many years, the main directory was missing one line in its
Makefile that prevented C++ files from being recognised there.
