### PR TITLE
Header fixes for compiling C++ source files

### DIFF
--- a/include/asterisk/astmm.h
+++ b/include/asterisk/astmm.h
@@ -300,7 +300,7 @@ int __ast_repl_vasprintf(char **strp, const char *format, va_list ap, const char
 	({                                                                \
 		const char *__old = (s);                                  \
 		size_t __len = strlen(__old) + 1;                         \
-		char *__new = __builtin_alloca(__len);                    \
+		char *__new = (char *)__builtin_alloca(__len);                    \
 		memcpy (__new, __old, __len);                             \
 		__new;                                                    \
 	}))

--- a/include/asterisk/lock.h
+++ b/include/asterisk/lock.h
@@ -63,6 +63,10 @@
 #include "asterisk/logger.h"
 #include "asterisk/compiler.h"
 
+#if defined(__cplusplus) || defined(c_plusplus)
+extern "C" {
+#endif
+
 #define AST_PTHREADT_NULL (pthread_t) -1
 #define AST_PTHREADT_STOP (pthread_t) -2
 
@@ -765,6 +769,10 @@ AST_INLINE_API(int ast_atomic_dec_and_test(volatile int *p),
 {
 	return ast_atomic_sub_fetch(p, 1, __ATOMIC_RELAXED) == 0;
 })
+
+#if defined(__cplusplus) || defined(c_plusplus)
+}
+#endif
 
 /*! @} */
 

--- a/include/asterisk/logger.h
+++ b/include/asterisk/logger.h
@@ -190,9 +190,6 @@ void __attribute__((format(printf, 6, 0))) __ast_verbose_ap(const char *file, in
 
 void __attribute__((format(printf, 2, 3))) ast_child_verbose(int level, const char *fmt, ...);
 
-int ast_register_verbose(void (*verboser)(const char *string)) attribute_warn_unused_result;
-int ast_unregister_verbose(void (*verboser)(const char *string)) attribute_warn_unused_result;
-
 /*
  * These gymnastics are due to platforms which designate char as unsigned by
  * default.  Level is the negative character -- offset by 1, because \0 is

--- a/include/asterisk/strings.h
+++ b/include/asterisk/strings.h
@@ -756,7 +756,7 @@ char * attribute_pure ast_str_buffer(const struct ast_str *buf),
 	if (__builtin_expect(buf->__AST_STR_LEN > 0, 1)) {
 		return (char *) buf->__AST_STR_STR;
 	}
-	return "";
+	return (char *)"";
 }
 )
 


### PR DESCRIPTION
A few tweaks needed to be done to some existing header files to allow them to
be compiled when included from C++ source files.

logger.h had declarations for ast_register_verbose() and
ast_unregister_verbose() which caused C++ issues but those functions were
actually removed from logger.c many years ago so the declarations were just
removed from logger.h.
