### PR TITLE
gcc14: Fix issues caught by gcc 14 (branches <= 20)

### DIFF
--- a/channels/sip/reqresp_parser.c
+++ b/channels/sip/reqresp_parser.c
@@ -279,7 +279,7 @@ AST_TEST_DEFINE(sip_parse_uri_full_test)
 
 	struct testdata *testdataptr;
 
-	static AST_LIST_HEAD_NOLOCK(testdataliststruct, testdata) testdatalist;
+	AST_LIST_HEAD_NOLOCK(testdataliststruct, testdata) testdatalist;
 
 	struct testdata td1 = {
 		.desc = "no headers",
@@ -1326,7 +1326,7 @@ AST_TEST_DEFINE(parse_name_andor_addr_test)
 
 	struct testdata *testdataptr;
 
-	static AST_LIST_HEAD_NOLOCK(testdataliststruct, testdata) testdatalist;
+	AST_LIST_HEAD_NOLOCK(testdataliststruct, testdata) testdatalist;
 
 	struct testdata td1 = {
 		.desc = "quotes and brackets",
@@ -1552,7 +1552,7 @@ AST_TEST_DEFINE(parse_contact_header_test)
 	struct contact *tdcontactptr;
 	struct contact *contactptr;
 
-	static AST_LIST_HEAD_NOLOCK(testdataliststruct, testdata) testdatalist;
+	AST_LIST_HEAD_NOLOCK(testdataliststruct, testdata) testdatalist;
 	struct contactliststruct contactlist1, contactlist2;
 
 	struct testdata td1 = {
@@ -1775,7 +1775,7 @@ AST_TEST_DEFINE(sip_parse_options_test)
 	};
 
 	struct testdata *testdataptr;
-	static AST_LIST_HEAD_NOLOCK(testdataliststruct, testdata) testdatalist;
+	AST_LIST_HEAD_NOLOCK(testdataliststruct, testdata) testdatalist;
 
 	struct testdata test1 = {
 		.name = "test_all_unsupported",
@@ -2475,7 +2475,7 @@ AST_TEST_DEFINE(parse_via_test)
 		AST_LIST_ENTRY(testdata) list;
 	};
 	struct testdata *testdataptr;
-	static AST_LIST_HEAD_NOLOCK(testdataliststruct, testdata) testdatalist;
+	AST_LIST_HEAD_NOLOCK(testdataliststruct, testdata) testdatalist;
 	struct testdata t1 = {
 		.in = "SIP/2.0/UDP host:port;branch=thebranch",
 		.expected_protocol = "SIP/2.0/UDP",

--- a/tests/test_message.c
+++ b/tests/test_message.c
@@ -680,10 +680,10 @@ AST_TEST_DEFINE(test_message_has_destination_dialplan)
 	ast_msg_set_exten(msg, "__I_SHOULD_NOT_EXIST_PLZ__");
 	ast_test_validate(test, ast_msg_has_destination(msg) == 0);
 
-	ast_msg_set_exten(msg, NULL);
+	ast_msg_set_exten(msg, "%s", "");
 	ast_test_validate(test, ast_msg_has_destination(msg) == 0);
 
-	ast_msg_set_context(msg, NULL);
+	ast_msg_set_context(msg, "%s", "");
 	ast_msg_set_exten(msg, TEST_EXTENSION);
 	ast_test_validate(test, ast_msg_has_destination(msg) == 0);
 
@@ -716,10 +716,10 @@ AST_TEST_DEFINE(test_message_has_destination_handler)
 
 	ast_msg_set_to(msg, "foo");
 	ast_msg_set_context(msg, TEST_CONTEXT);
-	ast_msg_set_exten(msg, NULL);
+	ast_msg_set_exten(msg, "%s", "");
 	ast_test_validate(test, ast_msg_has_destination(msg) == 1);
 
-	ast_msg_set_context(msg, NULL);
+	ast_msg_set_context(msg, "%s", "");
 	ast_test_validate(test, ast_msg_has_destination(msg) == 1);
 
 	ast_msg_set_to(msg, "__I_SHOULD_NOT_EXIST_PLZ__");
@@ -756,7 +756,7 @@ AST_TEST_DEFINE(test_message_msg_send)
 
 	ast_msg_set_to(msg, "foo");
 	ast_msg_set_context(msg, TEST_CONTEXT);
-	ast_msg_set_exten(msg, NULL);
+	ast_msg_set_exten(msg, "%s", "");
 	ast_test_validate(test, ast_msg_has_destination(msg) == 1);
 
 	if (!ast_msg_send(msg, "testmsg:foo", "blah")) {


### PR DESCRIPTION
* reqresp_parser.c: Fix misuse of "static" with linked list definitions
* test_message.c: Fix segfaults caused by passing NULL as an sprintf fmt
