### PR TITLE
manager: Add `<since>` tags for all AMI actions (20)

### DIFF
--- a/apps/app_agent_pool.c
+++ b/apps/app_agent_pool.c
@@ -162,6 +162,9 @@
 		<description></description>
 	</function>
 	<manager name="Agents" language="en_US">
+		<since>
+			<version>1.2.0</version>
+		</since>
 		<synopsis>
 			Lists agents and their status.
 		</synopsis>
@@ -235,6 +238,9 @@
 		</managerEventInstance>
 	</managerEvent>
 	<manager name="AgentLogoff" language="en_US">
+		<since>
+			<version>1.2.0</version>
+		</since>
 		<synopsis>
 			Sets an agent as no longer logged in.
 		</synopsis>

--- a/apps/app_confbridge.c
+++ b/apps/app_confbridge.c
@@ -302,6 +302,9 @@
 		</see-also>
 	</function>
 	<manager name="ConfbridgeList" language="en_US">
+		<since>
+			<version>10.0.0</version>
+		</since>
 		<synopsis>
 			List participants in a conference.
 		</synopsis>
@@ -381,6 +384,9 @@
 		</managerEventInstance>
 	</managerEvent>
 	<manager name="ConfbridgeListRooms" language="en_US">
+		<since>
+			<version>10.0.0</version>
+		</since>
 		<synopsis>
 			List active conferences.
 		</synopsis>
@@ -425,6 +431,9 @@
 		</managerEventInstance>
 	</managerEvent>
 	<manager name="ConfbridgeMute" language="en_US">
+		<since>
+			<version>10.0.0</version>
+		</since>
 		<synopsis>
 			Mute a Confbridge user.
 		</synopsis>
@@ -441,6 +450,9 @@
 		</description>
 	</manager>
 	<manager name="ConfbridgeUnmute" language="en_US">
+		<since>
+			<version>10.0.0</version>
+		</since>
 		<synopsis>
 			Unmute a Confbridge user.
 		</synopsis>
@@ -457,6 +469,9 @@
 		</description>
 	</manager>
 	<manager name="ConfbridgeKick" language="en_US">
+		<since>
+			<version>10.0.0</version>
+		</since>
 		<synopsis>
 			Kick a Confbridge user.
 		</synopsis>
@@ -472,6 +487,9 @@
 		</description>
 	</manager>
 	<manager name="ConfbridgeLock" language="en_US">
+		<since>
+			<version>10.0.0</version>
+		</since>
 		<synopsis>
 			Lock a Confbridge conference.
 		</synopsis>
@@ -483,6 +501,9 @@
 		</description>
 	</manager>
 	<manager name="ConfbridgeUnlock" language="en_US">
+		<since>
+			<version>10.0.0</version>
+		</since>
 		<synopsis>
 			Unlock a Confbridge conference.
 		</synopsis>
@@ -494,6 +515,9 @@
 		</description>
 	</manager>
 	<manager name="ConfbridgeStartRecord" language="en_US">
+		<since>
+			<version>10.0.0</version>
+		</since>
 		<synopsis>
 			Start recording a Confbridge conference.
 		</synopsis>
@@ -507,6 +531,9 @@
 		</description>
 	</manager>
 	<manager name="ConfbridgeStopRecord" language="en_US">
+		<since>
+			<version>10.0.0</version>
+		</since>
 		<synopsis>
 			Stop recording a Confbridge conference.
 		</synopsis>
@@ -518,6 +545,9 @@
 		</description>
 	</manager>
 	<manager name="ConfbridgeSetSingleVideoSrc" language="en_US">
+		<since>
+			<version>10.0.0</version>
+		</since>
 		<synopsis>
 			Set a conference user as the single video source distributed to all other participants.
 		</synopsis>

--- a/apps/app_controlplayback.c
+++ b/apps/app_controlplayback.c
@@ -98,6 +98,9 @@
 		</description>
 	</application>
 	<manager name="ControlPlayback" language="en_US">
+		<since>
+			<version>12.0.0</version>
+		</since>
 		<synopsis>
 			Control the playback of a file being played to a channel.
 		</synopsis>

--- a/apps/app_meetme.c
+++ b/apps/app_meetme.c
@@ -505,6 +505,9 @@
 		</see-also>
 	</function>
 	<manager name="MeetmeMute" language="en_US">
+		<since>
+			<version>1.4.0</version>
+		</since>
 		<synopsis>
 			Mute a Meetme user.
 		</synopsis>
@@ -517,6 +520,9 @@
 		</description>
 	</manager>
 	<manager name="MeetmeUnmute" language="en_US">
+		<since>
+			<version>1.4.0</version>
+		</since>
 		<synopsis>
 			Unmute a Meetme user.
 		</synopsis>
@@ -529,6 +535,9 @@
 		</description>
 	</manager>
 	<manager name="MeetmeList" language="en_US">
+		<since>
+			<version>1.6.0</version>
+		</since>
 		<synopsis>
 			List participants in a conference.
 		</synopsis>
@@ -545,6 +554,9 @@
 		</description>
 	</manager>
 	<manager name="MeetmeListRooms" language="en_US">
+		<since>
+			<version>10.0.0</version>
+		</since>
 		<synopsis>
 			List active conferences.
 		</synopsis>

--- a/apps/app_mixmonitor.c
+++ b/apps/app_mixmonitor.c
@@ -213,6 +213,9 @@
 		</see-also>
 	</application>
 	<manager name="MixMonitorMute" language="en_US">
+		<since>
+			<version>1.8.0</version>
+		</since>
 		<synopsis>
 			Mute / unMute a Mixmonitor recording.
 		</synopsis>
@@ -233,6 +236,9 @@
 		</description>
 	</manager>
 	<manager name="MixMonitor" language="en_US">
+		<since>
+			<version>11.0.0</version>
+		</since>
 		<synopsis>
 			Record a call and mix the audio during the recording.  Use of StopMixMonitor is required
 			to guarantee the audio file is available for processing during dialplan execution.
@@ -276,6 +282,9 @@
 		</description>
 	</manager>
 	<manager name="StopMixMonitor" language="en_US">
+		<since>
+			<version>11.0.0</version>
+		</since>
 		<synopsis>
 			Stop recording a call through MixMonitor, and free the recording's file handle.
 		</synopsis>

--- a/apps/app_queue.c
+++ b/apps/app_queue.c
@@ -855,6 +855,9 @@
 		</see-also>
 	</function>
 	<manager name="QueueStatus" language="en_US">
+		<since>
+			<version>0.5.0</version>
+		</since>
 		<synopsis>
 			Show queue status.
 		</synopsis>
@@ -872,6 +875,9 @@
 		</description>
 	</manager>
 	<manager name="QueueSummary" language="en_US">
+		<since>
+			<version>1.6.0</version>
+		</since>
 		<synopsis>
 			Show queue summary.
 		</synopsis>
@@ -886,6 +892,9 @@
 		</description>
 	</manager>
 	<manager name="QueueAdd" language="en_US">
+		<since>
+			<version>1.0.0</version>
+		</since>
 		<synopsis>
 			Add interface to queue.
 		</synopsis>
@@ -915,6 +924,9 @@
 		</description>
 	</manager>
 	<manager name="QueueRemove" language="en_US">
+		<since>
+			<version>1.0.0</version>
+		</since>
 		<synopsis>
 			Remove interface from queue.
 		</synopsis>
@@ -931,6 +943,9 @@
 		</description>
 	</manager>
 	<manager name="QueuePause" language="en_US">
+		<since>
+			<version>1.2.0</version>
+		</since>
 		<synopsis>
 			Makes a queue member temporarily unavailable.
 		</synopsis>
@@ -954,6 +969,9 @@
 		</description>
 	</manager>
 	<manager name="QueueLog" language="en_US">
+		<since>
+			<version>1.6.0</version>
+		</since>
 		<synopsis>
 			Adds custom entry in queue_log.
 		</synopsis>
@@ -969,6 +987,9 @@
 		</description>
 	</manager>
 	<manager name="QueuePenalty" language="en_US">
+		<since>
+			<version>1.6.0</version>
+		</since>
 		<synopsis>
 			Set the penalty for a queue member.
 		</synopsis>
@@ -989,6 +1010,9 @@
 		</description>
 	</manager>
 	<manager name="QueueMemberRingInUse" language="en_US">
+		<since>
+			<version>11.0.0</version>
+		</since>
 		<synopsis>
 			Set the ringinuse value for a queue member.
 		</synopsis>
@@ -1002,6 +1026,9 @@
 		</description>
 	</manager>
 	<manager name="QueueRule" language="en_US">
+		<since>
+			<version>1.6.0</version>
+		</since>
 		<synopsis>
 			Queue Rules.
 		</synopsis>
@@ -1016,6 +1043,9 @@
 		</description>
 	</manager>
 	<manager name="QueueReload" language="en_US">
+		<since>
+			<version>1.6.2.0</version>
+		</since>
 		<synopsis>
 			Reload a queue, queues, or any sub-section of a queue or queues.
 		</synopsis>
@@ -1050,6 +1080,9 @@
 		</description>
 	</manager>
 	<manager name="QueueReset" language="en_US">
+		<since>
+			<version>1.6.2.0</version>
+		</since>
 		<synopsis>
 			Reset queue statistics.
 		</synopsis>
@@ -1064,6 +1097,9 @@
 		</description>
 	</manager>
 	<manager name="QueueChangePriorityCaller" language="en_US">
+		<since>
+			<version>15.0.0</version>
+		</since>
 		<synopsis>
 			Change priority of a caller on queue.
 		</synopsis>
@@ -1087,6 +1123,11 @@
 		</description>
 	</manager>
 	<manager name="QueueWithdrawCaller" language="en_US">
+		<since>
+			<version>19.3.0</version>
+			<version>18.11.0</version>
+			<version>16.25.0</version>
+		</since>
 		<synopsis>
 			Request to withdraw a caller from the queue back to the dialplan.
 		</synopsis>

--- a/apps/app_senddtmf.c
+++ b/apps/app_senddtmf.c
@@ -75,6 +75,9 @@
 		</see-also>
 	</application>
 	<manager name="PlayDTMF" language="en_US">
+		<since>
+			<version>1.4.0</version>
+		</since>
 		<synopsis>
 			Play DTMF signal on a specific channel.
 		</synopsis>
@@ -98,6 +101,10 @@
 		</description>
 	</manager>
 	<manager name="SendFlash" language="en_US">
+		<since>
+			<version>20.3.0</version>
+			<version>18.18.0</version>
+		</since>
 		<synopsis>
 			Send a hook flash on a specific channel.
 		</synopsis>

--- a/apps/app_voicemail.c
+++ b/apps/app_voicemail.c
@@ -392,6 +392,9 @@
 		</description>
 	</function>
 	<manager name="VoicemailUsersList" language="en_US">
+		<since>
+			<version>1.6.0</version>
+		</since>
 		<synopsis>
 			List All Voicemail User Information.
 		</synopsis>
@@ -402,6 +405,9 @@
 		</description>
 	</manager>
 	<manager name="VoicemailUserStatus" language="en_US">
+		<since>
+			<version>16.0.0</version>
+		</since>
 		<synopsis>
 			Show the status of given voicemail user's info.
 		</synopsis>
@@ -419,6 +425,9 @@
 		</description>
 	</manager>
 	<manager name="VoicemailRefresh" language="en_US">
+		<since>
+			<version>12.0.0</version>
+		</since>
 		<synopsis>
 			Tell Asterisk to poll mailboxes for a change
 		</synopsis>
@@ -446,6 +455,10 @@
 		</description>
 	</manager>
 	<manager name="VoicemailBoxSummary" language="en_US">
+		<since>
+			<version>20.5.0</version>
+			<version>18.20.0</version>
+		</since>
 		<synopsis>
 			Show the mailbox contents of given voicemail user.
 		</synopsis>
@@ -463,6 +476,10 @@
 		</description>
 	</manager>
 	<manager name="VoicemailMove" language="en_US">
+		<since>
+			<version>20.5.0</version>
+			<version>18.20.0</version>
+		</since>
 		<synopsis>
 			Move Voicemail between mailbox folders of given user.
 		</synopsis>
@@ -489,6 +506,10 @@
 		</description>
 	</manager>
 	<manager name="VoicemailRemove" language="en_US">
+		<since>
+			<version>20.5.0</version>
+			<version>18.20.0</version>
+		</since>
 		<synopsis>
 			Remove Voicemail from mailbox folder.
 		</synopsis>
@@ -512,6 +533,10 @@
 		</description>
 	</manager>
 	<manager name="VoicemailForward" language="en_US">
+		<since>
+			<version>20.5.0</version>
+			<version>18.20.0</version>
+		</since>
 		<synopsis>
 			Forward Voicemail from one mailbox folder to another between given users.
 		</synopsis>

--- a/channels/chan_dahdi.c
+++ b/channels/chan_dahdi.c
@@ -347,6 +347,9 @@
 		</example>
 	</info>
 	<manager name="DAHDITransfer" language="en_US">
+		<since>
+			<version>1.4.22</version>
+		</since>
 		<synopsis>
 			Transfer DAHDI Channel.
 		</synopsis>
@@ -362,6 +365,9 @@
 		</description>
 	</manager>
 	<manager name="DAHDIHangup" language="en_US">
+		<since>
+			<version>1.4.22</version>
+		</since>
 		<synopsis>
 			Hangup DAHDI Channel.
 		</synopsis>
@@ -377,6 +383,9 @@
 		</description>
 	</manager>
 	<manager name="DAHDIDialOffhook" language="en_US">
+		<since>
+			<version>1.4.22</version>
+		</since>
 		<synopsis>
 			Dial over DAHDI channel while offhook.
 		</synopsis>
@@ -394,6 +403,9 @@
 		</description>
 	</manager>
 	<manager name="DAHDIDNDon" language="en_US">
+		<since>
+			<version>1.4.22</version>
+		</since>
 		<synopsis>
 			Toggle DAHDI channel Do Not Disturb status ON.
 		</synopsis>
@@ -409,6 +421,9 @@
 		</description>
 	</manager>
 	<manager name="DAHDIDNDoff" language="en_US">
+		<since>
+			<version>1.4.22</version>
+		</since>
 		<synopsis>
 			Toggle DAHDI channel Do Not Disturb status OFF.
 		</synopsis>
@@ -424,6 +439,9 @@
 		</description>
 	</manager>
 	<manager name="DAHDIShowChannels" language="en_US">
+		<since>
+			<version>1.4.22</version>
+		</since>
 		<synopsis>
 			Show status of DAHDI channels.
 		</synopsis>
@@ -438,6 +456,11 @@
 		</description>
 	</manager>
 	<manager name="DAHDIShowStatus" language="en_US">
+		<since>
+			<version>21.3.0</version>
+			<version>20.8.0</version>
+			<version>18.23.0</version>
+		</since>
 		<synopsis>
 			Show status of DAHDI spans.
 		</synopsis>
@@ -447,6 +470,9 @@
 		</description>
 	</manager>
 	<manager name="DAHDIRestart" language="en_US">
+		<since>
+			<version>1.4.22</version>
+		</since>
 		<synopsis>
 			Fully Restart DAHDI channels (terminates calls).
 		</synopsis>
@@ -458,6 +484,9 @@
 		</description>
 	</manager>
 	<manager name="PRIShowSpans" language="en_US">
+		<since>
+			<version>10.0.0</version>
+		</since>
 		<synopsis>
 			Show status of PRI spans.
 		</synopsis>
@@ -472,6 +501,9 @@
 		</description>
 	</manager>
 	<manager name="PRIDebugSet" language="en_US">
+		<since>
+			<version>13.0.0</version>
+		</since>
 		<synopsis>
 			Set PRI debug levels for a span
 		</synopsis>
@@ -495,6 +527,9 @@
 		</description>
 	</manager>
 	<manager name="PRIDebugFileSet" language="en_US">
+		<since>
+			<version>13.0.0</version>
+		</since>
 		<synopsis>
 			Set the file used for PRI debug message output
 		</synopsis>
@@ -509,6 +544,9 @@
 		</description>
 	</manager>
 	<manager name="PRIDebugFileUnset" language="en_US">
+		<since>
+			<version>13.0.0</version>
+		</since>
 		<synopsis>
 			Disables file output for PRI debug messages
 		</synopsis>

--- a/channels/chan_iax2.c
+++ b/channels/chan_iax2.c
@@ -234,6 +234,9 @@
 		</enumlist>
 	</info>
 	<manager name="IAXpeers" language="en_US">
+		<since>
+			<version>0.3.0</version>
+		</since>
 		<synopsis>
 			List IAX peers.
 		</synopsis>
@@ -244,6 +247,9 @@
 		</description>
 	</manager>
 	<manager name="IAXpeerlist" language="en_US">
+		<since>
+			<version>1.6.0</version>
+		</since>
 		<synopsis>
 			List IAX Peers.
 		</synopsis>
@@ -255,6 +261,9 @@
 		</description>
 	</manager>
 	<manager name="IAXnetstats" language="en_US">
+		<since>
+			<version>1.2.0</version>
+		</since>
 		<synopsis>
 			Show IAX Netstats.
 		</synopsis>
@@ -264,6 +273,9 @@
 		</description>
 	</manager>
 	<manager name="IAXregistry" language="en_US">
+		<since>
+			<version>1.6.2.0</version>
+		</since>
 		<synopsis>
 			Show IAX registrations.
 		</synopsis>

--- a/channels/chan_sip.c
+++ b/channels/chan_sip.c
@@ -531,6 +531,9 @@
 		</description>
 	</function>
 	<manager name="SIPpeers" language="en_US">
+		<since>
+			<version>1.2.0</version>
+		</since>
 		<synopsis>
 			List SIP peers (text format).
 		</synopsis>
@@ -544,6 +547,9 @@
 		</description>
 	</manager>
 	<manager name="SIPshowpeer" language="en_US">
+		<since>
+			<version>1.2.0</version>
+		</since>
 		<synopsis>
 			show SIP peer (text format).
 		</synopsis>
@@ -558,6 +564,9 @@
 		</description>
 	</manager>
 	<manager name="SIPqualifypeer" language="en_US">
+		<since>
+			<version>1.6.1.0</version>
+		</since>
 		<synopsis>
 			Qualify SIP peers.
 		</synopsis>
@@ -575,6 +584,9 @@
 		</see-also>
 	</manager>
 	<manager name="SIPshowregistry" language="en_US">
+		<since>
+			<version>1.6.0</version>
+		</since>
 		<synopsis>
 			Show SIP registrations (text format).
 		</synopsis>
@@ -587,6 +599,9 @@
 		</description>
 	</manager>
 	<manager name="SIPnotify" language="en_US">
+		<since>
+			<version>1.6.1.0</version>
+		</since>
 		<synopsis>
 			Send a SIP notify.
 		</synopsis>
@@ -610,6 +625,9 @@
 		</description>
 	</manager>
 	<manager name="SIPpeerstatus" language="en_US">
+		<since>
+			<version>11.0.0</version>
+		</since>
 		<synopsis>
 			Show the status of one or all of the sip peers.
 		</synopsis>

--- a/channels/chan_skinny.c
+++ b/channels/chan_skinny.c
@@ -89,6 +89,9 @@
 
 /*** DOCUMENTATION
 	<manager name="SKINNYdevices" language="en_US">
+		<since>
+			<version>1.6.2.0</version>
+		</since>
 		<synopsis>
 			List SKINNY devices (text format).
 		</synopsis>
@@ -102,6 +105,9 @@
 		</description>
 	</manager>
 	<manager name="SKINNYshowdevice" language="en_US">
+		<since>
+			<version>1.6.2.0</version>
+		</since>
 		<synopsis>
 			Show SKINNY device (text format).
 		</synopsis>
@@ -116,6 +122,9 @@
 		</description>
 	</manager>
 	<manager name="SKINNYlines" language="en_US">
+		<since>
+			<version>1.6.2.0</version>
+		</since>
 		<synopsis>
 			List SKINNY lines (text format).
 		</synopsis>
@@ -129,6 +138,9 @@
 		</description>
 	</manager>
 	<manager name="SKINNYshowline" language="en_US">
+		<since>
+			<version>1.6.2.0</version>
+		</since>
 		<synopsis>
 			Show SKINNY line (text format).
 		</synopsis>

--- a/channels/pjsip/dialplan_functions_doc.xml
+++ b/channels/pjsip/dialplan_functions_doc.xml
@@ -96,6 +96,11 @@
 	</application>
 
 	<manager name="PJSIPHangup" language="en_US">
+		<since>
+			<version>21.1.0</version>
+			<version>20.6.0</version>
+			<version>18.21.0</version>
+		</since>
 		<synopsis>
 			Hangup an incoming PJSIP channel with a SIP response code
 		</synopsis>

--- a/main/bridge.c
+++ b/main/bridge.c
@@ -29,6 +29,9 @@
 
 /*** DOCUMENTATION
 	<manager name="BridgeTechnologyList" language="en_US">
+		<since>
+			<version>12.0.0</version>
+		</since>
 		<synopsis>
 			List available bridging technologies and their statuses.
 		</synopsis>
@@ -44,6 +47,9 @@
 		</see-also>
 	</manager>
 	<manager name="BridgeTechnologySuspend" language="en_US">
+		<since>
+			<version>12.0.0</version>
+		</since>
 		<synopsis>
 			Suspend a bridging technology.
 		</synopsis>
@@ -62,6 +68,9 @@
 		</see-also>
 	</manager>
 	<manager name="BridgeTechnologyUnsuspend" language="en_US">
+		<since>
+			<version>12.0.0</version>
+		</since>
 		<synopsis>
 			Unsuspend a bridging technology.
 		</synopsis>

--- a/main/core_local.c
+++ b/main/core_local.c
@@ -53,6 +53,9 @@
 
 /*** DOCUMENTATION
 	<manager name="LocalOptimizeAway" language="en_US">
+		<since>
+			<version>1.8.0</version>
+		</since>
 		<synopsis>
 			Optimize away a local channel when possible.
 		</synopsis>

--- a/main/db.c
+++ b/main/db.c
@@ -54,6 +54,9 @@
 
 /*** DOCUMENTATION
 	<manager name="DBGet" language="en_US">
+		<since>
+			<version>1.2.0</version>
+		</since>
 		<synopsis>
 			Get DB Entry.
 		</synopsis>
@@ -66,6 +69,11 @@
 		</description>
 	</manager>
 	<manager name="DBGetTree" language="en_US">
+		<since>
+			<version>19.6.0</version>
+			<version>18.14.0</version>
+			<version>16.28.0</version>
+		</since>
 		<synopsis>
 			Get DB entries, optionally at a particular family/key
 		</synopsis>
@@ -78,6 +86,9 @@
 		</description>
 	</manager>
 	<manager name="DBPut" language="en_US">
+		<since>
+			<version>1.2.0</version>
+		</since>
 		<synopsis>
 			Put DB entry.
 		</synopsis>
@@ -91,6 +102,9 @@
 		</description>
 	</manager>
 	<manager name="DBDel" language="en_US">
+		<since>
+			<version>1.6.0</version>
+		</since>
 		<synopsis>
 			Delete DB entry.
 		</synopsis>
@@ -103,6 +117,9 @@
 		</description>
 	</manager>
 	<manager name="DBDelTree" language="en_US">
+		<since>
+			<version>1.6.0</version>
+		</since>
 		<synopsis>
 			Delete DB Tree.
 		</synopsis>

--- a/main/features.c
+++ b/main/features.c
@@ -216,6 +216,9 @@
 		</see-also>
 	</application>
 	<manager name="Bridge" language="en_US">
+		<since>
+			<version>1.6.0</version>
+		</since>
 		<synopsis>
 			Bridge two channels already in the PBX.
 		</synopsis>

--- a/main/manager_bridges.c
+++ b/main/manager_bridges.c
@@ -107,6 +107,9 @@ static struct stasis_message_router *bridge_state_router;
 		</managerEventInstance>
 	</managerEvent>
 	<manager name="BridgeList" language="en_US">
+		<since>
+			<version>12.0.0</version>
+		</since>
 		<synopsis>
 			Get a list of bridges in the system.
 		</synopsis>
@@ -127,6 +130,9 @@ static struct stasis_message_router *bridge_state_router;
 		</see-also>
 	</manager>
 	<manager name="BridgeInfo" language="en_US">
+		<since>
+			<version>12.0.0</version>
+		</since>
 		<synopsis>
 			Get information about a bridge.
 		</synopsis>
@@ -167,6 +173,9 @@ static struct stasis_message_router *bridge_state_router;
 		</responses>
 	</manager>
 	<manager name="BridgeDestroy" language="en_US">
+		<since>
+			<version>12.0.0</version>
+		</since>
 		<synopsis>
 			Destroy a bridge.
 		</synopsis>
@@ -188,6 +197,9 @@ static struct stasis_message_router *bridge_state_router;
 		</see-also>
 	</manager>
 	<manager name="BridgeKick" language="en_US">
+		<since>
+			<version>12.0.0</version>
+		</since>
 		<synopsis>
 			Kick a channel from a bridge.
 		</synopsis>

--- a/main/manager_doc.xml
+++ b/main/manager_doc.xml
@@ -3,6 +3,9 @@
 <?xml-stylesheet type="text/xsl" href="appdocsxml.xslt"?>
 <docs xmlns:xi="http://www.w3.org/2001/XInclude">
 	<manager name="Ping" language="en_US">
+		<since>
+			<version>0.2.0</version>
+		</since>
 		<synopsis>
 			Keepalive command.
 		</synopsis>
@@ -15,6 +18,9 @@
 		</description>
 	</manager>
 	<manager name="Events" language="en_US">
+		<since>
+			<version>0.9.0</version>
+		</since>
 		<synopsis>
 			Control Event Flow.
 		</synopsis>
@@ -39,6 +45,9 @@
 		</description>
 	</manager>
 	<manager name="Logoff" language="en_US">
+		<since>
+			<version>0.2.0</version>
+		</since>
 		<synopsis>
 			Logoff Manager.
 		</synopsis>
@@ -53,6 +62,9 @@
 		</see-also>
 	</manager>
 	<manager name="Login" language="en_US">
+		<since>
+			<version>0.2.0</version>
+		</since>
 		<synopsis>
 			Login Manager.
 		</synopsis>
@@ -102,6 +114,9 @@
 		</see-also>
 	</manager>
 	<manager name="Challenge" language="en_US">
+		<since>
+			<version>0.4.0</version>
+		</since>
 		<synopsis>
 			Generate Challenge for MD5 Auth.
 		</synopsis>
@@ -119,6 +134,9 @@
 		</description>
 	</manager>
 	<manager name="Hangup" language="en_US">
+		<since>
+			<version>0.2.0</version>
+		</since>
 		<synopsis>
 			Hangup channel.
 		</synopsis>
@@ -138,6 +156,9 @@
 		</description>
 	</manager>
 	<manager name="Status" language="en_US">
+		<since>
+			<version>0.2.0</version>
+		</since>
 		<synopsis>
 			List channel status.
 		</synopsis>
@@ -241,6 +262,9 @@
 		</managerEventInstance>
 	</managerEvent>
 	<manager name="Setvar" language="en_US">
+		<since>
+			<version>1.0.0</version>
+		</since>
 		<synopsis>
 			Sets a channel variable or function value.
 		</synopsis>
@@ -268,6 +292,9 @@
 		</see-also>
 	</manager>
 	<manager name="Getvar" language="en_US">
+		<since>
+			<version>1.0.0</version>
+		</since>
 		<synopsis>
 			Gets a channel variable or function value.
 		</synopsis>
@@ -291,6 +318,9 @@
 		</see-also>
 	</manager>
 	<manager name="GetConfig" language="en_US">
+		<since>
+			<version>1.4.0</version>
+		</since>
 		<synopsis>
 			Retrieve configuration.
 		</synopsis>
@@ -329,6 +359,9 @@
 		</see-also>
 	</manager>
 	<manager name="GetConfigJSON" language="en_US">
+		<since>
+			<version>1.6.0</version>
+		</since>
 		<synopsis>
 			Retrieve configuration (JSON format).
 		</synopsis>
@@ -359,6 +392,9 @@
 		</see-also>
 	</manager>
 	<manager name="UpdateConfig" language="en_US">
+		<since>
+			<version>1.4.0</version>
+		</since>
 		<synopsis>
 			Update basic configuration.
 		</synopsis>
@@ -456,6 +492,9 @@
 		</see-also>
 	</manager>
 	<manager name="CreateConfig" language="en_US">
+		<since>
+			<version>1.6.0</version>
+		</since>
 		<synopsis>
 			Creates an empty file in the configuration directory.
 		</synopsis>
@@ -478,6 +517,9 @@
 		</see-also>
 	</manager>
 	<manager name="ListCategories" language="en_US">
+		<since>
+			<version>1.6.0</version>
+		</since>
 		<synopsis>
 			List categories in configuration file.
 		</synopsis>
@@ -498,6 +540,9 @@
 		</see-also>
 	</manager>
 	<manager name="Redirect" language="en_US">
+		<since>
+			<version>0.2.0</version>
+		</since>
 		<synopsis>
 			Redirect (transfer) a call.
 		</synopsis>
@@ -536,6 +581,9 @@
 		</see-also>
 	</manager>
 	<manager name="Atxfer" language="en_US">
+		<since>
+			<version>1.6.1.0</version>
+		</since>
 		<synopsis>
 			Attended transfer.
 		</synopsis>
@@ -560,10 +608,9 @@
 	</manager>
 	<manager name="CancelAtxfer" language="en_US">
 		<since>
-			<version>13.18.0</version>
-			<version>14.7.0</version>
 			<version>15.1.0</version>
-			<version>16.0.0</version>
+			<version>14.7.0</version>
+			<version>13.18.0</version>
 		</since>
 		<synopsis>
 			Cancel an attended transfer.
@@ -584,6 +631,9 @@
 		</see-also>
 	</manager>
 	<manager name="Originate" language="en_US">
+		<since>
+			<version>0.2.0</version>
+		</since>
 		<synopsis>
 			Originate a call.
 		</synopsis>
@@ -677,6 +727,9 @@
 		</managerEventInstance>
 	</managerEvent>
 	<manager name="Command" language="en_US">
+		<since>
+			<version>0.3.0</version>
+		</since>
 		<synopsis>
 			Execute Asterisk CLI Command.
 		</synopsis>
@@ -691,6 +744,9 @@
 		</description>
 	</manager>
 	<manager name="ExtensionState" language="en_US">
+		<since>
+			<version>0.4.0</version>
+		</since>
 		<synopsis>
 			Check Extension Status.
 		</synopsis>
@@ -714,6 +770,9 @@
 		</see-also>
 	</manager>
 	<manager name="PresenceState" language="en_US">
+		<since>
+			<version>11.0.0</version>
+		</since>
 		<synopsis>
 			Check Presence State
 		</synopsis>
@@ -733,6 +792,9 @@
 		</see-also>
 	</manager>
 	<manager name="AbsoluteTimeout" language="en_US">
+		<since>
+			<version>0.5.0</version>
+		</since>
 		<synopsis>
 			Set absolute timeout.
 		</synopsis>
@@ -751,6 +813,9 @@
 		</description>
 	</manager>
 	<manager name="MailboxStatus" language="en_US">
+		<since>
+			<version>0.4.0</version>
+		</since>
 		<synopsis>
 			Check mailbox.
 		</synopsis>
@@ -773,6 +838,9 @@
 		</see-also>
 	</manager>
 	<manager name="MailboxCount" language="en_US">
+		<since>
+			<version>0.5.0</version>
+		</since>
 		<synopsis>
 			Check Mailbox Message Count.
 		</synopsis>
@@ -796,6 +864,9 @@
 		</see-also>
 	</manager>
 	<manager name="ListCommands" language="en_US">
+		<since>
+			<version>1.0.0</version>
+		</since>
 		<synopsis>
 			List available manager commands.
 		</synopsis>
@@ -808,6 +879,9 @@
 		</description>
 	</manager>
 	<manager name="SendText" language="en_US">
+		<since>
+			<version>1.6.0</version>
+		</since>
 		<synopsis>
 			Sends a text message to channel. A content type	can be optionally specified. If not set
 			it is set to an empty string allowing a custom handler to default it as it sees fit.
@@ -832,6 +906,9 @@
 		</see-also>
 	</manager>
 	<manager name="UserEvent" language="en_US">
+		<since>
+			<version>1.4.0</version>
+		</since>
 		<synopsis>
 			Send an arbitrary event.
 		</synopsis>
@@ -856,6 +933,9 @@
 		</see-also>
 	</manager>
 	<manager name="WaitEvent" language="en_US">
+		<since>
+			<version>1.4.0</version>
+		</since>
 		<synopsis>
 			Wait for an event to occur.
 		</synopsis>
@@ -872,6 +952,9 @@
 		</description>
 	</manager>
 	<manager name="CoreSettings" language="en_US">
+		<since>
+			<version>1.6.0</version>
+		</since>
 		<synopsis>
 			Show PBX core settings (version etc).
 		</synopsis>
@@ -883,6 +966,9 @@
 		</description>
 	</manager>
 	<manager name="CoreStatus" language="en_US">
+		<since>
+			<version>1.6.0</version>
+		</since>
 		<synopsis>
 			Show PBX core status variables.
 		</synopsis>
@@ -894,6 +980,9 @@
 		</description>
 	</manager>
 	<manager name="Reload" language="en_US">
+		<since>
+			<version>1.6.0</version>
+		</since>
 		<synopsis>
 			Send a reload event.
 		</synopsis>
@@ -954,6 +1043,9 @@
 		</managerEventInstance>
 	</managerEvent>
 	<manager name="CoreShowChannels" language="en_US">
+		<since>
+			<version>1.6.0</version>
+		</since>
 		<synopsis>
 			List currently active channels.
 		</synopsis>
@@ -984,6 +1076,10 @@
 		</managerEventInstance>
 	</managerEvent>
 	<manager name="CoreShowChannelMap" language="en_US">
+		<since>
+			<version>20.4.0</version>
+			<version>18.19.0</version>
+		</since>
 		<synopsis>
 			List all channels connected to the specified channel.
 		</synopsis>
@@ -998,6 +1094,9 @@
 		</description>
 	</manager>
 	<manager name="LoggerRotate" language="en_US">
+		<since>
+			<version>13.0.0</version>
+		</since>
 		<synopsis>
 			Reload and rotate the Asterisk logger.
 		</synopsis>
@@ -1009,6 +1108,9 @@
 		</description>
 	</manager>
 	<manager name="ModuleLoad" language="en_US">
+		<since>
+			<version>1.6.0</version>
+		</since>
 		<synopsis>
 			Module management.
 		</synopsis>
@@ -1062,6 +1164,9 @@
 		</see-also>
 	</manager>
 	<manager name="ModuleCheck" language="en_US">
+		<since>
+			<version>1.6.0</version>
+		</since>
 		<synopsis>
 			Check if module is loaded.
 		</synopsis>
@@ -1081,6 +1186,9 @@
 		</see-also>
 	</manager>
 	<manager name="AOCMessage" language="en_US">
+		<since>
+			<version>1.8.0</version>
+		</since>
 		<synopsis>
 			Generate an Advice of Charge message on a channel.
 		</synopsis>
@@ -1308,6 +1416,9 @@
 		</description>
 	</function>
 	<manager name="Filter" language="en_US">
+		<since>
+			<version>10.0.0</version>
+		</since>
 		<synopsis>
 			Dynamically add filters for the current manager session.
 		</synopsis>
@@ -1441,6 +1552,9 @@
 		</description>
 	</manager>
 	<manager name="BlindTransfer" language="en_US">
+		<since>
+			<version>12.0.0</version>
+		</since>
 		<synopsis>
 			Blind transfer channel(s) to the given destination
 		</synopsis>

--- a/main/message.c
+++ b/main/message.c
@@ -185,6 +185,9 @@
 		</description>
 	</application>
 	<manager name="MessageSend" language="en_US">
+		<since>
+			<version>11.0.0</version>
+		</since>
 		<synopsis>
 			Send an out of call message to an endpoint.
 		</synopsis>

--- a/main/pbx.c
+++ b/main/pbx.c
@@ -152,6 +152,9 @@
 		</see-also>
 	</function>
 	<manager name="ShowDialPlan" language="en_US">
+		<since>
+			<version>1.6.0</version>
+		</since>
 		<synopsis>
 			Show dialplan contexts and extensions
 		</synopsis>
@@ -170,6 +173,9 @@
 		</description>
 	</manager>
 	<manager name="ExtensionStateList" language="en_US">
+		<since>
+			<version>13.0.0</version>
+		</since>
 		<synopsis>
 			List the current known extension states.
 		</synopsis>

--- a/pbx/pbx_config.c
+++ b/pbx/pbx_config.c
@@ -29,6 +29,9 @@
 
 /*** DOCUMENTATION
 	<manager name="DialplanExtensionAdd" language="en_US">
+		<since>
+			<version>13.0.0</version>
+		</since>
 		<synopsis>
 			Add an extension to the dialplan
 		</synopsis>
@@ -61,6 +64,9 @@
 		</syntax>
 	</manager>
 	<manager name="DialplanExtensionRemove" language="en_US">
+		<since>
+			<version>13.0.0</version>
+		</since>
 		<synopsis>
 			Remove an extension from the dialplan
 		</synopsis>

--- a/res/parking/parking_manager.c
+++ b/res/parking/parking_manager.c
@@ -39,6 +39,9 @@
 
 /*** DOCUMENTATION
 	<manager name="Parkinglots" language="en_US">
+		<since>
+			<version>11.0.0</version>
+		</since>
 		<synopsis>
 			Get a list of parking lots
 		</synopsis>
@@ -50,6 +53,9 @@
 		</description>
 	</manager>
 	<manager name="ParkedCalls" language="en_US">
+		<since>
+			<version>0.7.2</version>
+		</since>
 		<synopsis>
 			List parked calls.
 		</synopsis>
@@ -64,6 +70,9 @@
 		</description>
 	</manager>
 	<manager name="Park" language="en_US">
+		<since>
+			<version>1.4.0</version>
+		</since>
 		<synopsis>
 			Park a channel.
 		</synopsis>

--- a/res/res_agi.c
+++ b/res/res_agi.c
@@ -1265,6 +1265,9 @@
 		</see-also>
 	</application>
 	<manager name="AGI" language="en_US">
+		<since>
+			<version>1.6.0</version>
+		</since>
 		<synopsis>
 			Add an AGI command to execute by Async AGI.
 		</synopsis>

--- a/res/res_fax.c
+++ b/res/res_fax.c
@@ -241,6 +241,9 @@
 		</see-also>
 	</function>
 	<manager name="FAXSessions" language="en_US">
+		<since>
+			<version>13.0.0</version>
+		</since>
 		<synopsis>
 			Lists active FAX sessions
 		</synopsis>
@@ -315,6 +318,9 @@
 		</managerEventInstance>
 	</managerEvent>
 	<manager name="FAXSession" language="en_US">
+		<since>
+			<version>13.0.0</version>
+		</since>
 		<synopsis>
 			Responds with a detailed description of a single FAX session
 		</synopsis>
@@ -384,6 +390,9 @@
 		</managerEventInstance>
 	</managerEvent>
 	<manager name="FAXStats" language="en_US">
+		<since>
+			<version>13.0.0</version>
+		</since>
 		<synopsis>
 			Responds with fax statistics
 		</synopsis>

--- a/res/res_manager_devicestate.c
+++ b/res/res_manager_devicestate.c
@@ -22,6 +22,9 @@
 
 /*** DOCUMENTATION
 	<manager name="DeviceStateList" language="en_US">
+		<since>
+			<version>13.0.0</version>
+		</since>
 		<synopsis>
 			List the current known device states.
 		</synopsis>

--- a/res/res_manager_presencestate.c
+++ b/res/res_manager_presencestate.c
@@ -22,6 +22,9 @@
 
 /*** DOCUMENTATION
 	<manager name="PresenceStateList" language="en_US">
+		<since>
+			<version>13.0.0</version>
+		</since>
 		<synopsis>
 			List the current known presence states.
 		</synopsis>

--- a/res/res_monitor.c
+++ b/res/res_monitor.c
@@ -170,6 +170,9 @@
 		</see-also>
 	</application>
 	<manager name="Monitor" language="en_US">
+		<since>
+			<version>0.4.0</version>
+		</since>
 		<synopsis>
 			Monitor a channel.
 		</synopsis>
@@ -196,6 +199,9 @@
 		</description>
 	</manager>
 	<manager name="StopMonitor" language="en_US">
+		<since>
+			<version>0.4.0</version>
+		</since>
 		<synopsis>
 			Stop monitoring a channel.
 		</synopsis>
@@ -210,6 +216,9 @@
 		</description>
 	</manager>
 	<manager name="ChangeMonitor" language="en_US">
+		<since>
+			<version>0.4.0</version>
+		</since>
 		<synopsis>
 			Change monitoring filename of a channel.
 		</synopsis>
@@ -229,6 +238,9 @@
 		</description>
 	</manager>
 	<manager name="PauseMonitor" language="en_US">
+		<since>
+			<version>1.4.0</version>
+		</since>
 		<synopsis>
 			Pause monitoring of a channel.
 		</synopsis>
@@ -244,6 +256,9 @@
 		</description>
 	</manager>
 	<manager name="UnpauseMonitor" language="en_US">
+		<since>
+			<version>1.4.0</version>
+		</since>
 		<synopsis>
 			Unpause monitoring of a channel.
 		</synopsis>

--- a/res/res_mutestream.c
+++ b/res/res_mutestream.c
@@ -79,6 +79,9 @@
 		</description>
 	</function>
 	<manager name="MuteAudio" language="en_US">
+		<since>
+			<version>1.8.0</version>
+		</since>
 		<synopsis>
 			Mute an audio stream.
 		</synopsis>

--- a/res/res_mwi_external_ami.c
+++ b/res/res_mwi_external_ami.c
@@ -34,6 +34,9 @@
 
 /*** DOCUMENTATION
 	<manager name="MWIGet" language="en_US">
+		<since>
+			<version>12.1.0</version>
+		</since>
 		<synopsis>
 			Get selected mailboxes with message counts.
 		</synopsis>
@@ -89,6 +92,9 @@
 		</managerEventInstance>
 	</managerEvent>
 	<manager name="MWIDelete" language="en_US">
+		<since>
+			<version>12.1.0</version>
+		</since>
 		<synopsis>
 			Delete selected mailboxes.
 		</synopsis>
@@ -101,6 +107,9 @@
 		</description>
 	</manager>
 	<manager name="MWIUpdate" language="en_US">
+		<since>
+			<version>12.1.0</version>
+		</since>
 		<synopsis>
 			Update the mailbox message counts.
 		</synopsis>

--- a/res/res_pjsip/pjsip_manager.xml
+++ b/res/res_pjsip/pjsip_manager.xml
@@ -3,6 +3,9 @@
 <?xml-stylesheet type="text/xsl" href="appdocsxml.xslt"?>
 <docs xmlns:xi="http://www.w3.org/2001/XInclude">
 	<manager name="PJSIPQualify" language="en_US">
+		<since>
+			<version>12.0.0</version>
+		</since>
 		<synopsis>
 			Qualify a chan_pjsip endpoint.
 		</synopsis>
@@ -754,6 +757,9 @@
 		</managerEventInstance>
 	</managerEvent>
 	<manager name="PJSIPShowEndpoints" language="en_US">
+		<since>
+			<version>12.0.0</version>
+		</since>
 		<synopsis>
 			Lists PJSIP endpoints.
 		</synopsis>
@@ -781,6 +787,9 @@
 		</responses>
 	</manager>
 	<manager name="PJSIPShowEndpoint" language="en_US">
+		<since>
+			<version>12.0.0</version>
+		</since>
 		<synopsis>
 			Detail listing of an endpoint and its objects.
 		</synopsis>
@@ -822,6 +831,9 @@
 		</responses>
 	</manager>
 	<manager name="PJSIPShowAors" language="en_US">
+		<since>
+			<version>16.0.0</version>
+		</since>
 		<synopsis>
 			Lists PJSIP AORs.
 		</synopsis>
@@ -849,6 +861,9 @@
 		</responses>
 	</manager>
 	<manager name="PJSIPShowAuths" language="en_US">
+		<since>
+			<version>16.0.0</version>
+		</since>
 		<synopsis>
 			Lists PJSIP Auths.
 		</synopsis>
@@ -875,6 +890,9 @@
 		</responses>
 	</manager>
 	<manager name="PJSIPShowContacts" language="en_US">
+		<since>
+			<version>16.0.0</version>
+		</since>
 		<synopsis>
 			Lists PJSIP Contacts.
 		</synopsis>

--- a/res/res_pjsip_notify.c
+++ b/res/res_pjsip_notify.c
@@ -39,6 +39,9 @@
 
 /*** DOCUMENTATION
 	<manager name="PJSIPNotify" language="en_US">
+		<since>
+			<version>12.0.0</version>
+		</since>
 		<synopsis>
 			Send a NOTIFY to either an endpoint, an arbitrary URI, or inside a SIP dialog.
 		</synopsis>

--- a/res/res_pjsip_outbound_registration.c
+++ b/res/res_pjsip_outbound_registration.c
@@ -213,6 +213,9 @@
 		</configFile>
 	</configInfo>
 	<manager name="PJSIPUnregister" language="en_US">
+		<since>
+			<version>12.0.0</version>
+		</since>
 		<synopsis>
 			Unregister an outbound registration.
 		</synopsis>
@@ -230,6 +233,9 @@
 		</description>
 	</manager>
 	<manager name="PJSIPRegister" language="en_US">
+		<since>
+			<version>13.2.0</version>
+		</since>
 		<synopsis>
 			Register an outbound registration.
 		</synopsis>
@@ -247,6 +253,9 @@
 		</description>
 	</manager>
 	<manager name="PJSIPShowRegistrationsOutbound" language="en_US">
+		<since>
+			<version>12.0.0</version>
+		</since>
 		<synopsis>
 			Lists PJSIP outbound registrations.
 		</synopsis>

--- a/res/res_pjsip_pubsub.c
+++ b/res/res_pjsip_pubsub.c
@@ -50,6 +50,9 @@
 
 /*** DOCUMENTATION
 	<manager name="PJSIPShowSubscriptionsInbound" language="en_US">
+		<since>
+			<version>12.0.0</version>
+		</since>
 		<synopsis>
 			Lists subscriptions.
 		</synopsis>
@@ -63,6 +66,9 @@
 		</description>
 	</manager>
 	<manager name="PJSIPShowSubscriptionsOutbound" language="en_US">
+		<since>
+			<version>12.0.0</version>
+		</since>
 		<synopsis>
 			Lists subscriptions.
 		</synopsis>
@@ -76,6 +82,9 @@
 		</description>
 	</manager>
 	<manager name="PJSIPShowResourceLists" language="en_US">
+		<since>
+			<version>13.0.0</version>
+		</since>
 		<synopsis>
 			Displays settings for configured resource lists.
 		</synopsis>

--- a/res/res_pjsip_registrar.c
+++ b/res/res_pjsip_registrar.c
@@ -41,6 +41,9 @@
 
 /*** DOCUMENTATION
 	<manager name="PJSIPShowRegistrationsInbound" language="en_US">
+		<since>
+			<version>12.0.0</version>
+		</since>
 		<synopsis>
 			Lists PJSIP inbound registrations.
 		</synopsis>
@@ -63,6 +66,10 @@
 		</see-also>
 	</manager>
 	<manager name="PJSIPShowRegistrationInboundContactStatuses" language="en_US">
+		<since>
+			<version>14.3.0</version>
+			<version>13.14.0</version>
+		</since>
 		<synopsis>
 			Lists ContactStatuses for PJSIP inbound registrations.
 		</synopsis>

--- a/res/res_sorcery_memory_cache.c
+++ b/res/res_sorcery_memory_cache.c
@@ -41,6 +41,9 @@
 
 /*** DOCUMENTATION
 	<manager name="SorceryMemoryCacheExpireObject" language="en_US">
+		<since>
+			<version>13.5.0</version>
+		</since>
 		<synopsis>
 			Expire (remove) an object from a sorcery memory cache.
 		</synopsis>
@@ -60,6 +63,9 @@
 		</description>
 	</manager>
 	<manager name="SorceryMemoryCacheExpire" language="en_US">
+		<since>
+			<version>13.5.0</version>
+		</since>
 		<synopsis>
 			Expire (remove) ALL objects from a sorcery memory cache.
 		</synopsis>
@@ -74,6 +80,9 @@
 		</description>
 	</manager>
 	<manager name="SorceryMemoryCacheStaleObject" language="en_US">
+		<since>
+			<version>13.5.0</version>
+		</since>
 		<synopsis>
 			Mark an object in a sorcery memory cache as stale.
 		</synopsis>
@@ -94,6 +103,9 @@
 		</description>
 	</manager>
 	<manager name="SorceryMemoryCacheStale" language="en_US">
+		<since>
+			<version>13.5.0</version>
+		</since>
 		<synopsis>
 			Marks ALL objects in a sorcery memory cache as stale.
 		</synopsis>
@@ -108,6 +120,9 @@
 		</description>
 	</manager>
 	<manager name="SorceryMemoryCachePopulate" language="en_US">
+		<since>
+			<version>13.7.0</version>
+		</since>
 		<synopsis>
 			Expire all objects from a memory cache and populate it with all objects from the backend.
 		</synopsis>

--- a/res/res_xmpp.c
+++ b/res/res_xmpp.c
@@ -238,6 +238,9 @@
 		</description>
 	</application>
 	<manager name="JabberSend" language="en_US" module="res_xmpp">
+		<since>
+			<version>1.4.0</version>
+		</since>
 		<synopsis>
 			Sends a message to a Jabber Client.
 		</synopsis>


### PR DESCRIPTION
This is the v20 version of [this PR](https://github.com/asterisk/asterisk/pull/1038) that also includes Monitor, chan_sip, and SKINNY manager actions that have since been removed.