### PR TITLE
samples: Use "asterisk" instead of "postgres" for username

### DIFF
--- a/configs/samples/cdr_pgsql.conf.sample
+++ b/configs/samples/cdr_pgsql.conf.sample
@@ -5,12 +5,13 @@
 ; on this system (check for pgsessions.conf)
 
 [global]
-;hostname=localhost
-;port=5432
-;dbname=asterisk
-;password=password
-;user=postgres
-;appname=asterisk    ; Postgres application_name support (optional). Whitespace not allowed.
-;table=cdr		;SQL table where CDRs will be inserted
-;encoding=LATIN9	; Encoding of logged characters in Asterisk
-;timezone=UTC		; Uncomment if you want datetime fields in UTC/GMT
+;hostname=localhost          ; Database server hostname
+;port=5432                   ; Port number for the PostgreSQL server
+;dbname=asterisk             ; Database name
+;user=asterisk               ; Username for the database
+;password=password           ; Password for the user
+;appname=asterisk            ; Optional PostgreSQL application_name (no whitespace allowed)
+;table=cdr                   ; SQL table where Call Detail Records (CDRs) will be inserted
+;encoding=LATIN9             ; Character encoding for logged data
+;timezone=UTC                ; Uncomment to log datetime fields in UTC/GMT
+

--- a/configs/samples/cel_pgsql.conf.sample
+++ b/configs/samples/cel_pgsql.conf.sample
@@ -3,71 +3,70 @@
 ;
 
 ; Sample Asterisk config file for CEL logging to PostgreSQL
-;
+
 ; CEL field names:
-;
-;	eventtype
-;	  CHANNEL_START = 1
-;	  CHANNEL_END = 2
-;	  HANGUP = 3
-;	  ANSWER = 4
-;	  APP_START = 5
-;	  APP_END = 6
-;	  BRIDGE_START = 7
-;	  BRIDGE_END = 8
-;	  CONF_START = 9
-;	  CONF_END = 10
-;	  PARK_START = 11
-;	  PARK_END = 12
-;	  BLINDTRANSFER = 13
-;	  ATTENDEDTRANSFER = 14
-;	  TRANSFER = 15
-;	  HOOKFLASH = 16
-;	  3WAY_START = 17
-;	  3WAY_END = 18
-;	  CONF_ENTER = 19
-;	  CONF_EXIT = 20
-;	  USER_DEFINED = 21
-;	  LINKEDID_END = 22
-;	  BRIDGE_UPDATE = 23
-;	  PICKUP = 24
-;	  FORWARD = 25
-;	eventtime  (timeval, includes microseconds)
-;	userdeftype (set only if eventtype == USER_DEFINED)
-;	cid_name
-;	cid_num
-;	cid_ani
-;	cid_rdnis
-;	cid_dnid
-;	exten
-;	context
-;	channame
-;	appname
-;	appdata
-;	accountcode
-;	peeraccount
-;	uniqueid
-;	linkedid
-;	amaflags  (an int)
-;	userfield
-;	peer
-;	extra
+;   eventtype
+;     CHANNEL_START = 1
+;     CHANNEL_END = 2
+;     HANGUP = 3
+;     ANSWER = 4
+;     APP_START = 5
+;     APP_END = 6
+;     BRIDGE_START = 7
+;     BRIDGE_END = 8
+;     CONF_START = 9
+;     CONF_END = 10
+;     PARK_START = 11
+;     PARK_END = 12
+;     BLINDTRANSFER = 13
+;     ATTENDEDTRANSFER = 14
+;     TRANSFER = 15
+;     HOOKFLASH = 16
+;     3WAY_START = 17
+;     3WAY_END = 18
+;     CONF_ENTER = 19
+;     CONF_EXIT = 20
+;     USER_DEFINED = 21
+;     LINKEDID_END = 22
+;     BRIDGE_UPDATE = 23
+;     PICKUP = 24
+;     FORWARD = 25
+;   eventtime      (timeval, includes microseconds)
+;   userdeftype    (set only if eventtype == USER_DEFINED)
+;   cid_name
+;   cid_num
+;   cid_ani
+;   cid_rdnis
+;   cid_dnid
+;   exten
+;   context
+;   channame
+;   appname
+;   appdata
+;   accountcode
+;   peeraccount
+;   uniqueid
+;   linkedid
+;   amaflags       (an int)
+;   userfield
+;   peer
+;   extra
 
 [global]
 ; Use 'show_user_defined' to put "USER_DEFINED" in the eventtype field,
-; instead of (by default) just putting the user defined event name there.
-;
+; instead of (by default) just putting the user-defined event name there.
 ;show_user_defined=yes
 
 ; Log date/time in GMT. The default of this option is 'no'.
 ;usegmtime=yes
 
-;hostname=localhost
-;port=5432
-;dbname=asterisk
-;password=password
-;user=postgres
-;table=cel		;SQL table where CEL's will be inserted
-;schema=public ;Schema where CEL's table is located.  Optional parameter.
-               ;If schema support is present the default value used will be current_schema().
-;appname=asterisk   ; Postgres application_name support (optional). Whitespace not allowed.
+; PostgreSQL connection settings
+;hostname=localhost           ; Database server hostname
+;port=5432                    ; Port number for the PostgreSQL server
+;dbname=asterisk              ; Database name
+;user=asterisk                ; Username for the database
+;password=password            ; Password for the user
+;table=cel                    ; SQL table where CELs will be inserted
+;schema=public                ; Schema where the CEL table is located (optional).
+                              ; Defaults to `current_schema()` if not specified.
+;appname=asterisk             ; Optional PostgreSQL application_name (no whitespace allowed)


### PR DESCRIPTION
These files were using postgres instead of asterisk.