### PR TITLE
logger.c fix: malformed JSON template

### DIFF
--- a/main/logger.c
+++ b/main/logger.c
@@ -287,7 +287,7 @@ static int format_log_json(struct logchannel *channel, struct logmsg *msg, char 
 	}
 
 	json = ast_json_pack("{s: s, s: s, "
-		"s: {s: i, s: s} "
+		"s: {s: i, s: s}, "
 		"s: {s: {s: s, s: s, s: i}, "
 		"s: s, s: s} }",
 		"hostname", ast_config_AST_SYSTEM_NAME,


### PR DESCRIPTION
this typo was mentioned multiple times in multiple tickets before, but never got fixed.

cherry-pick: master
cherry-pick: 22
cherry-pick: 21
cherry-pick: 20