### PR TITLE
logger.c fix: malformed JSON template

### DIFF
--- a/main/logger.c
+++ b/main/logger.c
@@ -287,7 +287,7 @@ static int format_log_json(struct logchannel *channel, struct logmsg *msg, char 
 	}
 
 	json = ast_json_pack("{s: s, s: s, "
-		"s: {s: i, s: s} "
+		"s: {s: i, s: s}, "
 		"s: {s: {s: s, s: s, s: i}, "
 		"s: s, s: s} }",
 		"hostname", ast_config_AST_SYSTEM_NAME,


### PR DESCRIPTION
this typo was mentioned before, but never got fixed.  https://community.asterisk.org/t/logger-cannot-log-long-json-lines-properly/87618/6

(I found it elsewhere too but wasn't able to dig it up)

We are hunting down an issue where the logger fails to log our Error (probably caused by invalid chars in the caller-ID).