### PR TITLE
res_config_pgsql: normalize database connection options

### DIFF
--- a/configs/samples/res_pgsql.conf.sample
+++ b/configs/samples/res_pgsql.conf.sample
@@ -1,25 +1,25 @@
 ;
 ; Sample configuration for res_config_pgsql
 ;
-; The value of dbhost may be either a hostname or an IP address.
-; If dbhost is commented out or the string "localhost", a connection
+; The value of hostname may be either a hostname or an IP address.
+; If hostname is commented out or the string "localhost", a connection
 ; to the local host is assumed and dbsock is used instead of TCP/IP
 ; to connect to the server.
 ;
 [general]
-dbhost=127.0.0.1
-dbport=5432
-dbname=asterisk
-dbuser=asterisk
-dbpass=password
-;dbappname=asterisk    ; Postgres application_name support (optional). Whitespace not allowed.
-;
-; dbsock is specified as the directory where the socket file may be found. The
-; actual socket is constructed as a combination of dbsock and dbport.  For
+;hostname=localhost
+;port=5432
+;dbname=asterisk
+;user=postgres
+;password=password
+;appname=asterisk    ; Postgres application_name support (optional). Whitespace not allowed.
+
+; socket is specified as the directory where the socket file may be found. The
+; actual socket is constructed as a combination of socket and port.  For
 ; example, the values of '/tmp' and '5432', respectively, will specify a socket
 ; file of '/tmp/.s.PGSQL.5432'.
 ;
-;dbsock=/tmp
+;socket=/tmp
 ;
 ; requirements - At startup, each realtime family will make requirements
 ; on the backend.  There are several strategies for handling requirements:


### PR DESCRIPTION
The syntax will match the other modules cel and cdr.

Let me know if this is the correct way to correct syntaxes.

Also i noticed that this module is the only one that use socket as option.

