### PR TITLE
manager.c: Restrict ListCategories to the configuration directory.

### DIFF
--- a/main/manager.c
+++ b/main/manager.c
@@ -2561,9 +2561,19 @@ static int action_listcategories(struct mansession *s, const struct message *m)
 	struct ast_category *category = NULL;
 	struct ast_flags config_flags = { CONFIG_FLAG_WITHCOMMENTS | CONFIG_FLAG_NOCACHE };
 	int catcount = 0;
+	int ret = 0;
 
 	if (ast_strlen_zero(fn)) {
 		astman_send_error(s, m, "Filename not specified");
+		return 0;
+	}
+
+	ret = restrictedFile(fn);
+	if (ret == 1) {
+		astman_send_error(s, m, "File requires escalated priveledges");
+		return 0;
+	} else if (ret == -1) {
+		astman_send_error(s, m, "Config file not found");
 		return 0;
 	}
 


### PR DESCRIPTION
When using the ListCategories AMI action, it was possible to traverse
upwards through the directories to files outside of the configured
configuration directory. This action is now restricted to the configured
directory and an error will now be returned if the specified file is
outside of this limitation.

Resolves: #GHSA-33x6-fj46-6rfh

UserNote: The ListCategories AMI action now restricts files to the
configured configuration directory.
