### PR TITLE
docs: Enable since/version handling for XML, CLI and ARI documentation

### DIFF
--- a/doc/appdocsxml.dtd
+++ b/doc/appdocsxml.dtd
@@ -72,10 +72,10 @@
   <!ELEMENT configFile (configObject|xi:include)+>
   <!ATTLIST configFile name CDATA #REQUIRED>
 
-  <!ELEMENT configObject (synopsis?|description?|syntax?|see-also?|(configOption|xi:include))*>
+  <!ELEMENT configObject (since?|synopsis?|description?|syntax?|see-also?|(configOption|xi:include))*>
   <!ATTLIST configObject name CDATA #REQUIRED>
 
-  <!ELEMENT configOption (synopsis,description?,syntax?,see-also?)*>
+  <!ELEMENT configOption (since?,synopsis,description?,syntax?,see-also?)*>
   <!ATTLIST configOption name CDATA #REQUIRED>
   <!ATTLIST configOption regex (yes|no|true|false) "false">
   <!ATTLIST configOption default CDATA #IMPLIED>

--- a/include/asterisk/agi.h
+++ b/include/asterisk/agi.h
@@ -60,6 +60,10 @@ typedef struct agi_command {
 	struct ast_module *mod;
 	/*! Linked list pointer */
 	AST_LIST_ENTRY(agi_command) list;
+	/*! Since content */
+	const char * const since;
+	/*! Syntax arguments content */
+	const char * const arguments;
 } agi_command;
 
 /*!

--- a/include/asterisk/manager.h
+++ b/include/asterisk/manager.h
@@ -181,6 +181,7 @@ struct manager_action {
 	 * function and unregistering the AMI action object.
 	 */
 	unsigned int registered:1;
+	AST_STRING_FIELD_EXTENDED(since);	/*!< Documentation "since" element */
 };
 
 /*! \brief External routines may register/unregister manager callbacks this way

--- a/include/asterisk/pbx.h
+++ b/include/asterisk/pbx.h
@@ -150,6 +150,7 @@ struct ast_custom_function {
 					 * \since 12 */
 
 	AST_RWLIST_ENTRY(ast_custom_function) acflist;
+	AST_STRING_FIELD_EXTENDED(since); /*!< Since text for 'show functions' */
 };
 
 /*! \brief All switch functions have the same interface, so define a type for them */

--- a/include/asterisk/xmldoc.h
+++ b/include/asterisk/xmldoc.h
@@ -78,6 +78,8 @@ struct ast_xml_doc_item {
 	struct ast_xml_node *node;
 	/*! The next XML documentation item that matches the same name/item type */
 	AST_LIST_ENTRY(ast_xml_doc_item) next;
+	/*! Since tagged information, if it exists */
+	struct ast_str *since;
 };
 
 /*! \brief Execute an XPath query on the loaded XML documentation
@@ -109,6 +111,16 @@ char *ast_xmldoc_build_syntax(const char *type, const char *name, const char *mo
  *  \retval Content of the see-also node.
  */
 char *ast_xmldoc_build_seealso(const char *type, const char *name, const char *module);
+
+/*!
+ *  \brief Parse the <since> node content.
+ *  \param type 'application', 'function' or 'agi'.
+ *  \param name Application or functions name.
+ *  \param module The module the item is in (optional, can be NULL)
+ *  \retval NULL on error.
+ *  \retval Content of the since node.
+ */
+char *ast_xmldoc_build_since(const char *type, const char *name, const char *module);
 
 /*!
  *  \brief Generate the [arguments] tag based on type of node ('application',

--- a/main/pbx_app.c
+++ b/main/pbx_app.c
@@ -46,6 +46,7 @@ struct ast_app {
 	int (*execute)(struct ast_channel *chan, const char *data);
 	AST_DECLARE_STRING_FIELDS(
 		AST_STRING_FIELD(synopsis);     /*!< Synopsis text for 'show applications' */
+		AST_STRING_FIELD(since);        /*!< Since text for 'show applications' */
 		AST_STRING_FIELD(description);  /*!< Description (help text) for 'show application &lt;name&gt;' */
 		AST_STRING_FIELD(syntax);       /*!< Syntax text for 'core show applications' */
 		AST_STRING_FIELD(arguments);    /*!< Arguments description */
@@ -142,6 +143,11 @@ int ast_register_application2(const char *app, int (*execute)(struct ast_channel
 		ast_string_field_set(tmp, synopsis, tmpxml);
 		ast_free(tmpxml);
 
+		/* load since */
+		tmpxml = ast_xmldoc_build_since("application", app, ast_module_name(tmp->module));
+		ast_string_field_set(tmp, since, tmpxml);
+		ast_free(tmpxml);
+
 		/* load description */
 		tmpxml = ast_xmldoc_build_description("application", app, ast_module_name(tmp->module));
 		ast_string_field_set(tmp, description, tmpxml);
@@ -191,67 +197,61 @@ int ast_register_application2(const char *app, int (*execute)(struct ast_channel
 
 static void print_app_docs(struct ast_app *aa, int fd)
 {
+	char *synopsis = NULL, *since = NULL, *description = NULL, *syntax = NULL, *arguments = NULL, *seealso = NULL;
+
 #ifdef AST_XML_DOCS
-	char *synopsis = NULL, *description = NULL, *arguments = NULL, *seealso = NULL;
 	if (aa->docsrc == AST_XML_DOC) {
 		synopsis = ast_xmldoc_printable(S_OR(aa->synopsis, "Not available"), 1);
+		since = ast_xmldoc_printable(S_OR(aa->since, "Not available"), 1);
 		description = ast_xmldoc_printable(S_OR(aa->description, "Not available"), 1);
+		syntax = ast_xmldoc_printable(S_OR(aa->syntax, "Not available"), 1);
 		arguments = ast_xmldoc_printable(S_OR(aa->arguments, "Not available"), 1);
 		seealso = ast_xmldoc_printable(S_OR(aa->seealso, "Not available"), 1);
-		if (!synopsis || !description || !arguments || !seealso) {
-			goto free_docs;
-		}
-		ast_cli(fd, "\n"
-			"%s  -= Info about application '%s' =- %s\n\n"
-			COLORIZE_FMT "\n"
-			"%s\n\n"
-			COLORIZE_FMT "\n"
-			"%s\n\n"
-			COLORIZE_FMT "\n"
-			"%s%s%s\n\n"
-			COLORIZE_FMT "\n"
-			"%s\n\n"
-			COLORIZE_FMT "\n"
-			"%s\n",
-			ast_term_color(COLOR_MAGENTA, 0), aa->name, ast_term_reset(),
-			COLORIZE(COLOR_MAGENTA, 0, "[Synopsis]"), synopsis,
-			COLORIZE(COLOR_MAGENTA, 0, "[Description]"), description,
-			COLORIZE(COLOR_MAGENTA, 0, "[Syntax]"),
-				ast_term_color(COLOR_CYAN, 0), S_OR(aa->syntax, "Not available"), ast_term_reset(),
-			COLORIZE(COLOR_MAGENTA, 0, "[Arguments]"), arguments,
-			COLORIZE(COLOR_MAGENTA, 0, "[See Also]"), seealso);
-free_docs:
-		ast_free(synopsis);
-		ast_free(description);
-		ast_free(arguments);
-		ast_free(seealso);
 	} else
 #endif
 	{
-		ast_cli(fd, "\n"
-			"%s  -= Info about application '%s' =- %s\n\n"
-			COLORIZE_FMT "\n"
-			COLORIZE_FMT "\n\n"
-			COLORIZE_FMT "\n"
-			COLORIZE_FMT "\n\n"
-			COLORIZE_FMT "\n"
-			COLORIZE_FMT "\n\n"
-			COLORIZE_FMT "\n"
-			COLORIZE_FMT "\n\n"
-			COLORIZE_FMT "\n"
-			COLORIZE_FMT "\n",
-			ast_term_color(COLOR_MAGENTA, 0), aa->name, ast_term_reset(),
-			COLORIZE(COLOR_MAGENTA, 0, "[Synopsis]"),
-			COLORIZE(COLOR_CYAN, 0, S_OR(aa->synopsis, "Not available")),
-			COLORIZE(COLOR_MAGENTA, 0, "[Description]"),
-			COLORIZE(COLOR_CYAN, 0, S_OR(aa->description, "Not available")),
-			COLORIZE(COLOR_MAGENTA, 0, "[Syntax]"),
-			COLORIZE(COLOR_CYAN, 0, S_OR(aa->syntax, "Not available")),
-			COLORIZE(COLOR_MAGENTA, 0, "[Arguments]"),
-			COLORIZE(COLOR_CYAN, 0, S_OR(aa->arguments, "Not available")),
-			COLORIZE(COLOR_MAGENTA, 0, "[See Also]"),
-			COLORIZE(COLOR_CYAN, 0, S_OR(aa->seealso, "Not available")));
+		synopsis = ast_strdup(S_OR(aa->synopsis, "Not Available"));
+		since = ast_strdup(S_OR(aa->since, "Not Available"));
+		description = ast_strdup(S_OR(aa->description, "Not Available"));
+		syntax = ast_strdup(S_OR(aa->syntax, "Not Available"));
+		arguments = ast_strdup(S_OR(aa->arguments, "Not Available"));
+		seealso = ast_strdup(S_OR(aa->seealso, "Not Available"));
 	}
+		/* check allocated memory. */
+	if (!synopsis || !since || !description || !syntax || !arguments || !seealso) {
+		goto free_docs;
+	}
+
+	ast_cli(fd, "\n"
+		"%s  -= Info about Application '%s' =- %s\n\n"
+		COLORIZE_FMT "\n"
+		"%s\n\n"
+		COLORIZE_FMT "\n"
+		"%s\n\n"
+		COLORIZE_FMT "\n"
+		"%s\n\n"
+		COLORIZE_FMT "\n"
+		"%s\n\n"
+		COLORIZE_FMT "\n"
+		"%s\n\n"
+		COLORIZE_FMT "\n"
+		"%s\n\n",
+		ast_term_color(COLOR_MAGENTA, 0), aa->name, ast_term_reset(),
+		COLORIZE(COLOR_MAGENTA, 0, "[Synopsis]"), synopsis,
+		COLORIZE(COLOR_MAGENTA, 0, "[Since]"), since,
+		COLORIZE(COLOR_MAGENTA, 0, "[Description]"), description,
+		COLORIZE(COLOR_MAGENTA, 0, "[Syntax]"), syntax,
+		COLORIZE(COLOR_MAGENTA, 0, "[Arguments]"), arguments,
+		COLORIZE(COLOR_MAGENTA, 0, "[See Also]"), seealso
+		);
+
+free_docs:
+	ast_free(synopsis);
+	ast_free(since);
+	ast_free(description);
+	ast_free(syntax);
+	ast_free(arguments);
+	ast_free(seealso);
 }
 
 /*!

--- a/res/res_agi.c
+++ b/res/res_agi.c
@@ -3831,8 +3831,10 @@ int AST_OPTIONAL_API_NAME(ast_agi_register)(struct ast_module *mod, agi_command 
 		if (ast_strlen_zero(cmd->summary) && ast_strlen_zero(cmd->usage)) {
 #ifdef AST_XML_DOCS
 			*((char **) &cmd->summary) = ast_xmldoc_build_synopsis("agi", fullcmd, NULL);
+			*((char **) &cmd->since) = ast_xmldoc_build_since("agi", fullcmd, NULL);
 			*((char **) &cmd->usage) = ast_xmldoc_build_description("agi", fullcmd, NULL);
 			*((char **) &cmd->syntax) = ast_xmldoc_build_syntax("agi", fullcmd, NULL);
+			*((char **) &cmd->arguments) = ast_xmldoc_build_arguments("agi", fullcmd, NULL);
 			*((char **) &cmd->seealso) = ast_xmldoc_build_seealso("agi", fullcmd, NULL);
 			*((enum ast_doc_src *) &cmd->docsrc) = AST_XML_DOC;
 #endif
@@ -3879,12 +3881,16 @@ int AST_OPTIONAL_API_NAME(ast_agi_unregister)(agi_command *cmd)
 #ifdef AST_XML_DOCS
 			if (e->docsrc == AST_XML_DOC) {
 				ast_free((char *) e->summary);
+				ast_free((char *) e->since);
 				ast_free((char *) e->usage);
 				ast_free((char *) e->syntax);
+				ast_free((char *) e->arguments);
 				ast_free((char *) e->seealso);
 				*((char **) &e->summary) = NULL;
+				*((char **) &e->since) = NULL;
 				*((char **) &e->usage) = NULL;
 				*((char **) &e->syntax) = NULL;
+				*((char **) &e->arguments) = NULL;
 				*((char **) &e->seealso) = NULL;
 			}
 #endif
@@ -4343,72 +4349,66 @@ static char *handle_cli_agi_show(struct ast_cli_entry *e, int cmd, struct ast_cl
 	if (a->argc > e->args - 1) {
 		command = find_command(a->argv + e->args, 1);
 		if (command) {
-			char *synopsis = NULL, *description = NULL, *syntax = NULL, *seealso = NULL;
-			char info[30 + MAX_CMD_LEN];					/* '-= Info about...' */
-			char infotitle[30 + MAX_CMD_LEN + AST_TERM_MAX_ESCAPE_CHARS];	/* '-= Info about...' with colors */
-			char syntitle[11 + AST_TERM_MAX_ESCAPE_CHARS];			/* [Syntax]\n with colors */
-			char desctitle[15 + AST_TERM_MAX_ESCAPE_CHARS];			/* [Description]\n with colors */
-			char deadtitle[13 + AST_TERM_MAX_ESCAPE_CHARS];			/* [Runs Dead]\n with colors */
-			char deadcontent[3 + AST_TERM_MAX_ESCAPE_CHARS];		/* 'Yes' or 'No' with colors */
-			char seealsotitle[12 + AST_TERM_MAX_ESCAPE_CHARS];		/* [See Also]\n with colors */
-			char stxtitle[10 + AST_TERM_MAX_ESCAPE_CHARS];			/* [Syntax]\n with colors */
-			size_t synlen, desclen, seealsolen, stxlen;
-
-			term_color(syntitle, "[Synopsis]\n", COLOR_MAGENTA, 0, sizeof(syntitle));
-			term_color(desctitle, "[Description]\n", COLOR_MAGENTA, 0, sizeof(desctitle));
-			term_color(deadtitle, "[Runs Dead]\n", COLOR_MAGENTA, 0, sizeof(deadtitle));
-			term_color(seealsotitle, "[See Also]\n", COLOR_MAGENTA, 0, sizeof(seealsotitle));
-			term_color(stxtitle, "[Syntax]\n", COLOR_MAGENTA, 0, sizeof(stxtitle));
-			term_color(deadcontent, command->dead ? "Yes" : "No", COLOR_CYAN, 0, sizeof(deadcontent));
+			char *synopsis = NULL, *since = NULL, *description = NULL, *syntax = NULL, *arguments = NULL, *seealso = NULL;
 
 			ast_join(fullcmd, sizeof(fullcmd), a->argv + e->args);
-			snprintf(info, sizeof(info), "\n  -= Info about agi '%s' =- ", fullcmd);
-			term_color(infotitle, info, COLOR_CYAN, 0, sizeof(infotitle));
+
 #ifdef AST_XML_DOCS
 			if (command->docsrc == AST_XML_DOC) {
 				synopsis = ast_xmldoc_printable(S_OR(command->summary, "Not available"), 1);
+				since = ast_xmldoc_printable(S_OR(command->since, "Not available"), 1);
 				description = ast_xmldoc_printable(S_OR(command->usage, "Not available"), 1);
+				syntax = ast_xmldoc_printable(S_OR(command->syntax, "Not available"), 1);
+				arguments = ast_xmldoc_printable(S_OR(command->arguments, "Not available"), 1);
 				seealso = ast_xmldoc_printable(S_OR(command->seealso, "Not available"), 1);
-				if (!seealso || !description || !synopsis) {
-					error = 1;
-					goto return_cleanup;
-				}
 			} else
 #endif
 			{
-				synlen = strlen(S_OR(command->summary, "Not available")) + AST_TERM_MAX_ESCAPE_CHARS;
-				synopsis = ast_malloc(synlen);
-
-				desclen = strlen(S_OR(command->usage, "Not available")) + AST_TERM_MAX_ESCAPE_CHARS;
-				description = ast_malloc(desclen);
-
-				seealsolen = strlen(S_OR(command->seealso, "Not available")) + AST_TERM_MAX_ESCAPE_CHARS;
-				seealso = ast_malloc(seealsolen);
-
-				if (!synopsis || !description || !seealso) {
-					error = 1;
-					goto return_cleanup;
-				}
-				term_color(synopsis, S_OR(command->summary, "Not available"), COLOR_CYAN, 0, synlen);
-				term_color(description, S_OR(command->usage, "Not available"), COLOR_CYAN, 0, desclen);
-				term_color(seealso, S_OR(command->seealso, "Not available"), COLOR_CYAN, 0, seealsolen);
+				synopsis = ast_strdup(S_OR(command->summary, "Not Available"));
+				since = ast_strdup(S_OR(command->since, "Not Available"));
+				description = ast_strdup(S_OR(command->usage, "Not Available"));
+				syntax = ast_strdup(S_OR(command->syntax, "Not Available"));
+				arguments = ast_strdup(S_OR(command->arguments, "Not Available"));
+				seealso = ast_strdup(S_OR(command->seealso, "Not Available"));
 			}
 
-			stxlen = strlen(S_OR(command->syntax, "Not available")) + AST_TERM_MAX_ESCAPE_CHARS;
-			syntax = ast_malloc(stxlen);
-			if (!syntax) {
+			if (!synopsis || !since || !description || !syntax || !arguments || !seealso) {
 				error = 1;
 				goto return_cleanup;
 			}
-			term_color(syntax, S_OR(command->syntax, "Not available"), COLOR_CYAN, 0, stxlen);
 
-			ast_cli(a->fd, "%s\n\n%s%s\n\n%s%s\n\n%s%s\n\n%s%s\n\n%s%s\n\n", infotitle, stxtitle, syntax,
-					desctitle, description, syntitle, synopsis, deadtitle, deadcontent,
-					seealsotitle, seealso);
+			ast_cli(a->fd, "\n"
+				"%s  -= Info about AGI '%s' =- %s\n\n"
+				COLORIZE_FMT "\n"
+				"%s\n\n"
+				COLORIZE_FMT "\n"
+				"%s\n\n"
+				COLORIZE_FMT "\n"
+				"%s\n\n"
+				COLORIZE_FMT "\n"
+				"%s\n\n"
+				COLORIZE_FMT "\n"
+				"%s\n\n"
+				COLORIZE_FMT "\n"
+				"%s\n\n"
+				COLORIZE_FMT "\n"
+				"%s\n\n",
+				ast_term_color(COLOR_MAGENTA, 0), fullcmd, ast_term_reset(),
+				COLORIZE(COLOR_MAGENTA, 0, "[Synopsis]"), synopsis,
+				COLORIZE(COLOR_MAGENTA, 0, "[Since]"), since,
+				COLORIZE(COLOR_MAGENTA, 0, "[Description]"), description,
+				COLORIZE(COLOR_MAGENTA, 0, "[Syntax]"), syntax,
+				COLORIZE(COLOR_MAGENTA, 0, "[Arguments]"), arguments,
+				COLORIZE(COLOR_MAGENTA, 0, "[Runs Dead]"), command->dead ? "Yes" : "No",
+				COLORIZE(COLOR_MAGENTA, 0, "[See Also]"), seealso
+				);
+
 return_cleanup:
 			ast_free(synopsis);
+			ast_free(since);
 			ast_free(description);
 			ast_free(syntax);
+			ast_free(arguments);
 			ast_free(seealso);
 		} else {
 			if (find_command(a->argv + e->args, -1)) {

--- a/rest-api-templates/api.wiki.mustache
+++ b/rest-api-templates/api.wiki.mustache
@@ -1,11 +1,14 @@
 {{#api_declaration}}
 # {{name_title}}
+{{#since}}
+## Since: {{since}}
+{{/since}}
 
-| Method | Path (Parameters are case-sensitive) | Return Model | Summary |
-|:------ |:------------------------------------ |:------------ |:------- |
+| Method | Path (Parameters are case-sensitive) | Return Model | Summary | Since |
+|:------ |:------------------------------------ |:------------ |:------- |:----- |
 {{#apis}}
 {{#operations}}
-| {{http_method}} | [{{wiki_path}}](#{{nickname_lc}}) | {{#response_class}}{{#is_primitive}}{{name}}{{/is_primitive}}{{^is_primitive}}[{{wiki_name}}]({{wiki_prefix}}Asterisk_REST_Data_Models#{{lc_singular_name}}){{/is_primitive}}{{/response_class}} | {{{summary}}} |
+| {{http_method}} | [{{wiki_path}}](#{{nickname_lc}}) | {{#response_class}}{{#is_primitive}}{{name}}{{/is_primitive}}{{^is_primitive}}[{{wiki_name}}]({{wiki_prefix}}Asterisk_REST_Data_Models#{{lc_singular_name}}){{/is_primitive}}{{/response_class}} | {{{summary}}} | {{since}} |
 {{/operations}}
 {{/apis}}
 {{#apis}}
@@ -14,6 +17,9 @@
 ---
 [//]: # (anchor:{{nickname_lc}})
 ## {{nickname}}
+{{#since}}
+### Since: {{since}}
+{{/since}}
 ### {{http_method}} {{wiki_path}}
 {{{wiki_summary}}}{{#wiki_notes}} {{{wiki_notes}}}{{/wiki_notes}}
 {{#has_path_parameters}}

--- a/rest-api-templates/swagger_model.py
+++ b/rest-api-templates/swagger_model.py
@@ -373,6 +373,7 @@ class Operation(Stringify):
         self.summary = None
         self.notes = None
         self.error_responses = []
+        self.since = []
 
     def load(self, op_json, processor, context):
         context = context.next_stack(op_json, 'nickname')
@@ -383,6 +384,8 @@ class Operation(Stringify):
         response_class = op_json.get('responseClass')
         self.response_class = response_class and SwaggerType().load(
             response_class, processor, context)
+        since = op_json.get('since') or []
+        self.since = ", ".join(since)
 
         # Specifying WebSocket URL's is our own extension
         self.is_websocket = op_json.get('upgrade') == 'websocket'
@@ -611,6 +614,7 @@ class ApiDeclaration(Stringify):
         self.api_version = None
         self.base_path = None
         self.resource_path = None
+        self.since = []
         self.apis = []
         self.models = []
 
@@ -658,6 +662,8 @@ class ApiDeclaration(Stringify):
         self.base_path = api_decl_json.get('basePath')
         self.resource_path = api_decl_json.get('resourcePath')
         self.requires_modules = api_decl_json.get('requiresModules') or []
+        since = api_decl_json.get('since') or []
+        self.since = ", ".join(since)
         api_json = api_decl_json.get('apis') or []
         self.apis = [
             Api().load(j, processor, context) for j in api_json]


### PR DESCRIPTION
* Added the "since" element to the XML configObject and configOption elements in appdocsxml.dtd.

* Added the "Since" section to the following CLI output:
  ```
  config show help <module> <object>
  config show help <module> <object> <option>
  core show application <app>
  core show function <func>
  manager show command <command>
  manager show event <event>
  agi show commands topic <topic>
  ```

* Refactored the commands above to output their sections in the same order:
Synopsis, Since, Description, Syntax, Arguments, SeeAlso

* Refactored the commands above so they all use the same pattern for writing the output to the CLI.

* Fixed several memory leaks caused by failure to free temporary output buffers.

* Added a "since" array to the mustache template for the top-level resources (Channel, Endpoint, etc.) and to the paths/methods underneath them. These will be added to the generated markdown if present.
  Example:
  ```
    "resourcePath": "/api-docs/channels.{format}",
    "requiresModules": [
        "res_stasis_answer",
        "res_stasis_playback",
        "res_stasis_recording",
        "res_stasis_snoop"
    ],
    "since": [
        "18.0.0",
        "21.0.0"
    ],
    "apis": [
        {
            "path": "/channels",
            "description": "Active channels",
            "operations": [
                {
                    "httpMethod": "GET",
                    "since": [
                        "18.6.0",
                        "21.8.0"
                    ],
                    "summary": "List all active channels in Asterisk.",
                    "nickname": "list",
                    "responseClass": "List[Channel]"
                },

  ```

NOTE:  No versioning information is actually added in this commit.
Those will be added separately and instructions for adding and maintaining
them will be published on the documentation site at a later date.
