### PR TITLE
fixed semicolons

### DIFF
--- a/include/asterisk/logger.h
+++ b/include/asterisk/logger.h
@@ -897,7 +897,7 @@ unsigned long _ast_trace_dec_indent(void);
 	__type __var; \
 	ast_trace(level, "--> Calling %s\n", #__funcname); \
 	__var = __funcname(__VA_ARGS__); \
-	ast_trace(level, "<-- Return from %s\n", #__funcname) \
+	ast_trace(level, "<-- Return from %s\n", #__funcname); \
 	__var; \
 })
 

--- a/res/res_pjsip_authenticator_digest.c
+++ b/res/res_pjsip_authenticator_digest.c
@@ -632,7 +632,7 @@ static enum ast_sip_check_auth_result digest_check_auth(struct ast_sip_endpoint 
 		 * sending challenges. We don't need to verify them.
 		 */
 		if (auth->type == AST_SIP_AUTH_TYPE_ARTIFICIAL) {
-			ast_trace(-1, "%s:%s:%s: Skipping verification on artificial endpoint\n", endpoint_id, auth_id, src_name )
+			ast_trace(-1, "%s:%s:%s: Skipping verification on artificial endpoint\n", endpoint_id, auth_id, src_name );
 			verify_res[idx] = AUTH_NOAUTH;
 		} else {
 			verify_res[idx] = SCOPE_CALL_WITH_RESULT(-1, int, verify, endpoint_id, auth, rdata, tdata->pool);


### PR DESCRIPTION
This fixes missing semicolons typoed in the latest release.  

I do this all the time when I'm writing python all day and then start writing C.