### PR TITLE
ast_tls_cert: Add option to skip passphrase for CA private key.

### DIFF
--- a/contrib/scripts/ast_tls_cert
+++ b/contrib/scripts/ast_tls_cert
@@ -3,6 +3,7 @@ DEFAULT_ORG="Asterisk"
 DEFAULT_CA_CN="Asterisk Private CA"
 DEFAULT_CLIENT_CN="asterisk"
 DEFAULT_SERVER_CN=`hostname -f`
+CA_ENCRYPTION_OPT="-des3"
 
 # arguments
 # $1 "ca" if we are to generate a CA cert
@@ -31,7 +32,7 @@ EOF
 
 create_ca () {
 	echo "Creating CA key ${CAKEY}"
-	openssl genrsa -des3 -out ${CAKEY} 4096 > /dev/null
+	openssl genrsa ${CA_ENCRYPTION_OPT} -out ${CAKEY} 4096 > /dev/null
 	if [ $? -ne 0 ];
 	then
 		echo "Failed"
@@ -87,6 +88,7 @@ OPTIONS:
   -f  Config filename (openssl config file format)
   -c  CA cert filename (creates new CA cert/key as ca.crt/ca.key if not passed)
   -k  CA key filename
+  -e  Don't encrypt the CA private key with a passphrase (default is to use 3DES encryption)
   -b  The desired size of the private key in bits. Default is 2048.
   -C  Common name (cert field)
         This should be the fully qualified domain name or IP address for
@@ -129,7 +131,7 @@ OUTPUT_BASE=asterisk # Our default cert basename
 CERT_MODE=server
 ORG_NAME=${DEFAULT_ORG}
 
-while getopts "hf:c:k:o:d:m:C:O:b:" OPTION
+while getopts "hf:c:ek:o:d:m:C:O:b:" OPTION
 do
 	case ${OPTION} in
 		h)
@@ -141,6 +143,9 @@ do
 			;;
 		c)
 			CACERT=${OPTARG}
+			;;
+		e)
+			CA_ENCRYPTION_OPT=""
 			;;
 		k)
 			CAKEY=${OPTARG}


### PR DESCRIPTION
Currently, ast_tls_cert file is hardcoded to use the -des3 option for 3DES encryption, and the script needs to be manually modified to not require a passphrase. Add an option (-e) that disables encryption of the CA private key so no passphrase is required.

Resolves: #1064