### PR TITLE
docs: Add version information to configObject and configOption XML elements (20 only)

### DIFF
--- a/apps/app_agent_pool.c
+++ b/apps/app_agent_pool.c
@@ -268,11 +268,13 @@
 				<synopsis>Unused, but reserved.</synopsis>
 			</configObject>
 			<configObject name="agent-id">
+				<since><version>12.0.0</version></since>
 				<synopsis>Configure an agent for the pool.</synopsis>
 				<description>
 					<xi:include xpointer="xpointer(/docs/configInfo[@name='app_agent_pool']/description/note)" />
 				</description>
 				<configOption name="ackcall">
+					<since><version>12.0.0</version></since>
 					<synopsis>Enable to require the agent to acknowledge a call.</synopsis>
 					<description>
 						<para>Enable to require the agent to give a DTMF acknowledgement
@@ -282,6 +284,7 @@
 					</description>
 				</configOption>
 				<configOption name="acceptdtmf">
+					<since><version>12.0.0</version></since>
 					<synopsis>DTMF key sequence the agent uses to acknowledge a call.</synopsis>
 					<description>
 						<note><para>The option is overridden by <variable>AGENTACCEPTDTMF</variable> on agent login.</para></note>
@@ -290,6 +293,7 @@
 					</description>
 				</configOption>
 				<configOption name="autologoff">
+					<since><version>12.0.0</version></since>
 					<synopsis>Time the agent has to acknowledge a call before being logged off.</synopsis>
 					<description>
 						<para>Set how many seconds a call for the agent has to wait for the
@@ -302,6 +306,7 @@
 					</description>
 				</configOption>
 				<configOption name="wrapuptime">
+					<since><version>12.0.0</version></since>
 					<synopsis>Minimum time the agent has between calls.</synopsis>
 					<description>
 						<para>Set the minimum amount of time in milliseconds after
@@ -311,12 +316,14 @@
 					</description>
 				</configOption>
 				<configOption name="musiconhold">
+					<since><version>12.0.0</version></since>
 					<synopsis>Music on hold class the agent listens to between calls.</synopsis>
 					<description>
 						<xi:include xpointer="xpointer(/docs/configInfo[@name='app_agent_pool']/description/note)" />
 					</description>
 				</configOption>
 				<configOption name="recordagentcalls">
+					<since><version>12.0.0</version></since>
 					<synopsis>Enable to automatically record calls the agent takes.</synopsis>
 					<description>
 						<para>Enable recording calls the agent takes automatically by
@@ -327,12 +334,14 @@
 					</description>
 				</configOption>
 				<configOption name="custom_beep">
+					<since><version>12.4.0</version></since>
 					<synopsis>Sound file played to alert the agent when a call is present.</synopsis>
 					<description>
 						<xi:include xpointer="xpointer(/docs/configInfo[@name='app_agent_pool']/description/note)" />
 					</description>
 				</configOption>
 				<configOption name="fullname">
+					<since><version>12.0.0</version></since>
 					<synopsis>A friendly name for the agent used in log messages.</synopsis>
 					<description>
 						<xi:include xpointer="xpointer(/docs/configInfo[@name='app_agent_pool']/description/note)" />

--- a/apps/app_skel.c
+++ b/apps/app_skel.c
@@ -88,42 +88,55 @@
 	<configInfo name="app_skel" language="en_US">
 		<configFile name="app_skel.conf">
 			<configObject name="globals">
+				<since><version>12.0.0</version></since>
 				<synopsis>Options that apply globally to app_skel</synopsis>
 				<configOption name="games">
+					<since><version>11.0.0</version></since>
 					<synopsis>The number of games a single execution of SkelGuessNumber will play</synopsis>
 				</configOption>
 				<configOption name="cheat">
+					<since><version>11.0.0</version></since>
 					<synopsis>Should the computer cheat?</synopsis>
 					<description><para>If enabled, the computer will ignore winning guesses.</para></description>
 				</configOption>
 			</configObject>
 			<configObject name="sounds">
+				<since><version>12.0.0</version></since>
 				<synopsis>Prompts for SkelGuessNumber to play</synopsis>
 				<configOption name="prompt" default="please-enter-your&amp;number&amp;queue-less-than">
+					<since><version>11.0.0</version></since>
 					<synopsis>A prompt directing the user to enter a number less than the max number</synopsis>
 				</configOption>
 				<configOption name="wrong_guess" default="vm-pls-try-again">
+					<since><version>11.0.0</version></since>
 					<synopsis>The sound file to play when a wrong guess is made</synopsis>
 				</configOption>
 				<configOption name="right_guess" default="auth-thankyou">
+					<since><version>11.0.0</version></since>
 					<synopsis>The sound file to play when a correct guess is made</synopsis>
 				</configOption>
 				<configOption name="too_low">
+					<since><version>11.0.0</version></since>
 					<synopsis>The sound file to play when a guess is too low</synopsis>
 				</configOption>
 				<configOption name="too_high">
+					<since><version>11.0.0</version></since>
 					<synopsis>The sound file to play when a guess is too high</synopsis>
 				</configOption>
 				<configOption name="lose" default="vm-goodbye">
+					<since><version>11.0.0</version></since>
 					<synopsis>The sound file to play when a player loses</synopsis>
 				</configOption>
 			</configObject>
 			<configObject name="level">
+				<since><version>12.0.0</version></since>
 				<synopsis>Defined levels for the SkelGuessNumber game</synopsis>
 				<configOption name="max_number">
+					<since><version>11.0.0</version></since>
 					<synopsis>The maximum in the range of numbers to guess (1 is the implied minimum)</synopsis>
 				</configOption>
 				<configOption name="max_guesses">
+					<since><version>11.22.0</version><version>13.9.0</version></since>
 					<synopsis>The maximum number of guesses before a game is considered lost</synopsis>
 				</configOption>
 			</configObject>

--- a/apps/confbridge/conf_config_parser.c
+++ b/apps/confbridge/conf_config_parser.c
@@ -48,6 +48,7 @@
 				<synopsis>Unused, but reserved.</synopsis>
 			</configObject>
 			<configObject name="user_profile">
+				<since><version>12.0.0</version></since>
 				<synopsis>A named profile to apply to specific callers.</synopsis>
 				<description><para>Callers in a ConfBridge have a profile associated with them
 				that determine their options. A configuration section is determined to be a
@@ -55,6 +56,7 @@
 				of <literal>user</literal>.
 				</para></description>
 				<configOption name="type">
+					<since><version>11.0.0</version></since>
 					<synopsis>Define this configuration category as a user profile.</synopsis>
 					<description><para>The type parameter determines how a context in the
 					configuration file is interpreted.</para>
@@ -66,9 +68,11 @@
 					</description>
 				</configOption>
 				<configOption name="admin">
+					<since><version>11.0.0</version></since>
 					<synopsis>Sets if the user is an admin or not</synopsis>
 				</configOption>
 				<configOption name="send_events" default="no">
+					<since><version>15.5.0</version></since>
 					<synopsis>Sets if events are send to the user</synopsis>
 					<description><para>If events are enabled for this bridge and this option is
 					set, users will receive events like join, leave, talking, etc. via text
@@ -78,6 +82,7 @@
 					interface.</para></description>
 				</configOption>
 				<configOption name="echo_events" default="yes">
+					<since><version>15.5.0</version></since>
 					<synopsis>Sets if events are echoed back to the user that
 					triggered them</synopsis>
 					<description><para>If events are enabled for this user and this option
@@ -86,24 +91,31 @@
 					</para></description>
 				</configOption>
 				<configOption name="marked">
+					<since><version>11.0.0</version></since>
 					<synopsis>Sets if this is a marked user or not</synopsis>
 				</configOption>
 				<configOption name="startmuted">
+					<since><version>11.0.0</version></since>
 					<synopsis>Sets if all users should start out muted</synopsis>
 				</configOption>
 				<configOption name="music_on_hold_when_empty">
+					<since><version>11.0.0</version></since>
 					<synopsis>Play MOH when user is alone or waiting on a marked user</synopsis>
 				</configOption>
 				<configOption name="quiet">
+					<since><version>11.0.0</version></since>
 					<synopsis>Silence enter/leave prompts and user intros for this user</synopsis>
 				</configOption>
 				<configOption name="hear_own_join_sound">
+					<since><version>16.26.0</version><version>18.12.0</version><version>19.4.0</version></since>
 					<synopsis>Determines if the user also hears the join sound when they enter a conference</synopsis>
 				</configOption>
 				<configOption name="announce_user_count">
+					<since><version>11.0.0</version></since>
 					<synopsis>Sets if the number of users should be announced to the user</synopsis>
 				</configOption>
 				<configOption name="announce_user_count_all">
+					<since><version>11.0.0</version></since>
 					<synopsis>Announce user count to all the other users when this user joins</synopsis>
 					<description><para>Sets if the number of users should be announced to all the other users
 					in the conference when this user joins. This option can be either set to 'yes' or
@@ -112,40 +124,52 @@
 					</para></description>
 				</configOption>
 				<configOption name="announce_only_user">
+					<since><version>11.0.0</version></since>
 					<synopsis>Announce to a user when they join an empty conference</synopsis>
 				</configOption>
 				<configOption name="wait_marked">
+					<since><version>11.0.0</version></since>
 					<synopsis>Sets if the user must wait for a marked user to enter before joining a conference</synopsis>
 				</configOption>
 				<configOption name="end_marked">
+					<since><version>11.0.0</version></since>
 					<synopsis>Kick the user from the conference when the last marked user leaves</synopsis>
 				</configOption>
 				<configOption name="end_marked_any">
+					<since><version>16.29.0</version><version>18.15.0</version><version>19.7.0</version></since>
 					<synopsis>Kick the user from the conference when any marked user leaves</synopsis>
 				</configOption>
 				<configOption name="talk_detection_events">
+					<since><version>11.0.0</version></since>
 					<synopsis>Set whether or not notifications of when a user begins and ends talking should be sent out as events over AMI</synopsis>
 				</configOption>
 				<configOption name="dtmf_passthrough">
+					<since><version>11.0.0</version></since>
 					<synopsis>Sets whether or not DTMF should pass through the conference</synopsis>
 				</configOption>
 				<configOption name="announce_join_leave">
+					<since><version>11.0.0</version></since>
 					<synopsis>Prompt user for their name when joining a conference and play it to the conference when they enter</synopsis>
 				</configOption>
 				<configOption name="announce_join_leave_review">
+					<since><version>13.0.0</version></since>
 					<synopsis>Prompt user for their name when joining a conference and play it to the conference when they enter.
 					The user will be asked to review the recording of their name before entering the conference.</synopsis>
 				</configOption>
 				<configOption name="pin">
+					<since><version>11.0.0</version></since>
 					<synopsis>Sets a PIN the user must enter before joining the conference</synopsis>
 				</configOption>
 				<configOption name="music_on_hold_class">
+					<since><version>11.0.0</version></since>
 					<synopsis>The MOH class to use for this user</synopsis>
 				</configOption>
 				<configOption name="announcement">
+					<since><version>11.0.0</version></since>
 					<synopsis>Sound file to play to the user when they join a conference</synopsis>
 				</configOption>
 				<configOption name="denoise">
+					<since><version>11.0.0</version></since>
 					<synopsis>Apply a denoise filter to the audio before mixing</synopsis>
 					<description><para>Sets whether or not a denoise filter should be applied
 					to the audio before mixing or not.  Off by default. Requires
@@ -157,6 +181,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="dsp_drop_silence">
+					<since><version>11.0.0</version></since>
 					<synopsis>Drop what Asterisk detects as silence from audio sent to the bridge</synopsis>
 					<description><para>
 					This option drops what Asterisk detects as silence from
@@ -167,6 +192,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="dsp_silence_threshold">
+					<since><version>11.0.0</version></since>
 					<synopsis>The number of milliseconds of silence necessary to declare talking stopped.</synopsis>
 					<description>
 						<para>The time in milliseconds of sound falling below the
@@ -200,6 +226,7 @@
 					</description>
 				</configOption>
 				<configOption name="dsp_talking_threshold">
+					<since><version>11.10.0</version><version>12.3.0</version></since>
 					<synopsis>Average magnitude threshold to determine talking.</synopsis>
 					<description>
 						<para>The minimum average magnitude per sample in a frame
@@ -230,6 +257,7 @@
 					</description>
 				</configOption>
 				<configOption name="jitterbuffer">
+					<since><version>11.0.0</version></since>
 					<synopsis>Place a jitter buffer on the user's audio stream before audio mixing is performed</synopsis>
 					<description><para>
 						Enabling this option places a jitterbuffer on the user's audio stream
@@ -241,12 +269,15 @@
 					</para></description>
 				</configOption>
 				<configOption name="template">
+					<since><version>11.0.0</version></since>
 					<synopsis>When using the CONFBRIDGE dialplan function, use a user profile as a template for creating a new temporary profile</synopsis>
 				</configOption>
 				<configOption name="timeout">
+					<since><version>13.7.0</version></since>
 					<synopsis>Kick the user out of the conference after this many seconds. 0 means there is no timeout for the user.</synopsis>
 				</configOption>
 				<configOption name="text_messaging" default="yes">
+					<since><version>16.10.0</version><version>17.4.0</version></since>
 					<synopsis>Sets if text messages are sent to the user.</synopsis>
 					<description><para>If text messaging is enabled for this user then
 					text messages will be sent to it. These may be events or from other
@@ -254,10 +285,12 @@
 					messages are sent to the user.</para></description>
 				</configOption>
 				<configOption name="answer_channel" default="yes">
+					<since><version>16.19.0</version><version>18.5.0</version></since>
 					<synopsis>Sets if a user's channel should be answered if currently unanswered.</synopsis>
 				</configOption>
 			</configObject>
 			<configObject name="bridge_profile">
+				<since><version>12.0.0</version></since>
 				<synopsis>A named profile to apply to specific bridges.</synopsis>
 				<description><para>ConfBridge bridges have a profile associated with them
 				that determine their options. A configuration section is determined to be a
@@ -265,6 +298,7 @@
 				of <literal>bridge</literal>.
 				</para></description>
 				<configOption name="type">
+					<since><version>12.0.0</version></since>
 					<synopsis>Define this configuration category as a bridge profile</synopsis>
 					<description><para>The type parameter determines how a context in the
 					configuration file is interpreted.</para>
@@ -276,9 +310,11 @@
 					</description>
 				</configOption>
 				<configOption name="jitterbuffer">
+					<since><version>11.0.0</version></since>
 					<synopsis>Place a jitter buffer on the conference's audio stream</synopsis>
 				</configOption>
 				<configOption name="internal_sample_rate">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>Set the internal native sample rate for mixing the conference</synopsis>
 					<description><para>
 						Sets the internal native sample rate the
@@ -291,6 +327,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="maximum_sample_rate">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>Set the maximum native sample rate for mixing the conference</synopsis>
 					<description><para>
 						Sets the maximum native sample rate the
@@ -300,6 +337,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="language" default="en">
+					<since><version>11.7.0</version></since>
 					<synopsis>The language used for announcements to the conference.</synopsis>
 					<description><para>
 						By default, announcements to a conference use English.  Which means
@@ -309,6 +347,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="mixing_interval">
+					<since><version>11.0.0</version></since>
 					<synopsis>Sets the internal mixing interval in milliseconds for the bridge</synopsis>
 					<description><para>
 						Sets the internal mixing interval in milliseconds for the bridge.  This
@@ -320,6 +359,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="binaural_active">
+					<since><version>15.0.0</version></since>
 					<synopsis>If true binaural conferencing with stereo audio is active</synopsis>
 					<description><para>
 						Activates binaural mixing for a conference bridge.
@@ -327,6 +367,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="record_conference">
+					<since><version>11.0.0</version></since>
 					<synopsis>Record the conference starting with the first active user's entrance and ending with the last active user's exit</synopsis>
 					<description><para>
 						Records the conference call starting when the first user
@@ -338,6 +379,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="record_file" default="confbridge-${name of conference bridge}-${start time}.wav">
+					<since><version>11.0.0</version></since>
 					<synopsis>The filename of the conference recording</synopsis>
 					<description><para>
 						When <replaceable>record_conference</replaceable> is set to yes, the specific name of the
@@ -351,6 +393,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="record_file_append" default="yes">
+					<since><version>12.0.0</version></since>
 					<synopsis>Append to record file when starting/stopping on same conference recording</synopsis>
 					<description><para>
 						When <replaceable>record_file_append</replaceable> is set to yes, stopping and starting recording on a
@@ -360,6 +403,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="record_file_timestamp" default="yes">
+					<since><version>14.0.0</version></since>
 					<synopsis>Append the start time to the record_file name so that it is unique.</synopsis>
 					<description><para>
 						When <replaceable>record_file_timestamp</replaceable> is set to yes, the start time is appended to
@@ -368,6 +412,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="record_options" default="">
+					<since><version>14.0.0</version></since>
 					<synopsis>Pass additional options to MixMonitor when recording</synopsis>
 					<description><para>
 						Pass additional options to MixMonitor when <replaceable>record_conference</replaceable> is set to yes.
@@ -375,6 +420,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="record_command" default="">
+					<since><version>14.0.0</version></since>
 					<synopsis>Execute a command after recording ends</synopsis>
 					<description><para>
 						Executes the specified command when recording ends. Any strings matching <literal>^{X}</literal> will be
@@ -382,6 +428,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="regcontext">
+					<since><version>13.10.0</version></since>
 					<synopsis>The name of the context into which to register the name of the conference bridge as NoOP() at priority 1</synopsis>
 					<description><para>
 						When set this will cause the name of the created conference to be registered
@@ -398,6 +445,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="video_mode">
+					<since><version>11.0.0</version></since>
 					<synopsis>Sets how confbridge handles video distribution to the conference participants</synopsis>
 					<description><para>
 						Sets how confbridge handles video distribution to the conference participants.
@@ -435,6 +483,7 @@
 					</description>
 				</configOption>
 				<configOption name="max_members">
+					<since><version>11.0.0</version></since>
 					<synopsis>Limit the maximum number of participants for a single conference</synopsis>
 					<description><para>
 						This option limits the number of participants for a single
@@ -446,6 +495,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="sound_">
+					<since><version>13.19.0</version><version>15.2.0</version></since>
 					<synopsis>Override the various conference bridge sound files</synopsis>
 					<description><para>
 						All sounds in the conference are customizable using the bridge profile options below.
@@ -491,6 +541,7 @@
 					</description>
 				</configOption>
 				<configOption name="video_update_discard" default="2000">
+					<since><version>15.0.0</version></since>
 					<synopsis>Sets the amount of time in milliseconds after sending a video update to discard subsequent video updates</synopsis>
 					<description><para>
 						Sets the amount of time in milliseconds after sending a video update request
@@ -501,6 +552,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="remb_send_interval" default="0">
+					<since><version>15.4.0</version></since>
 					<synopsis>Sets the interval in milliseconds that a combined REMB frame will be sent to video sources</synopsis>
 					<description><para>
 						Sets the interval in milliseconds that a combined REMB frame will be sent
@@ -513,6 +565,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="remb_behavior" default="average">
+					<since><version>15.4.0</version></since>
 					<synopsis>Sets how REMB reports are generated from multiple sources</synopsis>
 					<description><para>
 						Sets how REMB reports are combined from multiple sources to form one. A REMB report
@@ -551,6 +604,7 @@
 					<see-also><ref type="configOption">remb_estimated_bitrate</ref></see-also>
 				</configOption>
 				<configOption name="remb_estimated_bitrate">
+					<since><version>16.15.0</version><version>17.9.0</version><version>18.1.0</version></since>
 					<synopsis>Sets the estimated bitrate sent to each participant in REMB reports</synopsis>
 					<description><para>
 					    When <literal>remb_behavior</literal> is set to <literal>force</literal>,
@@ -560,6 +614,7 @@
 					<see-also><ref type="configOption">remb_behavior</ref></see-also>
 				</configOption>
 				<configOption name="enable_events" default="no">
+					<since><version>15.5.0</version></since>
 					<synopsis>Enables events for this bridge</synopsis>
 					<description><para>
 						If enabled, recipients who joined the bridge via a channel driver
@@ -571,10 +626,12 @@
 					</description>
 				</configOption>
 				<configOption name="template">
+					<since><version>11.0.0</version></since>
 					<synopsis>When using the CONFBRIDGE dialplan function, use a bridge profile as a template for creating a new temporary profile</synopsis>
 				</configOption>
 			</configObject>
 			<configObject name="menu">
+				<since><version>12.0.0</version></since>
 				<synopsis>A conference user menu</synopsis>
 				<description>
 					<para>Conference users, as defined by a <replaceable>conf_user</replaceable>,
@@ -582,6 +639,7 @@
 					<literal>ConfBridge</literal> application.</para>
 				</description>
 				<configOption name="type">
+					<since><version>12.0.0</version></since>
 					<synopsis>Define this configuration category as a menu</synopsis>
 					<description><para>The type parameter determines how a context in the
 					configuration file is interpreted.</para>
@@ -593,6 +651,7 @@
 					</description>
 				</configOption>
 				<configOption name="template">
+					<since><version>13.0.0</version></since>
 					<synopsis>When using the CONFBRIDGE dialplan function, use a menu profile as a template for creating a new temporary profile</synopsis>
 				</configOption>
 				<configOption name="^[0-9A-D*#]+$">

--- a/channels/chan_motif.c
+++ b/channels/chan_motif.c
@@ -149,38 +149,50 @@
 		</description>
 		<configFile name="motif.conf">
 			<configObject name="endpoint">
+				<since><version>12.0.0</version></since>
 				<synopsis>The configuration for an endpoint.</synopsis>
 				<configOption name="context">
+					<since><version>11.0.0</version></since>
 					<synopsis>Default dialplan context that incoming sessions will be routed to</synopsis>
 				</configOption>
 				<configOption name="callgroup">
+					<since><version>11.0.0</version></since>
 					<synopsis>A callgroup to assign to this endpoint.</synopsis>
 				</configOption>
 				<configOption name="pickupgroup">
+					<since><version>11.0.0</version></since>
 					<synopsis>A pickup group to assign to this endpoint.</synopsis>
 				</configOption>
 				<configOption name="language">
+					<since><version>11.0.0</version></since>
 					<synopsis>The default language for this endpoint.</synopsis>
 				</configOption>
 				<configOption name="musicclass">
+					<since><version>11.0.0</version></since>
 					<synopsis>Default music on hold class for this endpoint.</synopsis>
 				</configOption>
 				<configOption name="parkinglot">
+					<since><version>11.0.0</version></since>
 					<synopsis>Default parking lot for this endpoint.</synopsis>
 				</configOption>
 				<configOption name="accountcode">
+					<since><version>11.0.0</version></since>
 					<synopsis>Accout code for CDR purposes</synopsis>
 				</configOption>
 				<configOption name="allow">
+					<since><version>13.0.0</version></since>
 					<synopsis>Codecs to allow</synopsis>
 				</configOption>
 				<configOption name="disallow">
+					<since><version>13.0.0</version></since>
 					<synopsis>Codecs to disallow</synopsis>
 				</configOption>
 				<configOption name="connection">
+					<since><version>11.0.0</version></since>
 					<synopsis>Connection to accept traffic on and on which to send traffic out</synopsis>
 				</configOption>
 				<configOption name="transport">
+					<since><version>11.0.0</version></since>
 					<synopsis>The transport to use for the endpoint.</synopsis>
 					<description>
 						<para>The default outbound transport for this endpoint. Inbound
@@ -206,9 +218,11 @@
 					</description>
 				</configOption>
 				<configOption name="maxicecandidates">
+					<since><version>11.0.0</version></since>
 					<synopsis>Maximum number of ICE candidates to offer</synopsis>
 				</configOption>
 				<configOption name="maxpayloads">
+					<since><version>11.0.0</version></since>
 					<synopsis>Maximum number of payloads to offer</synopsis>
 				</configOption>
 			</configObject>

--- a/main/cdr.c
+++ b/main/cdr.c
@@ -82,8 +82,10 @@
 		</description>
 		<configFile name="cdr.conf">
 			<configObject name="general">
+				<since><version>12.0.0</version></since>
 				<synopsis>Global settings applied to the CDR engine.</synopsis>
 				<configOption name="debug">
+					<since><version>12.0.0</version></since>
 					<synopsis>Enable/disable verbose CDR debugging.</synopsis>
 					<description><para>When set to <literal>True</literal>, verbose updates
 					of changes in CDR information will be logged. Note that this is only
@@ -91,12 +93,14 @@
 					</description>
 				</configOption>
 				<configOption name="enable" default="yes">
+					<since><version>12.0.0</version></since>
 					<synopsis>Enable/disable CDR logging.</synopsis>
 					<description><para>Define whether or not to use CDR logging. Setting this to "no" will override
 					any loading of backend CDR modules.</para>
 					</description>
 				</configOption>
 				<configOption name="channeldefaultenabled" default="yes">
+					<since><version>16.24.0</version><version>18.10.0</version><version>19.2.0</version></since>
 					<synopsis>Whether CDR is enabled on a channel by default</synopsis>
 					<description><para>Define whether or not CDR should be enabled on a channel by default.
 					Setting this to "yes" will enable CDR on every channel unless it is explicitly disabled.
@@ -112,6 +116,7 @@
 					</description>
 				</configOption>
 				<configOption name="ignorestatechanges" default="no">
+					<since><version>16.30.0</version><version>18.16.0</version><version>19.8.0</version><version>20.1.0</version></since>
 					<synopsis>Whether CDR is updated or forked by bridging changes.</synopsis>
 					<description><para>Define whether or not CDR should be updated by bridging changes.
 					This includes entering and leaving bridges and call parking.</para>
@@ -122,6 +127,7 @@
 					</description>
 				</configOption>
 				<configOption name="ignoredialchanges" default="no">
+					<since><version>16.30.0</version><version>18.16.0</version><version>19.8.0</version><version>20.1.0</version></since>
 					<synopsis>Whether CDR is updated or forked by dial updates.</synopsis>
 					<description><para>Define whether or not CDR should be updated by dial updates.</para>
 					<para>If this is set to "no", a single CDR will be used for the channel, even if
@@ -135,6 +141,7 @@
 					</description>
 				</configOption>
 				<configOption name="unanswered">
+					<since><version>12.0.0</version></since>
 					<synopsis>Log calls that are never answered and don't set an outgoing party.</synopsis>
 					<description><para>
 					Define whether or not to log unanswered calls that don't involve an outgoing party. Setting
@@ -147,12 +154,14 @@
 					</description>
 				</configOption>
 				<configOption name="congestion">
+					<since><version>12.0.0</version></since>
 					<synopsis>Log congested calls.</synopsis>
 					<description><para>Define whether or not to log congested calls. Setting this to "yes" will
 					report each call that fails to complete due to congestion conditions.</para>
 					</description>
 				</configOption>
 				<configOption name="endbeforehexten">
+					<since><version>12.0.0</version></since>
 					<synopsis>Don't produce CDRs while executing hangup logic</synopsis>
 					<description>
 						<para>As each CDR for a channel is finished, its end time is updated
@@ -167,6 +176,7 @@
 					</description>
 				</configOption>
 				<configOption name="initiatedseconds">
+					<since><version>12.0.0</version></since>
 					<synopsis>Count microseconds for billsec purposes</synopsis>
 					<description><para>Normally, the <literal>billsec</literal> field logged to the CDR backends
 					is simply the end time (hangup time) minus the answer time in seconds. Internally,
@@ -178,6 +188,7 @@
 					</description>
 				</configOption>
 				<configOption name="batch">
+					<since><version>12.0.0</version></since>
 					<synopsis>Submit CDRs to the backends for processing in batches</synopsis>
 					<description><para>Define the CDR batch mode, where instead of posting the CDR at the end of
 					every call, the data will be stored in a buffer to help alleviate load on the
@@ -188,12 +199,14 @@
 					</description>
 				</configOption>
 				<configOption name="size">
+					<since><version>12.0.0</version></since>
 					<synopsis>The maximum number of CDRs to accumulate before triggering a batch</synopsis>
 					<description><para>Define the maximum number of CDRs to accumulate in the buffer before posting
 					them to the backend engines. batch must be set to <literal>yes</literal>.</para>
 					</description>
 				</configOption>
 				<configOption name="time">
+					<since><version>13.22.0</version><version>15.5.0</version></since>
 					<synopsis>The maximum time to accumulate CDRs before triggering a batch</synopsis>
 					<description><para>Define the maximum time to accumulate CDRs before posting them in a batch to the
 					backend engines. If this time limit is reached, then it will post the records, regardless of the value
@@ -202,6 +215,7 @@
 					</description>
 				</configOption>
 				<configOption name="scheduleronly">
+					<since><version>12.0.0</version></since>
 					<synopsis>Post batched CDRs on their own thread instead of the scheduler</synopsis>
 					<description><para>The CDR engine uses the internal asterisk scheduler to determine when to post
 					records.  Posting can either occur inside the scheduler thread, or a new
@@ -212,6 +226,7 @@
 					</description>
 				</configOption>
 				<configOption name="safeshutdown">
+					<since><version>12.0.0</version></since>
 					<synopsis>Block shutdown of Asterisk until CDRs are submitted</synopsis>
 					<description><para>When shutting down asterisk, you can block until the CDRs are submitted.  If
 					you don't, then data will likely be lost.  You can always check the size of

--- a/main/cel.c
+++ b/main/cel.c
@@ -63,20 +63,25 @@
 	<configInfo name="cel" language="en_US">
 		<configFile name="cel.conf">
 			<configObject name="general">
+				<since><version>12.0.0</version></since>
 				<synopsis>Options that apply globally to Channel Event Logging (CEL)</synopsis>
 				<configOption name="enable">
+					<since><version>12.0.0</version></since>
 					<synopsis>Determines whether CEL is enabled</synopsis>
 				</configOption>
 				<configOption name="dateformat">
+					<since><version>12.0.0</version></since>
 					<synopsis>The format to be used for dates when logging</synopsis>
 				</configOption>
 				<configOption name="apps">
+					<since><version>12.0.0</version></since>
 					<synopsis>List of apps for CEL to track</synopsis>
 					<description><para>A case-insensitive, comma-separated list of applications
 					to track when one or both of APP_START and APP_END events are flagged for
 					tracking</para></description>
 				</configOption>
 				<configOption name="events">
+					<since><version>12.0.0</version></since>
 					<synopsis>List of events for CEL to track</synopsis>
 					<description><para>A case-sensitive, comma-separated list of event names
 					to track. These event names do not include the leading <literal>AST_CEL</literal>.

--- a/main/features_config.c
+++ b/main/features_config.c
@@ -33,24 +33,31 @@
 		<synopsis>Features Configuration</synopsis>
 		<configFile name="features.conf">
 			<configObject name="globals">
+				<since><version>12.0.0</version></since>
 				<synopsis>
 				</synopsis>
 				<configOption name="featuredigittimeout" default="1000">
+					<since><version>12.0.0</version></since>
 					<synopsis>Milliseconds allowed between digit presses when entering a feature code.</synopsis>
 				</configOption>
 				<configOption name="courtesytone">
+					<since><version>12.0.0</version></since>
 					<synopsis>Sound to play when automon or automixmon is activated</synopsis>
 				</configOption>
 				<configOption name="recordingfailsound">
+					<since><version>12.0.0</version></since>
 					<synopsis>Sound to play when automon or automixmon is attempted but fails to start</synopsis>
 				</configOption>
 				<configOption name="transferdigittimeout" default="3">
+					<since><version>12.0.0</version></since>
 					<synopsis>Seconds allowed between digit presses when dialing a transfer destination</synopsis>
 				</configOption>
 				<configOption name="atxfernoanswertimeout" default="15">
+					<since><version>12.0.0</version></since>
 					<synopsis>Seconds to wait for attended transfer destination to answer</synopsis>
 				</configOption>
 				<configOption name="atxferdropcall" default="no">
+					<since><version>12.0.0</version></since>
 					<synopsis>Hang up the call entirely if the attended transfer fails</synopsis>
 					<description>
 						<para>When this option is set to <literal>no</literal>, then Asterisk will attempt to
@@ -65,14 +72,17 @@
 					</description>
 				</configOption>
 				<configOption name="atxferloopdelay" default="10">
+					<since><version>12.0.0</version></since>
 					<synopsis>Seconds to wait between attempts to re-dial transfer destination</synopsis>
 					<see-also><ref type="configOption">atxferdropcall</ref></see-also>
 				</configOption>
 				<configOption name="atxfercallbackretries" default="2">
+					<since><version>12.0.0</version></since>
 					<synopsis>Number of times to re-attempt dialing a transfer destination</synopsis>
 					<see-also><ref type="configOption">atxferdropcall</ref></see-also>
 				</configOption>
 				<configOption name="xfersound" default="beep">
+					<since><version>12.0.0</version></since>
 					<synopsis>Sound to play to during transfer and transfer-like operations.</synopsis>
 					<description>
 						<para>This sound will play to the transferrer and transfer target channels when
@@ -81,6 +91,7 @@
 					</description>
 				</configOption>
 				<configOption name="xferfailsound" default="beeperr">
+					<since><version>12.0.0</version></since>
 					<synopsis>Sound to play to a transferee when a transfer fails</synopsis>
 				</configOption>
 				<configOption name="atxferabort" default="*1">
@@ -129,27 +140,35 @@
 					</description>
 				</configOption>
 				<configOption name="pickupsound">
+					<since><version>12.0.0</version></since>
 					<synopsis>Sound to play to picker when a call is picked up</synopsis>
 				</configOption>
 				<configOption name="pickupfailsound">
+					<since><version>12.0.0</version></since>
 					<synopsis>Sound to play to picker when a call cannot be picked up</synopsis>
 				</configOption>
 				<configOption name="transferdialattempts" default="3">
+					<since><version>13.1.0</version></since>
 					<synopsis>Number of dial attempts allowed when attempting a transfer</synopsis>
 				</configOption>
 				<configOption name="transferretrysound" default="pbx-invalid">
+					<since><version>13.1.0</version></since>
 					<synopsis>Sound that is played when an incorrect extension is dialed and the transferer should try again.</synopsis>
 				</configOption>
 				<configOption name="transferinvalidsound" default="privacy-incorrect">
+					<since><version>13.1.0</version></since>
 					<synopsis>Sound that is played when an incorrect extension is dialed and the transferer has no attempts remaining.</synopsis>
 				</configOption>
 				<configOption name="transferannouncesound" default="pbx-transfer">
+					<since><version>16.29.0</version><version>18.15.0</version><version>19.7.0</version></since>
 					<synopsis>Sound that is played to the transferer when a transfer is initiated. If empty, no sound will be played.</synopsis>
 				</configOption>
 			</configObject>
 			<configObject name="featuremap">
+				<since><version>12.0.0</version></since>
 				<synopsis>DTMF options that can be triggered during bridged calls</synopsis>
 				<configOption name="atxfer">
+					<since><version>12.0.0</version></since>
 					<synopsis>DTMF sequence to initiate an attended transfer</synopsis>
 					<description>
 						<para>The transferee parties will be placed on hold and the
@@ -161,6 +180,7 @@
 					</description>
 				</configOption>
 				<configOption name="blindxfer" default="#">
+					<since><version>12.0.0</version></since>
 					<synopsis>DTMF sequence to initiate a blind transfer</synopsis>
 					<description>
 						<para>The transferee parties will be placed on hold and the
@@ -177,6 +197,7 @@
 					</description>
 				</configOption>
 				<configOption name="parkcall">
+					<since><version>12.0.0</version></since>
 					<synopsis>DTMF sequence to park a call</synopsis>
 					<description>
 						<para>The parking lot used to park the call is determined by using either the
@@ -206,6 +227,7 @@
 					<see-also><ref type="configOption">automixmon</ref></see-also>
 				</configOption>
 				<configOption name="automixmon">
+					<since><version>12.0.0</version></since>
 					<synopsis>DTMF sequence to start or stop MixMonitor on a call</synopsis>
 					<description>
 						<para>This will cause the channel that pressed the DTMF sequence
@@ -226,6 +248,7 @@
 				</configOption>
 			</configObject>
 			<configObject name="applicationmap">
+				<since><version>12.0.0</version></since>
 				<synopsis>Section for defining custom feature invocations during a call</synopsis>
 				<description>
 					<para>The applicationmap is an area where new custom features can be created. Items
@@ -278,6 +301,7 @@
 				</configOption>
 			</configObject>
 			<configObject name="featuregroup">
+				<since><version>12.0.0</version></since>
 				<synopsis>Groupings of items from the applicationmap</synopsis>
 				<description>
 					<para>Feature groups allow for multiple applicationmap items to be

--- a/main/named_acl.c
+++ b/main/named_acl.c
@@ -53,11 +53,14 @@
 	<configInfo name="named_acl" language="en_US">
 		<configFile name="acl.conf">
 			<configObject name="named_acl">
+				<since><version>12.0.0</version></since>
 				<synopsis>Options for configuring a named ACL</synopsis>
 				<configOption name="permit">
+					<since><version>11.0.0</version></since>
 					<synopsis>An address/subnet from which to allow access</synopsis>
 				</configOption>
 				<configOption name="deny">
+					<since><version>11.0.0</version></since>
 					<synopsis>An address/subnet from which to disallow access</synopsis>
 				</configOption>
 			</configObject>

--- a/main/stasis.c
+++ b/main/stasis.c
@@ -65,20 +65,26 @@
 	<configInfo name="stasis" language="en_US">
 		<configFile name="stasis.conf">
 			<configObject name="threadpool">
+				<since><version>12.8.0</version><version>13.1.0</version></since>
 				<synopsis>Settings that configure the threadpool Stasis uses to deliver some messages.</synopsis>
 				<configOption name="initial_size" default="5">
+					<since><version>12.8.0</version><version>13.1.0</version></since>
 					<synopsis>Initial number of threads in the message bus threadpool.</synopsis>
 				</configOption>
 				<configOption name="idle_timeout_sec" default="20">
+					<since><version>12.8.0</version><version>13.1.0</version></since>
 					<synopsis>Number of seconds before an idle thread is disposed of.</synopsis>
 				</configOption>
 				<configOption name="max_size" default="50">
+					<since><version>12.8.0</version><version>13.1.0</version></since>
 					<synopsis>Maximum number of threads in the threadpool.</synopsis>
 				</configOption>
 			</configObject>
 			<configObject name="declined_message_types">
+				<since><version>13.0.0</version></since>
 				<synopsis>Stasis message types for which to decline creation.</synopsis>
 				<configOption name="decline">
+					<since><version>12.8.0</version><version>13.1.0</version></since>
 					<synopsis>The message type to decline.</synopsis>
 					<description>
 						<para>This configuration option defines the name of the Stasis

--- a/main/udptl.c
+++ b/main/udptl.c
@@ -83,29 +83,38 @@
 	<configInfo name="udptl" language="en_US">
 		<configFile name="udptl.conf">
 			<configObject name="global">
+				<since><version>12.0.0</version></since>
 				<synopsis>Global options for configuring UDPTL</synopsis>
 				<configOption name="udptlstart">
+					<since><version>11.0.0</version></since>
 					<synopsis>The start of the UDPTL port range</synopsis>
 				</configOption>
 				<configOption name="udptlend">
+					<since><version>11.0.0</version></since>
 					<synopsis>The end of the UDPTL port range</synopsis>
 				</configOption>
 				<configOption name="udptlchecksums">
+					<since><version>11.0.0</version></since>
 					<synopsis>Whether to enable or disable UDP checksums on UDPTL traffic</synopsis>
 				</configOption>
 				<configOption name="udptlfecentries">
+					<since><version>11.0.0</version></since>
 					<synopsis>The number of error correction entries in a UDPTL packet</synopsis>
 				</configOption>
 				<configOption name="udptlfecspan">
+					<since><version>11.0.0</version></since>
 					<synopsis>The span over which parity is calculated for FEC in a UDPTL packet</synopsis>
 				</configOption>
 				<configOption name="use_even_ports">
+					<since><version>11.0.0</version></since>
 					<synopsis>Whether to only use even-numbered UDPTL ports</synopsis>
 				</configOption>
 				<configOption name="t38faxudpec">
+					<since><version>11.0.0</version></since>
 					<synopsis>Removed</synopsis>
 				</configOption>
 				<configOption name="t38faxmaxdatagram">
+					<since><version>11.0.0</version></since>
 					<synopsis>Removed</synopsis>
 				</configOption>
 			</configObject>

--- a/res/res_aeap.c
+++ b/res/res_aeap.c
@@ -38,17 +38,22 @@
 		<synopsis>Asterisk External Application Protocol (AEAP) module for Asterisk</synopsis>
 		<configFile name="aeap.conf">
 			<configObject name="client">
+				<since><version>18.12.0</version><version>19.4.0</version></since>
 				<synopsis>AEAP client options</synopsis>
 				<configOption name="type">
+					<since><version>18.12.0</version><version>19.4.0</version></since>
 					<synopsis>Must be of type 'client'.</synopsis>
 				</configOption>
 				<configOption name="url">
+					<since><version>18.12.0</version><version>19.4.0</version></since>
 					<synopsis>The URL of the server to connect to.</synopsis>
 				</configOption>
 				<configOption name="protocol">
+					<since><version>18.12.0</version><version>19.4.0</version></since>
 					<synopsis>The application protocol.</synopsis>
 				</configOption>
 				<configOption name="codecs">
+					<since><version>18.12.0</version><version>19.4.0</version></since>
 				        <synopsis>Optional media codec(s)</synopsis>
 					<description><para>
 					If this is specified, Asterisk will use this for codec related negotiations

--- a/res/res_ari.c
+++ b/res/res_ari.c
@@ -82,8 +82,10 @@
 		<synopsis>HTTP binding for the Stasis API</synopsis>
 		<configFile name="ari.conf">
 			<configObject name="general">
+				<since><version>12.0.0</version></since>
 				<synopsis>General configuration settings</synopsis>
 				<configOption name="enabled">
+					<since><version>12.0.0</version></since>
 					<synopsis>Enable/disable the ARI module</synopsis>
 					<description>
 						<para>This option enables or disables the ARI module.</para>
@@ -97,6 +99,7 @@
 					</see-also>
 				</configOption>
 				<configOption name="websocket_write_timeout" default="100">
+					<since><version>11.11.0</version><version>12.4.0</version></since>
 					<synopsis>The timeout (in milliseconds) to set on WebSocket connections.</synopsis>
 					<description>
 						<para>If a websocket connection accepts input slowly, the timeout
@@ -105,22 +108,28 @@
 					</description>
 				</configOption>
 				<configOption name="pretty">
+					<since><version>12.0.0</version></since>
 					<synopsis>Responses from ARI are formatted to be human readable</synopsis>
 				</configOption>
 				<configOption name="auth_realm">
+					<since><version>12.0.0</version></since>
 					<synopsis>Realm to use for authentication. Defaults to Asterisk REST Interface.</synopsis>
 				</configOption>
 				<configOption name="allowed_origins">
+					<since><version>12.0.0</version></since>
 					<synopsis>Comma separated list of allowed origins, for Cross-Origin Resource Sharing. May be set to * to allow all origins.</synopsis>
 				</configOption>
 				<configOption name="channelvars">
+					<since><version>14.2.0</version></since>
 					<synopsis>Comma separated list of channel variables to display in channel json.</synopsis>
 				</configOption>
 			</configObject>
 
 			<configObject name="user">
+				<since><version>12.0.0</version></since>
 				<synopsis>Per-user configuration settings</synopsis>
 				<configOption name="type">
+					<since><version>13.30.0</version><version>16.7.0</version><version>17.1.0</version></since>
 					<synopsis>Define this configuration section as a user.</synopsis>
 					<description>
 						<enumlist>
@@ -129,12 +138,15 @@
 					</description>
 				</configOption>
 				<configOption name="read_only">
+					<since><version>13.30.0</version><version>16.7.0</version><version>17.1.0</version></since>
 					<synopsis>When set to yes, user is only authorized for read-only requests</synopsis>
 				</configOption>
 				<configOption name="password">
+					<since><version>13.30.0</version><version>16.7.0</version><version>17.1.0</version></since>
 					<synopsis>Crypted or plaintext password (see password_format)</synopsis>
 				</configOption>
 				<configOption name="password_format">
+					<since><version>12.0.0</version></since>
 					<synopsis>password_format may be set to plain (the default) or crypt. When set to crypt, crypt(3) is used to validate the password. A crypted password can be generated using mkpasswd -m sha-512. When set to plain, the password is in plaintext</synopsis>
 				</configOption>
 			</configObject>

--- a/res/res_geolocation/geoloc_doc.xml
+++ b/res/res_geolocation/geoloc_doc.xml
@@ -5,16 +5,19 @@
 		<synopsis>Core Geolocation Support</synopsis>
 		<configFile name="geolocation.conf">
 			<configObject name="location">
+				<since><version>16.29.0</version><version>18.15.0</version><version>19.7.0</version></since>
 				<synopsis>Location</synopsis>
 				<description>
 					<para>Parameters for defining a Location object</para>
 				</description>
 
 				<configOption name="type">
+					<since><version>16.28.0</version><version>18.14.0</version><version>19.6.0</version></since>
 					<synopsis>Must be of type 'location'.</synopsis>
 				</configOption>
 
 				<configOption name="format" default="none">
+					<since><version>16.28.0</version><version>18.14.0</version><version>19.6.0</version></since>
 					<synopsis>Location specification type</synopsis>
 					<description>
 						<enumlist>
@@ -46,6 +49,7 @@
 				</configOption>
 
 				<configOption name="location_info" default="none">
+					<since><version>16.28.0</version><version>18.14.0</version><version>19.6.0</version></since>
 					<synopsis>Location information</synopsis>
 					<description>
 						<para>The contents of this parameter are specific to the
@@ -73,6 +77,7 @@
 				</configOption>
 
 				<configOption name="location_source" default="none">
+					<since><version>16.28.0</version><version>18.14.0</version><version>19.6.0</version></since>
 					<synopsis>Fully qualified host name</synopsis>
 					<description>
 						<para>This parameter isn't required but if provided, RFC8787 says it MUST be a fully
@@ -83,6 +88,7 @@
 				</configOption>
 
 				<configOption name="method" default="none">
+					<since><version>16.28.0</version><version>18.14.0</version><version>19.6.0</version></since>
 					<synopsis>Location determination method</synopsis>
 					<description>
 						<para>This is a rarely used field in the specification that would
@@ -101,6 +107,7 @@
 				</configOption>
 
 				<configOption name="confidence" default="none">
+					<since><version>16.28.0</version><version>18.14.0</version><version>19.6.0</version></since>
 					<synopsis>Level of confidence</synopsis>
 					<description>
 						<para>This is a rarely used field in the specification that would
@@ -131,15 +138,18 @@
 			</configObject>
 
 			<configObject name="profile">
+				<since><version>16.29.0</version><version>18.15.0</version><version>19.7.0</version></since>
 				<synopsis>Profile</synopsis>
 				<description>
 					<para>Parameters for defining a Profile object</para>
 				</description>
 				<configOption name="type">
+					<since><version>16.28.0</version><version>18.14.0</version><version>19.6.0</version></since>
 					<synopsis>Must be of type 'profile'.</synopsis>
 				</configOption>
 
 				<configOption name="pidf_element" default="device">
+					<since><version>16.28.0</version><version>18.14.0</version><version>19.6.0</version></since>
 					<synopsis>PIDF-LO element to place this profile in</synopsis>
 					<description>
 						<enumlist>
@@ -158,17 +168,21 @@
 				</configOption>
 
 				<configOption name="location_reference" default="none">
+					<since><version>16.28.0</version><version>18.14.0</version><version>19.6.0</version></since>
 					<synopsis>Reference to a location object</synopsis>
 				</configOption>
 
 				<configOption name="location_info_refinement" default="none">
+					<since><version>16.28.0</version><version>18.14.0</version><version>19.6.0</version></since>
 					<synopsis>Reference to a location object</synopsis>
 				</configOption>
 				<configOption name="location_variables" default="none">
+					<since><version>16.28.0</version><version>18.14.0</version><version>19.6.0</version></since>
 					<synopsis>Reference to a location object</synopsis>
 				</configOption>
 
 				<configOption name="usage_rules" default="empty &lt;usage_rules&gt; element">
+					<since><version>16.28.0</version><version>18.14.0</version><version>19.6.0</version></since>
 					<synopsis>location specification type</synopsis>
 					<description>
 						<para>xxxx</para>
@@ -176,6 +190,7 @@
 				</configOption>
 
 				<configOption name="notes" default="">
+					<since><version>16.28.0</version><version>18.14.0</version><version>19.6.0</version></since>
 					<synopsis>Notes to be added to the outgoing PIDF-LO document</synopsis>
 					<description>
 						<para>The specification of this parameter will cause a
@@ -186,15 +201,18 @@
 
 				</configOption>
 				<configOption name="allow_routing_use" default="no">
+					<since><version>16.28.0</version><version>18.14.0</version><version>19.6.0</version></since>
 					<synopsis>Sets the value of the Geolocation-Routing header.</synopsis>
 				</configOption>
 
 				<configOption name="suppress_empty_ca_elements" default="no">
+					<since><version>16.29.0</version><version>18.15.0</version><version>19.7.0</version></since>
 					<synopsis>Sets if empty Civic Address elements should be suppressed
 					from the PIDF-LO document.</synopsis>
 				</configOption>
 
 				<configOption name="profile_precedence" default="discard_incoming">
+					<since><version>16.28.0</version><version>18.14.0</version><version>19.6.0</version></since>
 					<synopsis>Determine which profile on a channel should be used</synopsis>
 					<description>
 						<enumlist>

--- a/res/res_hep.c
+++ b/res/res_hep.c
@@ -45,6 +45,7 @@
 		<synopsis>Resource for integration with Homer using HEPv3</synopsis>
 		<configFile name="hep.conf">
 			<configObject name="general">
+				<since><version>12.2.0</version></since>
 				<synopsis>General settings.</synopsis>
 				<description><para>
 					The <emphasis>general</emphasis> settings section contains information
@@ -52,6 +53,7 @@
 					</para>
 				</description>
 				<configOption name="enabled" default="yes">
+					<since><version>12.2.0</version></since>
 					<synopsis>Enable or disable packet capturing.</synopsis>
 					<description>
 						<enumlist>
@@ -61,6 +63,7 @@
 					</description>
 				</configOption>
 				<configOption name="uuid_type" default="call-id">
+					<since><version>12.2.0</version></since>
 					<synopsis>The preferred type of UUID to pass to Homer.</synopsis>
 					<description>
 						<enumlist>
@@ -70,15 +73,19 @@
 					</description>
 				</configOption>
 				<configOption name="capture_address">
+					<since><version>13.16.0</version><version>14.5.0</version></since>
 					<synopsis>The address and port of the Homer server to send packets to.</synopsis>
 				</configOption>
 				<configOption name="capture_password">
+					<since><version>12.2.0</version></since>
 					<synopsis>If set, the authentication password to send to Homer.</synopsis>
 				</configOption>
 				<configOption name="capture_id" default="0">
+					<since><version>12.2.0</version></since>
 					<synopsis>The ID for this capture agent.</synopsis>
 				</configOption>
 				<configOption name="capture_name" default="">
+					<since><version>18.16.0</version><version>20.1.0</version></since>
 					<synopsis>The name for this capture agent.</synopsis>
 				</configOption>
 			</configObject>

--- a/res/res_http_media_cache.c
+++ b/res/res_http_media_cache.c
@@ -36,29 +36,38 @@
 		<synopsis>HTTP media cache</synopsis>
 		<configFile name="res_http_media_cache.conf">
 			<configObject name="general">
+				<since><version>18.18.0</version><version>20.3.0</version></since>
 				<synopsis>General configuration</synopsis>
 				<configOption name="timeout_secs" default="180">
+					<since><version>18.18.0</version><version>20.3.0</version></since>
 					<synopsis>The maximum time the transfer is allowed to complete in seconds. See https://curl.se/libcurl/c/CURLOPT_TIMEOUT.html for details.</synopsis>
 				</configOption>
 				<configOption name="user_agent">
+					<since><version>18.18.0</version><version>20.3.0</version></since>
 					<synopsis>The HTTP User-Agent to use for requests. See https://curl.se/libcurl/c/CURLOPT_USERAGENT.html for details.</synopsis>
 				</configOption>
 				<configOption name="follow_location" default="1">
+					<since><version>18.18.0</version><version>20.3.0</version></since>
 					<synopsis>Follow HTTP 3xx redirects on requests. See https://curl.se/libcurl/c/CURLOPT_FOLLOWLOCATION.html for details.</synopsis>
 				</configOption>
 				<configOption name="max_redirects" default="8">
+					<since><version>18.18.0</version><version>20.3.0</version></since>
 					<synopsis>The maximum number of redirects to follow. See https://curl.se/libcurl/c/CURLOPT_MAXREDIRS.html for details.</synopsis>
 				</configOption>
 				<configOption name="proxy">
+					<since><version>18.18.0</version><version>20.3.0</version></since>
 					<synopsis>The proxy to use for requests. See https://curl.se/libcurl/c/CURLOPT_PROXY.html for details.</synopsis>
 				</configOption>
 				<configOption name="protocols">
+					<since><version>18.18.0</version><version>20.3.0</version></since>
 					<synopsis>The comma separated list of allowed protocols for the request. Available with cURL 7.85.0 or later. See https://curl.se/libcurl/c/CURLOPT_PROTOCOLS_STR.html for details.</synopsis>
 				</configOption>
 				<configOption name="redirect_protocols">
+					<since><version>18.18.0</version><version>20.3.0</version></since>
 					<synopsis>The comma separated list of allowed protocols for redirects. Available with cURL 7.85.0 or later. See https://curl.se/libcurl/c/CURLOPT_REDIR_PROTOCOLS_STR.html for details.</synopsis>
 				</configOption>
 				<configOption name="dns_cache_timeout_secs" default="60">
+					<since><version>18.18.0</version><version>20.3.0</version></since>
 					<synopsis>The life-time for DNS cache entries. See https://curl.se/libcurl/c/CURLOPT_DNS_CACHE_TIMEOUT.html for details.</synopsis>
 				</configOption>
 			</configObject>

--- a/res/res_parking.c
+++ b/res/res_parking.c
@@ -32,8 +32,10 @@
 	<configInfo name="res_parking" language="en_US">
 		<configFile name="res_parking.conf">
 			<configObject name="globals">
+				<since><version>12.0.0</version></since>
 				<synopsis>Options that apply to every parking lot</synopsis>
 				<configOption name="parkeddynamic">
+					<since><version>12.0.0</version></since>
 					<synopsis>Enables dynamically created parkinglots.</synopsis>
 					<description>
 						<para>If the option is enabled then the following variables can
@@ -70,12 +72,15 @@
 				</configOption>
 			</configObject>
 			<configObject name="parking_lot">
+				<since><version>12.0.0</version></since>
 				<synopsis>Defined parking lots for res_parking to use to park calls on</synopsis>
 				<configOption name="context" default="parkedcalls">
+					<since><version>12.0.0</version></since>
 					<synopsis>The name of the context where calls are parked and picked up from.</synopsis>
 					<description><para>This option is only used if parkext is set.</para></description>
 				</configOption>
 				<configOption name="parkext">
+					<since><version>12.0.0</version></since>
 					<synopsis>Extension to park calls to this parking lot.</synopsis>
 					<description>
 						<para>If this option is used, this extension will automatically
@@ -96,9 +101,11 @@
 					</description>
 				</configOption>
 				<configOption name="parkext_exclusive" default="no">
+					<since><version>12.0.0</version></since>
 					<synopsis>If yes, the extension registered as parkext will park exclusively to this parking lot.</synopsis>
 				</configOption>
 				<configOption name="parkpos" default="701-750">
+					<since><version>12.0.0</version></since>
 					<synopsis>Numerical range of parking spaces which can be used to retrieve parked calls.</synopsis>
 					<description>
 						<para>If <literal>parkext</literal> is set, these extensions
@@ -108,15 +115,19 @@
 					</description>
 				</configOption>
 				<configOption name="parkinghints" default="no">
+					<since><version>12.0.0</version></since>
 					<synopsis>If yes, this parking lot will add hints automatically for parking spaces.</synopsis>
 				</configOption>
 				<configOption name="parkingtime" default="45">
+					<since><version>12.0.0</version></since>
 					<synopsis>Amount of time a call will remain parked before giving up (in seconds).</synopsis>
 				</configOption>
 				<configOption name="parkedmusicclass">
+					<since><version>12.0.0</version></since>
 					<synopsis>Which music class to use for parked calls. They will use the default if unspecified.</synopsis>
 				</configOption>
 				<configOption name="comebacktoorigin" default="yes">
+					<since><version>12.0.0</version></since>
 					<synopsis>Determines what should be done with the parked channel if no one picks it up before it times out.</synopsis>
 					<description><para>Valid Options:</para>
 						<enumlist>
@@ -162,9 +173,11 @@
 					</description>
 				</configOption>
 				<configOption name="comebackdialtime" default="30">
+					<since><version>12.0.0</version></since>
 					<synopsis>Timeout for the Dial extension created to call back the parker when a parked call times out.</synopsis>
 				</configOption>
 				<configOption name="comebackcontext" default="parkedcallstimeout">
+					<since><version>12.0.0</version></since>
 					<synopsis>Context where parked calls will enter the PBX on timeout when comebacktoorigin=no</synopsis>
 					<description><para>The extension the call enters will prioritize the flattened peer name in this context.
 						If the flattened peer name extension is unavailable, then the 's' extension in this context will be
@@ -172,12 +185,14 @@
 					</description>
 				</configOption>
 				<configOption name="courtesytone">
+					<since><version>12.0.0</version></since>
 					<synopsis>If the name of a sound file is provided, use this as the courtesy tone</synopsis>
 					<description><para>By default, this tone is only played to the caller of a parked call. Who receives the tone
 						can be changed using the <literal>parkedplay</literal> option.</para>
 					</description>
 				</configOption>
 				<configOption name="parkedplay" default="caller">
+					<since><version>12.0.0</version></since>
 					<synopsis>Who we should play the courtesytone to on the pickup of a parked call from this lot</synopsis>
 					<description>
 						<enumlist>
@@ -190,30 +205,35 @@
 					</description>
 				</configOption>
 				<configOption name="parkedcalltransfers" default="no">
+					<since><version>12.0.0</version></since>
 					<synopsis>Who to apply the DTMF transfer features to when parked calls are picked up or timeout.</synopsis>
 					<description>
 						<xi:include xpointer="xpointer(/docs/configInfo[@name='res_parking']/configFile[@name='res_parking.conf']/configObject[@name='parking_lot']/configOption[@name='parkedplay']/description/enumlist)" />
 					</description>
 				</configOption>
 				<configOption name="parkedcallreparking" default="no">
+					<since><version>12.0.0</version></since>
 					<synopsis>Who to apply the DTMF parking feature to when parked calls are picked up or timeout.</synopsis>
 					<description>
 						<xi:include xpointer="xpointer(/docs/configInfo[@name='res_parking']/configFile[@name='res_parking.conf']/configObject[@name='parking_lot']/configOption[@name='parkedplay']/description/enumlist)" />
 					</description>
 				</configOption>
 				<configOption name="parkedcallhangup" default="no">
+					<since><version>12.0.0</version></since>
 					<synopsis>Who to apply the DTMF hangup feature to when parked calls are picked up or timeout.</synopsis>
 					<description>
 						<xi:include xpointer="xpointer(/docs/configInfo[@name='res_parking']/configFile[@name='res_parking.conf']/configObject[@name='parking_lot']/configOption[@name='parkedplay']/description/enumlist)" />
 					</description>
 				</configOption>
 				<configOption name="parkedcallrecording" default="no">
+					<since><version>12.0.0</version></since>
 					<synopsis>Who to apply the DTMF MixMonitor recording feature to when parked calls are picked up or timeout.</synopsis>
 					<description>
 						<xi:include xpointer="xpointer(/docs/configInfo[@name='res_parking']/configFile[@name='res_parking.conf']/configObject[@name='parking_lot']/configOption[@name='parkedplay']/description/enumlist)" />
 					</description>
 				</configOption>
 				<configOption name="findslot" default="first">
+					<since><version>12.0.0</version></since>
 					<synopsis>Rule to use when trying to figure out which parking space a call should be parked with.</synopsis>
 					<description>
 						<enumlist>

--- a/res/res_pjproject.c
+++ b/res/res_pjproject.c
@@ -67,6 +67,7 @@
 				</configOption>
 			</configObject>
 			<configObject name="log_mappings">
+				<since><version>13.8.0</version></since>
 				<synopsis>PJPROJECT to Asterisk Log Level Mapping</synopsis>
 				<description><para>Warnings and errors in the pjproject libraries are generally handled
 					by Asterisk.  In many cases, Asterisk wouldn't even consider them to
@@ -78,24 +79,31 @@
 					'log_mappings' or it won't be found.</para></note>
 				</description>
 				<configOption name="type">
+					<since><version>13.8.0</version></since>
 					<synopsis>Must be of type 'log_mappings'.</synopsis>
 				</configOption>
 				<configOption name="asterisk_error" default="0,1">
+					<since><version>13.8.0</version></since>
 					<synopsis>A comma separated list of pjproject log levels to map to Asterisk LOG_ERROR.</synopsis>
 				</configOption>
 				<configOption name="asterisk_warning" default="2">
+					<since><version>13.8.0</version></since>
 					<synopsis>A comma separated list of pjproject log levels to map to Asterisk LOG_WARNING.</synopsis>
 				</configOption>
 				<configOption name="asterisk_notice" default="">
+					<since><version>13.8.0</version></since>
 					<synopsis>A comma separated list of pjproject log levels to map to Asterisk LOG_NOTICE.</synopsis>
 				</configOption>
 				<configOption name="asterisk_verbose" default="">
+					<since><version>13.8.0</version></since>
 					<synopsis>A comma separated list of pjproject log levels to map to Asterisk LOG_VERBOSE.</synopsis>
 				</configOption>
 				<configOption name="asterisk_debug" default="3,4">
+					<since><version>13.8.0</version></since>
 					<synopsis>A comma separated list of pjproject log levels to map to Asterisk LOG_DEBUG.</synopsis>
 				</configOption>
 				<configOption name="asterisk_trace" default="5,6">
+					<since><version>16.21.0</version><version>18.7.0</version></since>
 					<synopsis>A comma separated list of pjproject log levels to map to Asterisk LOG_TRACE.</synopsis>
 				</configOption>
 			</configObject>

--- a/res/res_pjsip/pjsip_config.xml
+++ b/res/res_pjsip/pjsip_config.xml
@@ -6,6 +6,7 @@
 		<synopsis>SIP Resource using PJProject</synopsis>
 		<configFile name="pjsip.conf">
 			<configObject name="endpoint">
+				<since><version>12.0.0</version></since>
 				<synopsis>Endpoint</synopsis>
 				<description><para>
 					The <emphasis>Endpoint</emphasis> is the primary configuration object.
@@ -29,6 +30,7 @@
 					</para>
 				</description>
 				<configOption name="100rel" default="yes">
+					<since><version>12.2.0</version></since>
 					<synopsis>Allow support for RFC3262 provisional ACK tags</synopsis>
 					<description>
 						<enumlist>
@@ -63,15 +65,18 @@
 					</description>
 				</configOption>
 				<configOption name="aggregate_mwi" default="yes">
+					<since><version>12.0.0</version></since>
 					<synopsis>Condense MWI notifications into a single NOTIFY.</synopsis>
 					<description><para>When enabled, <replaceable>aggregate_mwi</replaceable> condenses message
 					waiting notifications from multiple mailboxes into a single NOTIFY. If it is disabled,
 					individual NOTIFYs are sent for each mailbox.</para></description>
 				</configOption>
 				<configOption name="allow">
+					<since><version>13.0.0</version></since>
 					<synopsis>Media Codec(s) to allow</synopsis>
 				</configOption>
 				<configOption name="codec_prefs_incoming_offer">
+					<since><version>18.0.0</version></since>
 					<synopsis>Codec negotiation prefs for incoming offers.</synopsis>
 					<description>
 						<para>
@@ -133,6 +138,7 @@
 					</description>
 				</configOption>
 				<configOption name="codec_prefs_outgoing_offer">
+					<since><version>18.0.0</version></since>
 					<synopsis>Codec negotiation prefs for outgoing offers.</synopsis>
 					<description>
 						<para>
@@ -195,6 +201,7 @@
 					</description>
 				</configOption>
 				<configOption name="codec_prefs_incoming_answer">
+					<since><version>18.0.0</version></since>
 					<synopsis>Codec negotiation prefs for incoming answers.</synopsis>
 					<description>
 						<para>
@@ -253,6 +260,7 @@
 					</description>
 				</configOption>
 				<configOption name="codec_prefs_outgoing_answer">
+					<since><version>18.0.0</version></since>
 					<synopsis>Codec negotiation prefs for outgoing answers.</synopsis>
 					<description>
 						<para>
@@ -311,9 +319,11 @@
 					</description>
 				</configOption>
 				<configOption name="allow_overlap" default="yes">
+					<since><version>13.15.0</version><version>14.4.0</version></since>
 					<synopsis>Enable RFC3578 overlap dialing support.</synopsis>
 				</configOption>
 				<configOption name="overlap_context">
+					<since><version>18.17.0</version><version>20.2.0</version></since>
 					<synopsis>Dialplan context to use for RFC3578 overlap dialing.</synopsis>
 					<description>
 						<para>Dialplan context to use for overlap dialing extension matching.
@@ -324,12 +334,14 @@
 					</description>
 				</configOption>
 				<configOption name="aors">
+					<since><version>12.0.0</version></since>
 					<synopsis>AoR(s) to be used with the endpoint</synopsis>
 					<description><para>
 						List of comma separated AoRs that the endpoint should be associated with.
 					</para></description>
 				</configOption>
 				<configOption name="auth">
+					<since><version>12.2.0</version></since>
 					<synopsis>Authentication Object(s) associated with the endpoint</synopsis>
 					<description><para>
 						This is a comma-delimited list of <replaceable>auth</replaceable> sections defined
@@ -346,6 +358,7 @@
 					</description>
 				</configOption>
 				<configOption name="callerid">
+					<since><version>12.2.0</version></since>
 					<synopsis>CallerID information for the endpoint</synopsis>
 					<description><para>
 						Must be in the format <literal>Name &lt;Number&gt;</literal>,
@@ -353,6 +366,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="callerid_privacy">
+					<since><version>12.7.0</version></since>
 					<synopsis>Default privacy level</synopsis>
 					<description>
 						<enumlist>
@@ -369,12 +383,15 @@
 					</description>
 				</configOption>
 				<configOption name="callerid_tag">
+					<since><version>12.2.0</version></since>
 					<synopsis>Internal id_tag for the endpoint</synopsis>
 				</configOption>
 				<configOption name="context">
+					<since><version>12.0.0</version></since>
 					<synopsis>Dialplan context for inbound sessions</synopsis>
 				</configOption>
 				<configOption name="direct_media_glare_mitigation" default="none">
+					<since><version>12.2.0</version></since>
 					<synopsis>Mitigation of direct media (re)INVITE glare</synopsis>
 					<description>
 						<para>
@@ -396,6 +413,7 @@
 					</description>
 				</configOption>
 				<configOption name="direct_media_method" default="invite">
+					<since><version>12.2.0</version></since>
 					<synopsis>Direct Media method type</synopsis>
 					<description>
 						<para>Method for setting up Direct Media between endpoints.</para>
@@ -409,12 +427,15 @@
 					</description>
 				</configOption>
 				<configOption name="trust_connected_line">
+					<since><version>13.24.0</version><version>16.1.0</version></since>
 					<synopsis>Accept Connected Line updates from this endpoint</synopsis>
 				</configOption>
 				<configOption name="send_connected_line">
+					<since><version>13.24.0</version><version>16.1.0</version></since>
 					<synopsis>Send Connected Line updates to this endpoint</synopsis>
 				</configOption>
 				<configOption name="connected_line_method" default="invite">
+					<since><version>12.2.0</version></since>
 					<synopsis>Connected line method type</synopsis>
 					<description>
 						<para>Method used when updating connected line information.</para>
@@ -435,15 +456,19 @@
 					</description>
 				</configOption>
 				<configOption name="direct_media" default="yes">
+					<since><version>12.0.0</version></since>
 					<synopsis>Determines whether media may flow directly between endpoints.</synopsis>
 				</configOption>
 				<configOption name="disable_direct_media_on_nat" default="no">
+					<since><version>12.0.0</version></since>
 					<synopsis>Disable direct media session refreshes when NAT obstructs the media session</synopsis>
 				</configOption>
 				<configOption name="disallow">
+					<since><version>13.0.0</version></since>
 					<synopsis>Media Codec(s) to disallow</synopsis>
 				</configOption>
 				<configOption name="dtmf_mode" default="rfc4733">
+					<since><version>12.2.0</version></since>
 					<synopsis>DTMF mode</synopsis>
 					<description>
 						<para>This setting allows to choose the DTMF mode for endpoint communication.</para>
@@ -469,6 +494,7 @@
 					</description>
 				</configOption>
 				<configOption name="media_address">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>IP address used in SDP for media handling</synopsis>
 					<description><para>
 						At the time of SDP creation, the IP address defined here will be used as
@@ -481,6 +507,7 @@
 					</description>
 				</configOption>
 				<configOption name="bind_rtp_to_media_address">
+					<since><version>13.8.0</version></since>
 					<synopsis>Bind the RTP instance to the media_address</synopsis>
 					<description><para>
 						If media_address is specified, this option causes the RTP instance to be bound to the
@@ -489,12 +516,15 @@
 					</description>
 				</configOption>
 				<configOption name="force_rport" default="yes">
+					<since><version>12.0.0</version></since>
 					<synopsis>Force use of return port</synopsis>
 				</configOption>
 				<configOption name="ice_support" default="no">
+					<since><version>12.0.0</version></since>
 					<synopsis>Enable the ICE mechanism to help traverse NAT</synopsis>
 				</configOption>
 				<configOption name="identify_by">
+					<since><version>13.19.0</version><version>15.2.0</version></since>
 					<synopsis>Way(s) for the endpoint to be identified</synopsis>
 					<description>
 						<para>Endpoints and AORs can be identified in multiple ways.  This
@@ -571,6 +601,7 @@
 					</description>
 				</configOption>
 				<configOption name="redirect_method">
+					<since><version>12.2.0</version></since>
 					<synopsis>How redirects received from an endpoint are handled</synopsis>
 					<description><para>
 						When a redirect is received from an endpoint there are multiple ways it can be handled.
@@ -592,6 +623,7 @@
 					</description>
 				</configOption>
 				<configOption name="mailboxes">
+					<since><version>12.0.0</version></since>
 					<synopsis>NOTIFY the endpoint when state changes for any of the specified mailboxes</synopsis>
 					<description><para>
 						Asterisk will send unsolicited MWI NOTIFY messages to the endpoint when state
@@ -606,15 +638,19 @@
 					</para></description>
 				</configOption>
 				<configOption name="mwi_subscribe_replaces_unsolicited">
+					<since><version>13.24.0</version><version>15.7.0</version></since>
 					<synopsis>An MWI subscribe will replace sending unsolicited NOTIFYs</synopsis>
 				</configOption>
 				<configOption name="voicemail_extension">
+					<since><version>13.9.0</version></since>
 					<synopsis>The voicemail extension to send in the NOTIFY Message-Account header</synopsis>
 				</configOption>
 				<configOption name="moh_suggest" default="default">
+					<since><version>12.0.0</version></since>
 					<synopsis>Default Music On Hold class</synopsis>
 				</configOption>
 				<configOption name="outbound_auth">
+					<since><version>12.2.0</version></since>
 					<synopsis>Authentication object(s) used for outbound requests</synopsis>
 					<description><para>
 						This is a comma-delimited list of <replaceable>auth</replaceable>
@@ -629,9 +665,11 @@
 					</description>
 				</configOption>
 				<configOption name="outbound_proxy">
+					<since><version>12.0.0</version></since>
 					<synopsis>Full SIP URI of the outbound proxy used to send requests</synopsis>
 				</configOption>
 				<configOption name="rewrite_contact">
+					<since><version>12.0.0</version></since>
 					<synopsis>Allow Contact header to be rewritten with the source IP address-port</synopsis>
 					<description><para>
 						On inbound SIP messages from this endpoint, the Contact header or an
@@ -643,26 +681,33 @@
 					</para></description>
 				</configOption>
 				<configOption name="rtp_ipv6" default="no">
+					<since><version>12.0.0</version></since>
 					<synopsis>Allow use of IPv6 for RTP traffic</synopsis>
 				</configOption>
 				<configOption name="rtp_symmetric" default="no">
+					<since><version>12.0.0</version></since>
 					<synopsis>Enforce that RTP must be symmetric</synopsis>
 				</configOption>
 				<configOption name="send_diversion" default="yes">
+					<since><version>12.0.0</version></since>
 					<synopsis>Send the Diversion header, conveying the diversion
 					information to the called user agent</synopsis>
 				</configOption>
 				<configOption name="send_history_info" default="no">
+					<since><version>13.38.0</version><version>16.15.0</version><version>17.9.0</version><version>18.1.0</version></since>
 					<synopsis>Send the History-Info header, conveying the diversion
 					information to the called and calling user agents</synopsis>
 				</configOption>
 				<configOption name="send_pai" default="no">
+					<since><version>12.0.0</version></since>
 					<synopsis>Send the P-Asserted-Identity header</synopsis>
 				</configOption>
 				<configOption name="send_rpid" default="no">
+					<since><version>12.0.0</version></since>
 					<synopsis>Send the Remote-Party-ID header</synopsis>
 				</configOption>
 				<configOption name="rpid_immediate" default="no">
+					<since><version>13.4.0</version></since>
 					<synopsis>Immediately send connected line updates on unanswered incoming calls.</synopsis>
 					<description>
 						<para>When enabled, immediately send <emphasis>180 Ringing</emphasis>
@@ -684,6 +729,7 @@
 					</description>
 				</configOption>
 				<configOption name="tenantid" default="">
+					<since><version>18.25.0</version><version>20.10.0</version><version>21.5.0</version></since>
 					<synopsis>The tenant ID for this endpoint.</synopsis>
 					<description><para>
 						Sets the tenant ID for this endpoint. When a channel is created,
@@ -692,12 +738,14 @@
 					</para></description>
 				</configOption>
 				<configOption name="timers_min_se" default="90">
+					<since><version>12.0.0</version></since>
 					<synopsis>Minimum session timers expiration period</synopsis>
 					<description><para>
 						Minimum session timer expiration period. Time in seconds.
 					</para></description>
 				</configOption>
 				<configOption name="timers" default="yes">
+					<since><version>12.2.0</version></since>
 					<synopsis>Session timers for SIP packets</synopsis>
 					<description>
 						<enumlist>
@@ -710,12 +758,14 @@
 					</description>
 				</configOption>
 				<configOption name="timers_sess_expires" default="1800">
+					<since><version>12.0.0</version></since>
 					<synopsis>Maximum session timer expiration period</synopsis>
 					<description><para>
 						Maximum session timer expiration period. Time in seconds.
 					</para></description>
 				</configOption>
 				<configOption name="transport">
+					<since><version>12.0.0</version></since>
 					<synopsis>Explicit transport configuration to use</synopsis>
 					<description>
 						<para>This will <emphasis>force</emphasis> the endpoint to use the
@@ -732,6 +782,7 @@
 					</description>
 				</configOption>
 				<configOption name="trust_id_inbound" default="no">
+					<since><version>12.0.0</version></since>
 					<synopsis>Accept identification information received from this endpoint</synopsis>
 					<description><para>This option determines whether Asterisk will accept
 					identification from the endpoint from headers such as P-Asserted-Identity
@@ -741,6 +792,7 @@
 					the endpoint.</para></description>
 				</configOption>
 				<configOption name="trust_id_outbound" default="no">
+					<since><version>12.0.0</version></since>
 					<synopsis>Send private identification details to the endpoint.</synopsis>
 					<description><para>This option determines whether res_pjsip will send private
 					identification information to the endpoint. If <literal>no</literal>,
@@ -754,12 +806,15 @@
 					provided in the request is private.</para></description>
 				</configOption>
 				<configOption name="type">
+					<since><version>12.0.0</version></since>
 					<synopsis>Must be of type 'endpoint'.</synopsis>
 				</configOption>
 				<configOption name="use_ptime" default="no">
+					<since><version>12.0.0</version></since>
 					<synopsis>Use Endpoint's requested packetization interval</synopsis>
 				</configOption>
 				<configOption name="use_avpf" default="no">
+					<since><version>12.0.0</version></since>
 					<synopsis>Determines whether res_pjsip will use and enforce usage of AVPF for this
 					endpoint.</synopsis>
 					<description><para>
@@ -773,6 +828,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="force_avp" default="no">
+					<since><version>12.4.0</version></since>
 					<synopsis>Determines whether res_pjsip will use and enforce usage of AVP,
 					regardless of the RTP profile in use for this endpoint.</synopsis>
 					<description><para>
@@ -785,6 +841,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="media_use_received_transport" default="no">
+					<since><version>12.4.0</version></since>
 					<synopsis>Determines whether res_pjsip will use the media transport received in the
 					offer SDP in the corresponding answer SDP.</synopsis>
 					<description><para>
@@ -795,6 +852,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="media_encryption" default="no">
+					<since><version>12.2.0</version></since>
 					<synopsis>Determines whether res_pjsip will use and enforce usage of media encryption
 					for this endpoint.</synopsis>
 					<description>
@@ -814,6 +872,7 @@
 					</description>
 				</configOption>
 				<configOption name="media_encryption_optimistic" default="no">
+					<since><version>13.1.0</version></since>
 					<synopsis>Determines whether encryption should be used if possible but does not terminate the
 					session if not achieved.</synopsis>
 					<description><para>
@@ -822,6 +881,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="g726_non_standard" default="no">
+					<since><version>13.5.0</version></since>
 					<synopsis>Force g.726 to use AAL2 packing order when negotiating g.726 audio</synopsis>
 					<description><para>
 						When set to "yes" and an endpoint negotiates g.726 audio then use g.726 for AAL2
@@ -831,6 +891,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="inband_progress" default="no">
+					<since><version>12.0.0</version></since>
 					<synopsis>Determines whether chan_pjsip will indicate ringing using inband
 						progress.</synopsis>
 					<description><para>
@@ -843,6 +904,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="call_group">
+					<since><version>12.2.0</version></since>
 					<synopsis>The numeric pickup groups for a channel.</synopsis>
 					<description><para>
 						Can be set to a comma separated list of numbers or ranges between the values
@@ -850,6 +912,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="pickup_group">
+					<since><version>12.2.0</version></since>
 					<synopsis>The numeric pickup groups that a channel can pickup.</synopsis>
 					<description><para>
 						Can be set to a comma separated list of numbers or ranges between the values
@@ -857,6 +920,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="named_call_group">
+					<since><version>12.2.0</version></since>
 					<synopsis>The named pickup groups for a channel.</synopsis>
 					<description><para>
 						Can be set to a comma separated list of case sensitive strings limited by
@@ -864,6 +928,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="named_pickup_group">
+					<since><version>12.2.0</version></since>
 					<synopsis>The named pickup groups that a channel can pickup.</synopsis>
 					<description><para>
 						Can be set to a comma separated list of case sensitive strings limited by
@@ -871,6 +936,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="device_state_busy_at" default="0">
+					<since><version>12.0.0</version></since>
 					<synopsis>The number of in-use channels which will cause busy to be returned as device state</synopsis>
 					<description><para>
 						When the number of in-use channels for the endpoint matches the devicestate_busy_at setting the
@@ -878,6 +944,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="t38_udptl" default="no">
+					<since><version>12.0.0</version></since>
 					<synopsis>Whether T.38 UDPTL support is enabled or not</synopsis>
 					<description><para>
 						If set to yes T.38 UDPTL support will be enabled, and T.38 negotiation requests will be accepted
@@ -885,6 +952,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="t38_udptl_ec" default="none">
+					<since><version>12.2.0</version></since>
 					<synopsis>T.38 UDPTL error correction method</synopsis>
 					<description>
 						<enumlist>
@@ -901,6 +969,7 @@
 					</description>
 				</configOption>
 				<configOption name="t38_udptl_maxdatagram" default="0">
+					<since><version>12.0.0</version></since>
 					<synopsis>T.38 UDPTL maximum datagram size</synopsis>
 					<description><para>
 						This option can be set to override the maximum datagram of a remote endpoint for broken
@@ -908,6 +977,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="fax_detect" default="no">
+					<since><version>12.0.0</version></since>
 					<synopsis>Whether CNG tone detection is enabled</synopsis>
 					<description><para>
 						This option can be set to send the session to the fax extension when a CNG tone is
@@ -915,6 +985,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="fax_detect_timeout">
+					<since><version>13.11.0</version></since>
 					<synopsis>How long into a call before fax_detect is disabled for the call</synopsis>
 					<description><para>
 						The option determines how many seconds into a call before the
@@ -923,6 +994,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="t38_udptl_nat" default="no">
+					<since><version>12.0.0</version></since>
 					<synopsis>Whether NAT support is enabled on UDPTL sessions</synopsis>
 					<description><para>
 						When enabled the UDPTL stack will send UDPTL packets to the source address of
@@ -930,12 +1002,14 @@
 					</para></description>
 				</configOption>
 				<configOption name="t38_udptl_ipv6" default="no">
+					<since><version>12.0.0</version></since>
 					<synopsis>Whether IPv6 is used for UDPTL Sessions</synopsis>
 					<description><para>
 						When enabled the UDPTL stack will use IPv6.
 					</para></description>
 				</configOption>
 				<configOption name="t38_bind_udptl_to_media_address" default="no">
+					<since><version>16.22.0</version><version>18.8.0</version></since>
 					<synopsis>Bind the UDPTL instance to the media_adress</synopsis>
 					<description><para>
 						If media_address is specified, this option causes the UDPTL instance to be bound to
@@ -943,12 +1017,15 @@
 					</para></description>
 				</configOption>
 				<configOption name="tone_zone">
+					<since><version>12.0.0</version></since>
 					<synopsis>Set which country's indications to use for channels created for this endpoint.</synopsis>
 				</configOption>
 				<configOption name="language">
+					<since><version>12.0.0</version></since>
 					<synopsis>Set the default language to use for channels created for this endpoint.</synopsis>
 				</configOption>
 				<configOption name="one_touch_recording" default="no">
+					<since><version>12.0.0</version></since>
 					<synopsis>Determines whether one-touch recording is allowed for this endpoint.</synopsis>
 					<see-also>
 						<ref type="configOption">record_on_feature</ref>
@@ -956,6 +1033,7 @@
 					</see-also>
 				</configOption>
 				<configOption name="record_on_feature" default="automixmon">
+					<since><version>12.0.0</version></since>
 					<synopsis>The feature to enact when one-touch recording is turned on.</synopsis>
 					<description>
 						<para>When an INFO request for one-touch recording arrives with a Record header set to "on", this
@@ -969,6 +1047,7 @@
 					</see-also>
 				</configOption>
 				<configOption name="record_off_feature" default="automixmon">
+					<since><version>12.0.0</version></since>
 					<synopsis>The feature to enact when one-touch recording is turned off.</synopsis>
 					<description>
 						<para>When an INFO request for one-touch recording arrives with a Record header set to "off", this
@@ -982,63 +1061,79 @@
 					</see-also>
 				</configOption>
 				<configOption name="rtp_engine" default="asterisk">
+					<since><version>12.0.0</version></since>
 					<synopsis>Name of the RTP engine to use for channels created for this endpoint</synopsis>
 				</configOption>
 				<configOption name="allow_transfer" default="yes">
+					<since><version>12.0.0</version></since>
 					<synopsis>Determines whether SIP REFER transfers are allowed for this endpoint</synopsis>
 				</configOption>
 				<configOption name="user_eq_phone" default="no">
+					<since><version>13.2.0</version></since>
 					<synopsis>Determines whether a user=phone parameter is placed into the request URI if the user is determined to be a phone number</synopsis>
 				</configOption>
 				<configOption name="moh_passthrough" default="no">
+					<since><version>13.30.0</version></since>
 					<synopsis>Determines whether hold and unhold will be passed through using re-INVITEs with recvonly and sendrecv to the remote side</synopsis>
 				</configOption>
 				<configOption name="sdp_owner" default="-">
+					<since><version>12.0.0</version></since>
 					<synopsis>String placed as the username portion of an SDP origin (o=) line.</synopsis>
 				</configOption>
 				<configOption name="sdp_session" default="Asterisk">
+					<since><version>12.0.0</version></since>
 					<synopsis>String used for the SDP session (s=) line.</synopsis>
 				</configOption>
 				<configOption name="tos_audio">
+					<since><version>12.2.0</version></since>
 					<synopsis>DSCP TOS bits for audio streams</synopsis>
 					<description><para>
 						See https://docs.asterisk.org/Configuration/Channel-Drivers/IP-Quality-of-Service for more information about QoS settings
 					</para></description>
 				</configOption>
 				<configOption name="tos_video">
+					<since><version>12.2.0</version></since>
 					<synopsis>DSCP TOS bits for video streams</synopsis>
 					<description><para>
 						See https://docs.asterisk.org/Configuration/Channel-Drivers/IP-Quality-of-Service for more information about QoS settings
 					</para></description>
 				</configOption>
 				<configOption name="cos_audio">
+					<since><version>12.0.0</version></since>
 					<synopsis>Priority for audio streams</synopsis>
 					<description><para>
 						See https://docs.asterisk.org/Configuration/Channel-Drivers/IP-Quality-of-Service for more information about QoS settings
 					</para></description>
 				</configOption>
 				<configOption name="cos_video">
+					<since><version>12.0.0</version></since>
 					<synopsis>Priority for video streams</synopsis>
 					<description><para>
 						See https://docs.asterisk.org/Configuration/Channel-Drivers/IP-Quality-of-Service for more information about QoS settings
 					</para></description>
 				</configOption>
 				<configOption name="allow_subscribe" default="yes">
+					<since><version>12.0.0</version></since>
 					<synopsis>Determines if endpoint is allowed to initiate subscriptions with Asterisk.</synopsis>
 				</configOption>
 				<configOption name="sub_min_expiry" default="60">
+					<since><version>12.0.0</version></since>
 					<synopsis>The minimum allowed expiry time for subscriptions initiated by the endpoint.</synopsis>
 				</configOption>
 				<configOption name="from_user">
+					<since><version>13.18.0</version><version>14.7.0</version></since>
 					<synopsis>Username to use in From header for requests to this endpoint.</synopsis>
 				</configOption>
 				<configOption name="mwi_from_user">
+					<since><version>12.0.0</version></since>
 					<synopsis>Username to use in From header for unsolicited MWI NOTIFYs to this endpoint.</synopsis>
 				</configOption>
 				<configOption name="from_domain">
+					<since><version>12.0.0</version></since>
 					<synopsis>Domain to use in From header for requests to this endpoint.</synopsis>
 				</configOption>
 				<configOption name="dtls_verify">
+					<since><version>12.7.0</version></since>
 					<synopsis>Verify that the provided peer certificate is valid</synopsis>
 					<description><para>
 						This option only applies if <replaceable>media_encryption</replaceable> is
@@ -1062,6 +1157,7 @@
 					</description>
 				</configOption>
 				<configOption name="dtls_rekey">
+					<since><version>12.7.0</version></since>
 					<synopsis>Interval at which to renegotiate the TLS session and rekey the SRTP session</synopsis>
 					<description><para>
 						This option only applies if <replaceable>media_encryption</replaceable> is
@@ -1071,6 +1167,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="dtls_auto_generate_cert" default="no">
+					<since><version>15.2.0</version></since>
 					<synopsis>Whether or not to automatically generate an ephemeral X.509 certificate</synopsis>
 					<description>
 						<para>
@@ -1083,6 +1180,7 @@
 					</description>
 				</configOption>
 				<configOption name="dtls_cert_file">
+					<since><version>12.2.0</version></since>
 					<synopsis>Path to certificate file to present to peer</synopsis>
 					<description><para>
 						This option only applies if <replaceable>media_encryption</replaceable> is
@@ -1090,6 +1188,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="dtls_private_key">
+					<since><version>12.2.0</version></since>
 					<synopsis>Path to private key for certificate file</synopsis>
 					<description><para>
 						This option only applies if <replaceable>media_encryption</replaceable> is
@@ -1097,6 +1196,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="dtls_cipher">
+					<since><version>12.2.0</version></since>
 					<synopsis>Cipher to use for DTLS negotiation</synopsis>
 					<description><para>
 						This option only applies if <replaceable>media_encryption</replaceable> is
@@ -1107,6 +1207,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="dtls_ca_file">
+					<since><version>12.2.0</version></since>
 					<synopsis>Path to certificate authority certificate</synopsis>
 					<description><para>
 						This option only applies if <replaceable>media_encryption</replaceable> is
@@ -1114,6 +1215,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="dtls_ca_path">
+					<since><version>12.2.0</version></since>
 					<synopsis>Path to a directory containing certificate authority certificates</synopsis>
 					<description><para>
 						This option only applies if <replaceable>media_encryption</replaceable> is
@@ -1121,6 +1223,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="dtls_setup">
+					<since><version>12.2.0</version></since>
 					<synopsis>Whether we are willing to accept connections, connect to the other party, or both.</synopsis>
 					<description>
 						<para>
@@ -1141,6 +1244,7 @@
 					</description>
 				</configOption>
 				<configOption name="dtls_fingerprint">
+					<since><version>12.7.0</version></since>
 					<synopsis>Type of hash to use for the DTLS fingerprint in the SDP.</synopsis>
 					<description>
 						<para>
@@ -1154,6 +1258,7 @@
 					</description>
 				</configOption>
 				<configOption name="srtp_tag_32">
+					<since><version>12.0.0</version></since>
 					<synopsis>Determines whether 32 byte tags should be used instead of 80 byte tags.</synopsis>
 					<description><para>
 						This option only applies if <replaceable>media_encryption</replaceable> is
@@ -1161,6 +1266,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="set_var">
+					<since><version>12.2.0</version></since>
 					<synopsis>Variable set on a channel involving the endpoint.</synopsis>
 					<description><para>
 						When a new channel is created using the endpoint set the specified
@@ -1169,6 +1275,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="message_context">
+					<since><version>13.5.0</version></since>
 					<synopsis>Context to route incoming MESSAGE requests to.</synopsis>
 					<description><para>
 						If specified, incoming MESSAGE requests will be routed to the indicated
@@ -1177,6 +1284,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="accountcode">
+					<since><version>13.5.0</version></since>
 					<synopsis>An accountcode to set automatically on any channels created for this endpoint.</synopsis>
 					<description><para>
 						If specified, any channel created for this endpoint will automatically
@@ -1184,6 +1292,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="preferred_codec_only" default="no">
+					<since><version>15.0.0</version></since>
 					<synopsis>Respond to a SIP invite with the single most preferred codec (DEPRECATED)</synopsis>
 					<description><para>Respond to a SIP invite with the single most preferred codec
 					rather than advertising all joint codec capabilities. This limits the other side's codec
@@ -1197,6 +1306,7 @@
 					</see-also>
 				</configOption>
 				<configOption name="incoming_call_offer_pref" default="local">
+					<since><version>18.0.0</version></since>
 					<synopsis>Preferences for selecting codecs for an incoming call.</synopsis>
 					<description>
 						<para>Based on this setting, a joint list of preferred codecs between those
@@ -1223,6 +1333,7 @@
 					</description>
 				</configOption>
 				<configOption name="outgoing_call_offer_pref" default="remote_merge">
+					<since><version>18.0.0</version></since>
 					<synopsis>Preferences for selecting codecs for an outgoing call.</synopsis>
 					<description>
 						<para>Based on this setting, a joint list of preferred codecs between
@@ -1254,6 +1365,7 @@
 					</description>
 				</configOption>
 				<configOption name="rtp_keepalive">
+					<since><version>13.5.0</version></since>
 					<synopsis>Number of seconds between RTP comfort noise keepalive packets.</synopsis>
 					<description><para>
 						At the specified interval, Asterisk will send an RTP comfort noise frame. This may
@@ -1262,6 +1374,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="rtp_timeout" default="0">
+					<since><version>13.5.0</version></since>
 					<synopsis>Maximum number of seconds without receiving RTP (while off hold) before terminating call.</synopsis>
 					<description><para>
 						This option configures the number of seconds without RTP (while off hold) before
@@ -1270,6 +1383,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="rtp_timeout_hold" default="0">
+					<since><version>13.5.0</version></since>
 					<synopsis>Maximum number of seconds without receiving RTP (while on hold) before terminating call.</synopsis>
 					<description><para>
 						This option configures the number of seconds without RTP (while on hold) before
@@ -1278,6 +1392,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="acl">
+					<since><version>13.10.0</version></since>
 					<synopsis>List of IP ACL section names in acl.conf</synopsis>
 					<description><para>
 						This matches sections configured in <literal>acl.conf</literal>. The value is
@@ -1285,6 +1400,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="deny">
+					<since><version>13.10.0</version></since>
 					<synopsis>List of IP addresses to deny access from</synopsis>
 					<description><para>
 						The value is a comma-delimited list of IP addresses. IP addresses may
@@ -1294,6 +1410,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="permit">
+					<since><version>13.10.0</version></since>
 					<synopsis>List of IP addresses to permit access from</synopsis>
 					<description><para>
 						The value is a comma-delimited list of IP addresses. IP addresses may
@@ -1303,6 +1420,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="contact_acl">
+					<since><version>13.10.0</version></since>
 					<synopsis>List of Contact ACL section names in acl.conf</synopsis>
 					<description><para>
 						This matches sections configured in <literal>acl.conf</literal>. The value is
@@ -1310,6 +1428,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="contact_deny">
+					<since><version>13.10.0</version></since>
 					<synopsis>List of Contact header addresses to deny</synopsis>
 					<description><para>
 						The value is a comma-delimited list of IP addresses. IP addresses may
@@ -1319,6 +1438,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="contact_permit">
+					<since><version>13.10.0</version></since>
 					<synopsis>List of Contact header addresses to permit</synopsis>
 					<description><para>
 						The value is a comma-delimited list of IP addresses. IP addresses may
@@ -1328,6 +1448,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="subscribe_context">
+					<since><version>13.11.0</version></since>
 					<synopsis>Context for incoming MESSAGE requests.</synopsis>
 					<description><para>
 						If specified, incoming SUBSCRIBE requests will be searched for the matching
@@ -1337,12 +1458,14 @@
 					</para></description>
 				</configOption>
 				<configOption name="contact_user" default="">
+					<since><version>13.12.0</version><version>14.1.0</version></since>
 					<synopsis>Force the user on the outgoing Contact header to this value.</synopsis>
 					<description><para>
 						On outbound requests, force the user portion of the Contact header to this value.
 					</para></description>
 				</configOption>
 				<configOption name="asymmetric_rtp_codec" default="no">
+					<since><version>13.13.0</version><version>14.2.0</version></since>
 					<synopsis>Allow the sending and receiving RTP codec to differ</synopsis>
 					<description><para>
 						When set to "yes" the codec in use for sending will be allowed to differ from
@@ -1351,6 +1474,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="rtcp_mux" default="no">
+					<since><version>13.15.0</version><version>14.4.0</version></since>
 					<synopsis>Enable RFC 5761 RTCP multiplexing on the RTP port</synopsis>
 					<description><para>
 						With this option enabled, Asterisk will attempt to negotiate the use of the "rtcp-mux"
@@ -1361,6 +1485,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="refer_blind_progress" default="yes">
+					<since><version>13.17.0</version><version>14.6.0</version></since>
 					<synopsis>Whether to notifies all the progress details on blind transfer</synopsis>
 					<description><para>
 						Some SIP phones (Mitel/Aastra, Snom) expect a sip/frag "200 OK"
@@ -1369,6 +1494,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="notify_early_inuse_ringing" default="no">
+					<since><version>13.17.0</version><version>14.6.0</version></since>
 					<synopsis>Whether to notifies dialog-info 'early' on InUse&amp;Ringing state</synopsis>
 					<description><para>
 						Control whether dialog-info subscriptions get 'early' state
@@ -1376,6 +1502,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="max_audio_streams" default="1">
+					<since><version>15.0.0</version></since>
 					<synopsis>The maximum number of allowed audio streams for the endpoint</synopsis>
 					<description><para>
 						This option enforces a limit on the maximum simultaneous negotiated audio
@@ -1383,6 +1510,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="max_video_streams" default="1">
+					<since><version>15.0.0</version></since>
 					<synopsis>The maximum number of allowed video streams for the endpoint</synopsis>
 					<description><para>
 						This option enforces a limit on the maximum simultaneous negotiated video
@@ -1390,6 +1518,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="bundle" default="no">
+					<since><version>15.0.0</version></since>
 					<synopsis>Enable RTP bundling</synopsis>
 					<description><para>
 						With this option enabled, Asterisk will attempt to negotiate the use of bundle.
@@ -1398,6 +1527,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="webrtc" default="no">
+					<since><version>15.0.0</version></since>
 					<synopsis>Defaults and enables some options that are relevant to WebRTC</synopsis>
 					<description><para>
 						When set to "yes" this also enables the following values that are needed in
@@ -1411,6 +1541,7 @@
 					</description>
 				</configOption>
 				<configOption name="incoming_mwi_mailbox">
+					<since><version>13.18.0</version><version>14.7.0</version><version>15.1.0</version></since>
 					<synopsis>Mailbox name to use when incoming MWI NOTIFYs are received</synopsis>
 					<description><para>
 						If an MWI NOTIFY is received <emphasis>from</emphasis> this endpoint,
@@ -1419,6 +1550,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="follow_early_media_fork">
+					<since><version>13.22.0</version><version>15.5.0</version></since>
 					<synopsis>Follow SDP forked media when To tag is different</synopsis>
 					<description><para>
 						On outgoing calls, if the UAS responds with different SDP attributes
@@ -1434,6 +1566,7 @@
 					</description>
 				</configOption>
 				<configOption name="accept_multiple_sdp_answers" default="no">
+					<since><version>13.22.0</version><version>15.5.0</version></since>
 					<synopsis>Accept multiple SDP answers on non-100rel responses</synopsis>
 					<description><para>
 						On outgoing calls, if the UAS responds with different SDP attributes
@@ -1449,6 +1582,7 @@
 					</description>
 				</configOption>
 				<configOption name="suppress_q850_reason_headers" default="no">
+					<since><version>13.23.0</version><version>15.6.0</version></since>
 					<synopsis>Suppress Q.850 Reason headers for this endpoint</synopsis>
 					<description><para>
 						Some devices can't accept multiple Reason headers and get confused
@@ -1457,6 +1591,7 @@
 					</description>
 				</configOption>
 				<configOption name="ignore_183_without_sdp" default="no">
+					<since><version>13.26.0</version><version>16.3.0</version></since>
 					<synopsis>Do not forward 183 when it doesn't contain SDP</synopsis>
 					<description><para>
 						Certain SS7 internetworking scenarios can result in a 183
@@ -1467,6 +1602,7 @@
 					</description>
 				</configOption>
 				<configOption name="stir_shaken" default="no">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>Enable STIR/SHAKEN support on this endpoint</synopsis>
 					<description><para>
 						Enable STIR/SHAKEN support on this endpoint. On incoming INVITEs,
@@ -1475,6 +1611,7 @@
 					</description>
 				</configOption>
 				<configOption name="stir_shaken_profile" default="">
+					<since><version>16.26.0</version><version>18.12.0</version><version>19.4.0</version></since>
 					<synopsis>STIR/SHAKEN profile containing additional configuration options</synopsis>
 					<description><para>
 						A STIR/SHAKEN profile that is defined in stir_shaken.conf. Contains
@@ -1482,6 +1619,7 @@
 					</description>
 				</configOption>
 				<configOption name="allow_unauthenticated_options" default="no">
+					<since><version>16.18.0</version><version>18.4.0</version></since>
 					<synopsis>Skip authentication when receiving OPTIONS requests</synopsis>
 					<description><para>
 						RFC 3261 says that the response to an OPTIONS request MUST be the
@@ -1499,6 +1637,7 @@
 					</description>
 				</configOption>
 				<configOption name="security_negotiation" default="no">
+					<since><version>21.0.0</version></since>
 					<synopsis>The kind of security agreement negotiation to use. Currently, only mediasec is supported.</synopsis>
 					<description>
 						<enumlist>
@@ -1508,6 +1647,7 @@
 					</description>
 				</configOption>
 				<configOption name="security_mechanisms">
+					<since><version>21.0.0</version></since>
 					<synopsis>List of security mechanisms supported.</synopsis>
 					<description><para>
 						This is a comma-delimited list of security mechanisms to use. Each security mechanism
@@ -1515,6 +1655,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="geoloc_incoming_call_profile" default="">
+					<since><version>16.28.0</version><version>18.14.0</version><version>19.6.0</version></since>
 					<synopsis>Geolocation profile to apply to incoming calls</synopsis>
 					<description><para>
 						This geolocation profile will be applied to all calls received
@@ -1524,6 +1665,7 @@
 					</description>
 				</configOption>
 				<configOption name="geoloc_outgoing_call_profile" default="">
+					<since><version>16.28.0</version><version>18.14.0</version><version>19.6.0</version></since>
 					<synopsis>Geolocation profile to apply to outgoing calls</synopsis>
 					<description><para>
 						This geolocation profile will be applied to all calls received
@@ -1533,9 +1675,11 @@
 					</description>
 				</configOption>
 				<configOption name="send_aoc" default="no">
+					<since><version>18.16.0</version><version>20.1.0</version></since>
 					<synopsis>Send Advice-of-Charge messages</synopsis>
 				</configOption>
 				<configOption name="suppress_moh_on_sendonly" default="no">
+					<since><version>20.11.0</version><version>21.6.0</version><version>22.1.0</version></since>
 					<synopsis>Suppress playing MOH to party A if party B sends
 					"sendonly" or "inactive" in an SDP</synopsis>
 					<description><para>
@@ -1558,6 +1702,7 @@
 				</configOption>
 			</configObject>
 			<configObject name="auth">
+				<since><version>12.0.0</version></since>
 				<!--
 				Be sure to update the following documentation page when making changes to this object:
 				https://docs.asterisk.org/Configuration/Channel-Drivers/SIP/Configuring-res_pjsip/PJSIP-Authentication
@@ -1582,6 +1727,7 @@
 					<ref type="link">https://docs.asterisk.org/Configuration/Channel-Drivers/SIP/Configuring-res_pjsip/PJSIP-Authentication</ref>
 				</see-also>
 				<configOption name="auth_type" default="digest">
+					<since><version>12.0.0</version></since>
 					<synopsis>Authentication type</synopsis>
 					<description><para>
 						If set to <literal>google_oauth</literal> then we'll read from the
@@ -1606,13 +1752,16 @@
 					</description>
 				</configOption>
 				<configOption name="username">
+					<since><version>12.0.0</version></since>
 					<synopsis>Username to use for account</synopsis>
 				</configOption>
 				<configOption name="password">
+					<since><version>12.0.0</version></since>
 					<synopsis>Plain text password used for authentication.</synopsis>
 					<description><para>Only used when auth_type is <literal>digest</literal>.</para></description>
 				</configOption>
 				<configOption name="password_digest" default="">
+					<since><version>20.12.0</version><version>21.7.0</version><version>22.2.0</version></since>
 					<synopsis>One or more pre-computed hashes used for authentication.</synopsis>
 					<description><para>Only used when auth_type is <literal>digest</literal>.
 						As an alternative to specifying a plain text password,
@@ -1655,6 +1804,7 @@
 					</description>
 				</configOption>
 				<configOption name="md5_cred" default="">
+					<since><version>12.0.0</version></since>
 					<synopsis>MD5 Hash used for authentication. (deprecated)</synopsis>
 					<description><para>Use the <literal>password_digest</literal> parameter instead.
 					If supplied, a <literal>password_digest</literal> parameter will be created
@@ -1662,6 +1812,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="supported_algorithms_uac">
+					<since><version>20.12.0</version><version>21.7.0</version><version>22.2.0</version></since>
 					<synopsis>Comma separated list of algorithms to support when this auth is used as a UAC</synopsis>
 					<description><para>Valid values:</para>
 						<enumlist>
@@ -1677,6 +1828,7 @@
 					</description>
 				</configOption>
 				<configOption name="supported_algorithms_uas">
+					<since><version>20.12.0</version><version>21.7.0</version><version>22.2.0</version></since>
 					<synopsis>Comma separated list of algorithms to support when this auth is used as a UAS</synopsis>
 					<description><para>Valid values:</para>
 						<enumlist>
@@ -1692,15 +1844,19 @@
 					</description>
 				</configOption>
 				<configOption name="refresh_token">
+					<since><version>17.0.0</version></since>
 					<synopsis>OAuth 2.0 refresh token</synopsis>
 				</configOption>
 				<configOption name="oauth_clientid">
+					<since><version>17.0.0</version></since>
 					<synopsis>OAuth 2.0 application's client id</synopsis>
 				</configOption>
 				<configOption name="oauth_secret">
+					<since><version>17.0.0</version></since>
 					<synopsis>OAuth 2.0 application's secret</synopsis>
 				</configOption>
 				<configOption name="realm" default="">
+					<since><version>12.0.0</version></since>
 					<synopsis>SIP realm for endpoint</synopsis>
 					<description><para>
 						For incoming authentication (asterisk is the UAS),
@@ -1741,13 +1897,16 @@
 					</description>
 				</configOption>
 				<configOption name="nonce_lifetime" default="32">
+					<since><version>12.0.0</version></since>
 					<synopsis>Lifetime of a nonce associated with this authentication config.</synopsis>
 				</configOption>
 				<configOption name="type">
+					<since><version>12.0.0</version></since>
 					<synopsis>Must be 'auth'</synopsis>
 				</configOption>
 			</configObject>
 			<configObject name="domain_alias">
+				<since><version>13.20.0</version><version>15.3.0</version></since>
 				<synopsis>Domain Alias</synopsis>
 				<description><para>
 					Signifies that a domain is an alias. If the domain on a session is
@@ -1757,13 +1916,16 @@
 					config option is provided to specify the domain to be aliased.
 				</para></description>
 				<configOption name="type">
+					<since><version>12.0.0</version></since>
 					<synopsis>Must be of type 'domain_alias'.</synopsis>
 				</configOption>
 				<configOption name="domain">
+					<since><version>12.0.0</version></since>
 					<synopsis>Domain to be aliased</synopsis>
 				</configOption>
 			</configObject>
 			<configObject name="transport">
+				<since><version>13.8.0</version></since>
 				<synopsis>SIP Transport</synopsis>
 				<description><para>
 					<emphasis>Transports</emphasis>
@@ -1776,18 +1938,23 @@
 						will not suffice.</para></note>
 				</description>
 				<configOption name="async_operations" default="1">
+					<since><version>12.0.0</version></since>
 					<synopsis>Number of simultaneous Asynchronous Operations, can no longer be set, always set to 1</synopsis>
 				</configOption>
 				<configOption name="bind">
+					<since><version>12.2.0</version></since>
 					<synopsis>IP Address and optional port to bind to for this transport</synopsis>
 				</configOption>
 				<configOption name="ca_list_file">
+					<since><version>13.8.0</version></since>
 					<synopsis>File containing a list of certificates to read (TLS ONLY, not WSS)</synopsis>
 				</configOption>
 				<configOption name="ca_list_path">
+					<since><version>13.8.0</version></since>
 					<synopsis>Path to directory containing a list of certificates to read (TLS ONLY, not WSS)</synopsis>
 				</configOption>
 				<configOption name="cert_file">
+					<since><version>13.8.0</version></since>
 					<synopsis>Certificate file for endpoint (TLS ONLY, not WSS)</synopsis>
 					<description><para>
 						A path to a .crt or .pem file can be provided.  However, only
@@ -1798,6 +1965,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="cipher">
+					<since><version>12.2.0</version></since>
 					<synopsis>Preferred cryptography cipher names (TLS ONLY, not WSS)</synopsis>
 					<description>
 					<para>Comma separated list of cipher names or numeric equivalents.
@@ -1811,9 +1979,11 @@
 					</description>
 				</configOption>
 				<configOption name="domain">
+					<since><version>12.0.0</version></since>
 					<synopsis>Domain the transport comes from</synopsis>
 				</configOption>
 				<configOption name="external_media_address">
+					<since><version>12.0.0</version></since>
 					<synopsis>External IP address to use in RTP handling</synopsis>
 					<description><para>
 						When a request or response is sent out, if the destination of the
@@ -1824,12 +1994,15 @@
 					</para></description>
 				</configOption>
 				<configOption name="external_signaling_address">
+					<since><version>12.0.0</version></since>
 					<synopsis>External address for SIP signalling</synopsis>
 				</configOption>
 				<configOption name="external_signaling_port" default="0">
+					<since><version>12.0.0</version></since>
 					<synopsis>External port for SIP signalling</synopsis>
 				</configOption>
 				<configOption name="method">
+					<since><version>12.2.0</version></since>
 					<synopsis>Method of SSL transport (TLS ONLY, not WSS)</synopsis>
 					<description>
 						<para>The availability of each of these options is dependent on the
@@ -1852,14 +2025,17 @@
 					</description>
 				</configOption>
 				<configOption name="local_net">
+					<since><version>12.2.0</version></since>
 					<synopsis>Network to consider local (used for NAT purposes).</synopsis>
 					<description><para>This must be in CIDR or dotted decimal format with the IP
 					and mask separated with a slash ('/').</para></description>
 				</configOption>
 				<configOption name="password">
+					<since><version>12.0.0</version></since>
 					<synopsis>Password required for transport</synopsis>
 				</configOption>
 				<configOption name="priv_key_file">
+					<since><version>13.8.0</version></since>
 					<synopsis>Private key file (TLS ONLY, not WSS)</synopsis>
 					<description><para>
 						A path to a key file can be provided. The private key file
@@ -1868,6 +2044,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="protocol" default="udp">
+					<since><version>12.2.0</version></since>
 					<synopsis>Protocol to use for SIP traffic</synopsis>
 					<description>
 						<enumlist>
@@ -1881,42 +2058,51 @@
 					</description>
 				</configOption>
 				<configOption name="require_client_cert" default="false">
+					<since><version>12.2.0</version></since>
 					<synopsis>Require client certificate (TLS ONLY, not WSS)</synopsis>
 				</configOption>
 				<configOption name="tcp_keepalive_enable" default="no">
+					<since><version>18.23.0</version><version>20.8.0</version><version>21.3.0</version></since>
 					<synopsis>Enable TCP keepalive</synopsis>
 					<description><para>
 						When set to 'yes', TCP keepalive messages are sent to verify that the endpoint is still reachable. This can help detect dead TCP connections in environments where connections may be silently dropped (e.g., NAT timeouts).
 					</para></description>
 				</configOption>
 				<configOption name="tcp_keepalive_idle_time" default="30">
+					<since><version>18.23.0</version><version>20.8.0</version><version>21.3.0</version></since>
 					<synopsis>Idle time before the first TCP keepalive probe is sent</synopsis>
 					<description><para>
 						Specifies the amount of time in seconds that the connection must be idle before the first TCP keepalive probe is sent. An idle connection is defined as a connection in which no data has been sent or received by the application.
 					</para></description>
 				</configOption>
 				<configOption name="tcp_keepalive_interval_time" default="10">
+					<since><version>18.23.0</version><version>20.8.0</version><version>21.3.0</version></since>
 					<synopsis>Interval between TCP keepalive probes</synopsis>
 					<description><para>
 						Specifies the interval in seconds between individual TCP keepalive probes, once the first probe is sent. This interval is used for subsequent probes if the peer does not respond to the previous probe.
 					</para></description>
 				</configOption>
 				<configOption name="tcp_keepalive_probe_count" default="5">
+					<since><version>18.23.0</version><version>20.8.0</version><version>21.3.0</version></since>
 					<synopsis>Maximum number of TCP keepalive probes</synopsis>
 					<description><para>
 						Specifies the maximum number of TCP keepalive probes to send before considering the connection dead and notifying the application. If the peer does not respond after this many probes, the connection is considered broken.
 					</para></description>
 				</configOption>
 				<configOption name="type">
+					<since><version>13.8.0</version></since>
 					<synopsis>Must be of type 'transport'.</synopsis>
 				</configOption>
 				<configOption name="verify_client" default="false">
+					<since><version>12.2.0</version></since>
 					<synopsis>Require verification of client certificate (TLS ONLY, not WSS)</synopsis>
 				</configOption>
 				<configOption name="verify_server" default="false">
+					<since><version>12.2.0</version></since>
 					<synopsis>Require verification of server certificate (TLS ONLY, not WSS)</synopsis>
 				</configOption>
 				<configOption name="tos" default="false">
+					<since><version>12.2.0</version></since>
 					<synopsis>Enable TOS for the signalling sent over this transport</synopsis>
 					<description>
 					<para>See <literal>https://docs.asterisk.org/Configuration/Channel-Drivers/IP-Quality-of-Service</literal>
@@ -1926,6 +2112,7 @@
 					</description>
 				</configOption>
 				<configOption name="cos" default="false">
+					<since><version>12.0.0</version></since>
 					<synopsis>Enable COS for the signalling sent over this transport</synopsis>
 					<description>
 					<para>See <literal>https://docs.asterisk.org/Configuration/Channel-Drivers/IP-Quality-of-Service</literal>
@@ -1935,6 +2122,7 @@
 					</description>
 				</configOption>
 				<configOption name="websocket_write_timeout" default="100">
+					<since><version>11.11.0</version><version>12.4.0</version></since>
 					<synopsis>The timeout (in milliseconds) to set on WebSocket connections.</synopsis>
 					<description>
 						<para>If a websocket connection accepts input slowly, the timeout
@@ -1943,6 +2131,7 @@
 					</description>
 				</configOption>
 				<configOption name="allow_reload" default="no">
+					<since><version>13.8.0</version></since>
 					<synopsis>Allow this transport to be reloaded.</synopsis>
 					<description>
 						<para>Allow this transport to be reloaded when res_pjsip is reloaded.
@@ -1951,6 +2140,7 @@
 					</description>
 				</configOption>
 				<configOption name="allow_wildcard_certs" default="false">
+					<since><version>16.28.0</version><version>18.14.0</version><version>19.6.0</version></since>
 					<synopsis>Allow use of wildcards in certificates (TLS ONLY)</synopsis>
 					<description>
 					  <para>In combination with verify_server, when enabled allow use of wildcards,
@@ -1963,6 +2153,7 @@
 					</description>
 				</configOption>
 				<configOption name="symmetric_transport" default="no">
+					<since><version>13.15.0</version><version>14.4.0</version></since>
 					<synopsis>Use the same transport for outgoing requests as incoming ones.</synopsis>
 					<description>
 						<para>When a request from a dynamic contact
@@ -2094,6 +2285,7 @@
 				</configOption>
 			</configObject>
 			<configObject name="aor">
+				<since><version>13.35.0</version><version>16.12.0</version><version>17.6.0</version></since>
 				<synopsis>The configuration for a location of an endpoint</synopsis>
 				<description><para>
 					An AoR is what allows Asterisk to contact an endpoint via res_pjsip. If no
@@ -2115,6 +2307,7 @@
 					to the "user name" set in your hard or soft phones configuration.
 				</para></description>
 				<configOption name="contact">
+					<since><version>12.2.0</version></since>
 					<synopsis>Permanent contacts assigned to AoR</synopsis>
 					<description><para>
 						Contacts specified will be called whenever referenced
@@ -2125,9 +2318,11 @@
 					</para></description>
 				</configOption>
 				<configOption name="default_expiration" default="3600">
+					<since><version>12.0.0</version></since>
 					<synopsis>Default expiration time in seconds for contacts that are dynamically bound to an AoR.</synopsis>
 				</configOption>
 				<configOption name="mailboxes">
+					<since><version>12.0.0</version></since>
 					<synopsis>Allow subscriptions for the specified mailbox(es)</synopsis>
 					<description><para>This option applies when an external entity subscribes to an AoR
 						for Message Waiting Indications. The mailboxes specified will be subscribed to.
@@ -2142,15 +2337,18 @@
 					</para></description>
 				</configOption>
 				<configOption name="voicemail_extension">
+					<since><version>13.9.0</version></since>
 					<synopsis>The voicemail extension to send in the NOTIFY Message-Account header</synopsis>
 				</configOption>
 				<configOption name="maximum_expiration" default="7200">
+					<since><version>12.0.0</version></since>
 					<synopsis>Maximum time to keep an AoR</synopsis>
 					<description><para>
 						Maximum time to keep a peer with explicit expiration. Time in seconds.
 					</para></description>
 				</configOption>
 				<configOption name="max_contacts" default="0">
+					<since><version>12.0.0</version></since>
 					<synopsis>Maximum number of contacts that can bind to an AoR</synopsis>
 					<description><para>
 						Maximum number of contacts that can associate with this AoR. This value does
@@ -2178,12 +2376,14 @@
 					</description>
 				</configOption>
 				<configOption name="minimum_expiration" default="60">
+					<since><version>12.0.0</version></since>
 					<synopsis>Minimum keep alive time for an AoR</synopsis>
 					<description><para>
 						Minimum time to keep a peer with an explicit expiration. Time in seconds.
 					</para></description>
 				</configOption>
 				<configOption name="remove_existing" default="no">
+					<since><version>12.0.0</version></since>
 					<synopsis>Determines whether new contacts replace existing ones.</synopsis>
 					<description><para>
 						On receiving a new registration to the AoR should it remove enough
@@ -2210,6 +2410,7 @@
 					</description>
 				</configOption>
 				<configOption name="remove_unavailable" default="no">
+					<since><version>16.22.0</version><version>18.8.0</version></since>
 					<synopsis>Determines whether new contacts should replace unavailable ones.</synopsis>
 					<description><para>
 						The effect of this setting depends on the setting of
@@ -2230,9 +2431,11 @@
 					</description>
 				</configOption>
 				<configOption name="type">
+					<since><version>12.0.0</version></since>
 					<synopsis>Must be of type 'aor'.</synopsis>
 				</configOption>
 				<configOption name="qualify_frequency" default="0">
+					<since><version>12.0.0</version></since>
 					<synopsis>Interval at which to qualify an AoR</synopsis>
 					<description><para>
 						Interval between attempts to qualify the AoR for reachability.
@@ -2240,6 +2443,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="qualify_timeout" default="3.0">
+					<since><version>13.4.0</version></since>
 					<synopsis>Timeout for qualify</synopsis>
 					<description><para>
 						If the contact doesn't respond to the OPTIONS request before the timeout,
@@ -2249,6 +2453,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="qualify_2xx_only">
+                    <since><version>20.12.0</version><version>21.7.0</version><version>22.2.0</version></since>
 					<synopsis>Only qualify contact if OPTIONS request returns 2XX</synopsis>
 					<description>
 						<para>If true only mark a contact as available if the qualify OPTIONS
@@ -2257,6 +2462,7 @@
 					</description>
 				</configOption>
 				<configOption name="authenticate_qualify">
+					<since><version>12.0.0</version></since>
 					<synopsis>Authenticates a qualify challenge response if needed</synopsis>
 					<description>
 						<para>If true and a qualify request receives a challenge response then
@@ -2269,6 +2475,7 @@
 					</description>
 				</configOption>
 				<configOption name="outbound_proxy">
+					<since><version>12.0.0</version></since>
 					<synopsis>Outbound proxy used when sending OPTIONS request</synopsis>
 					<description><para>
 						If set the provided URI will be used as the outbound proxy when an
@@ -2276,6 +2483,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="support_path">
+					<since><version>12.1.0</version></since>
 					<synopsis>Enables Path support for REGISTER requests and Route support for other requests.</synopsis>
 					<description><para>
 						When this option is enabled, the Path headers in register requests will be saved
@@ -2286,6 +2494,7 @@
 				</configOption>
 			</configObject>
 			<configObject name="system">
+				<since><version>12.2.0</version></since>
 				<synopsis>Options that apply to the SIP stack as well as other system-wide settings</synopsis>
 				<description><para>
 					The settings in this section are global. In addition to being global, the values will
@@ -2294,6 +2503,7 @@
 					restart Asterisk, or unload res_pjsip.so and then load it again.
 				</para></description>
 				<configOption name="timer_t1" default="500">
+					<since><version>12.0.0</version></since>
 					<synopsis>Set transaction timer T1 value (milliseconds).</synopsis>
 					<description><para>
 						Timer T1 is the base for determining how long to wait before retransmitting
@@ -2302,6 +2512,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="timer_b" default="32000">
+					<since><version>12.0.0</version></since>
 					<synopsis>Set transaction timer B value (milliseconds).</synopsis>
 					<description><para>
 						Timer B determines the maximum amount of time to wait after sending an INVITE
@@ -2311,22 +2522,28 @@
 					</para></description>
 				</configOption>
 				<configOption name="compact_headers" default="no">
+					<since><version>12.0.0</version></since>
 					<synopsis>Use the short forms of common SIP header names.</synopsis>
 				</configOption>
 				<configOption name="threadpool_initial_size" default="0">
+					<since><version>12.0.0</version></since>
 					<synopsis>Initial number of threads in the res_pjsip threadpool.</synopsis>
 				</configOption>
 				<configOption name="threadpool_auto_increment" default="5">
+					<since><version>12.0.0</version></since>
 					<synopsis>The amount by which the number of threads is incremented when necessary.</synopsis>
 				</configOption>
 				<configOption name="threadpool_idle_timeout" default="60">
+					<since><version>12.0.0</version></since>
 					<synopsis>Number of seconds before an idle thread should be disposed of.</synopsis>
 				</configOption>
 				<configOption name="threadpool_max_size" default="0">
+					<since><version>13.7.0</version></since>
 					<synopsis>Maximum number of threads in the res_pjsip threadpool.
 					A value of 0 indicates no maximum.</synopsis>
 				</configOption>
 				<configOption name="disable_tcp_switch" default="yes">
+					<since><version>13.1.0</version></since>
 					<synopsis>Disable automatic switching from UDP to TCP transports.</synopsis>
 					<description><para>
 						Disable automatic switching from UDP to TCP transports if outgoing
@@ -2334,6 +2551,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="follow_early_media_fork">
+					<since><version>13.22.0</version><version>15.5.0</version></since>
 					<synopsis>Follow SDP forked media when To tag is different</synopsis>
 					<description><para>
 						On outgoing calls, if the UAS responds with different SDP attributes
@@ -2348,6 +2566,7 @@
 					</description>
 				</configOption>
 				<configOption name="accept_multiple_sdp_answers">
+					<since><version>13.22.0</version><version>15.5.0</version></since>
 					<synopsis>Follow SDP forked media when To tag is the same</synopsis>
 					<description><para>
 						On outgoing calls, if the UAS responds with different SDP attributes
@@ -2362,41 +2581,50 @@
 					</description>
 				</configOption>
 				<configOption name="disable_rport" default="no">
+					<since><version>13.35.0</version><version>16.12.0</version><version>17.6.0</version></since>
 					<synopsis>Disable the use of rport in outgoing requests.</synopsis>
 					<description><para>
 						Remove "rport" parameter from the outgoing requests.
 					</para></description>
 				</configOption>
 				<configOption name="type">
+					<since><version>12.0.0</version></since>
 					<synopsis>Must be of type 'system' UNLESS the object name is 'system'.</synopsis>
 				</configOption>
 			</configObject>
 			<configObject name="global">
+				<since><version>12.0.0</version></since>
 				<synopsis>Options that apply globally to all SIP communications</synopsis>
 				<description><para>
 					The settings in this section are global. Unlike options in the <literal>system</literal>
 					section, these options can be refreshed by performing a reload.
 				</para></description>
 				<configOption name="max_forwards" default="70">
+					<since><version>13.3.0</version></since>
 					<synopsis>Value used in Max-Forwards header for SIP requests.</synopsis>
 				</configOption>
 				<configOption name="keep_alive_interval" default="90">
+					<since><version>13.3.0</version></since>
 					<synopsis>The interval (in seconds) to send keepalives to active connection-oriented transports.</synopsis>
 				</configOption>
 				<configOption name="contact_expiration_check_interval" default="30">
+					<since><version>13.9.0</version></since>
 					<synopsis>The interval (in seconds) to check for expired contacts.</synopsis>
 				</configOption>
 				<configOption name="disable_multi_domain" default="no">
+					<since><version>13.12.0</version><version>14.1.0</version></since>
 					<synopsis>Disable Multi Domain support</synopsis>
 					<description><para>
 						If disabled it can improve realtime performance by reducing the number of database requests.
 					</para></description>
 				</configOption>
 				<configOption name="max_initial_qualify_time" default="0">
+					<since><version>13.4.0</version></since>
 					<synopsis>The maximum amount of time from startup that qualifies should be attempted on all contacts.
 					If greater than the qualify_frequency for an aor, qualify_frequency will be used instead.</synopsis>
 				</configOption>
 				<configOption name="unidentified_request_period" default="5">
+					<since><version>13.10.0</version></since>
 					<synopsis>The number of seconds over which to accumulate unidentified requests.</synopsis>
 					<description><para>
 					If <literal>unidentified_request_count</literal> unidentified requests are received
@@ -2404,6 +2632,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="unidentified_request_count" default="5">
+					<since><version>13.10.0</version></since>
 					<synopsis>The number of unidentified requests from a single IP to allow.</synopsis>
 					<description><para>
 					If <literal>unidentified_request_count</literal> unidentified requests are received
@@ -2411,30 +2640,38 @@
 					</para></description>
 				</configOption>
 				<configOption name="unidentified_request_prune_interval" default="30">
+					<since><version>13.10.0</version></since>
 					<synopsis>The interval at which unidentified requests are older than
 					twice the unidentified_request_period are pruned.</synopsis>
 				</configOption>
 				<configOption name="type">
+					<since><version>12.0.0</version></since>
 					<synopsis>Must be of type 'global' UNLESS the object name is 'global'.</synopsis>
 				</configOption>
 				<configOption name="user_agent" default="Asterisk &lt;Asterisk Version&gt;">
+					<since><version>12.0.0</version></since>
 					<synopsis>Value used in User-Agent header for SIP requests and Server header for SIP responses.</synopsis>
 				</configOption>
 				<configOption name="regcontext" default="">
+					<since><version>13.8.0</version></since>
 					<synopsis>When set, Asterisk will dynamically create and destroy a NoOp priority 1 extension for a given
 						peer who registers or unregisters with us.</synopsis>
 				</configOption>
 				<configOption name="default_outbound_endpoint" default="default_outbound_endpoint">
+					<since><version>13.3.0</version></since>
 					<synopsis>Endpoint to use when sending an outbound request to a URI without a specified endpoint.</synopsis>
 				</configOption>
 				<configOption name="default_voicemail_extension">
+					<since><version>13.9.0</version></since>
 					<synopsis>The voicemail extension to send in the NOTIFY Message-Account header if not specified on endpoint or aor</synopsis>
 				</configOption>
 				<configOption name="debug" default="no">
+					<since><version>13.3.0</version></since>
 					<synopsis>Enable/Disable SIP debug logging.  Valid options include yes, no, or
 						a host address</synopsis>
 				</configOption>
 				<configOption name="endpoint_identifier_order">
+					<since><version>13.3.0</version></since>
 					<synopsis>The order by which endpoint identifiers are processed and checked.
 						Identifier names are usually derived from and can be found in the endpoint
 						identifier module itself (res_pjsip_endpoint_identifier_*).
@@ -2457,16 +2694,19 @@
 					</description>
 				</configOption>
 				<configOption name="default_from_user" default="asterisk">
+					<since><version>13.6.0</version></since>
 					<synopsis>When Asterisk generates an outgoing SIP request, the From header username will be
 						set to this value if there is no better option (such as CallerID) to be
 						used.</synopsis>
 				</configOption>
 				<configOption name="default_realm" default="asterisk">
+					<since><version>13.10.0</version></since>
 					<synopsis>When Asterisk generates a challenge, the digest realm will be
 						set to this value if there is no better option (such as auth/realm) to be
 						used.</synopsis>
 				</configOption>
 				<configOption name="mwi_tps_queue_high" default="500">
+					<since><version>13.12.0</version><version>14.1.0</version></since>
 					<synopsis>MWI taskprocessor high water alert trigger level.</synopsis>
 					<description>
 						<para>On a heavily loaded system you may need to adjust the
@@ -2479,6 +2719,7 @@
 					</description>
 				</configOption>
 				<configOption name="mwi_tps_queue_low" default="-1">
+					<since><version>13.12.0</version><version>14.1.0</version></since>
 					<synopsis>MWI taskprocessor low water clear alert level.</synopsis>
 					<description>
 						<para>On a heavily loaded system you may need to adjust the
@@ -2493,6 +2734,7 @@
 					</description>
 				</configOption>
 				<configOption name="mwi_disable_initial_unsolicited" default="no">
+					<since><version>13.12.0</version><version>14.1.0</version></since>
 					<synopsis>Enable/Disable sending unsolicited MWI to all endpoints on startup.</synopsis>
 					<description>
 						<para>When the initial unsolicited MWI notification are
@@ -2509,6 +2751,7 @@
 					</description>
 				</configOption>
 				<configOption name="ignore_uri_user_options">
+					<since><version>13.12.0</version><version>14.1.0</version></since>
 					<synopsis>Enable/Disable ignoring SIP URI user field options.</synopsis>
 					<description>
 						<para>If you have this option enabled and there are semicolons
@@ -2533,6 +2776,7 @@
 					</description>
 				</configOption>
 				<configOption name="use_callerid_contact" default="no">
+					<since><version>13.24.0</version><version>16.1.0</version></since>
 					<synopsis>Place caller-id information into Contact header</synopsis>
 					<description><para>
 						This option will cause Asterisk to place caller-id information into
@@ -2540,9 +2784,11 @@
 					</description>
 				</configOption>
 				<configOption name="send_contact_status_on_update_registration" default="no">
+					<since><version>16.2.0</version></since>
 					<synopsis>Enable sending AMI ContactStatus event when a device refreshes its registration.</synopsis>
 				</configOption>
 				<configOption name="taskprocessor_overload_trigger">
+					<since><version>13.26.0</version><version>16.3.0</version></since>
 					<synopsis>Trigger scope for taskprocessor overloads</synopsis>
 					<description><para>
 						This option specifies the trigger the distributor will use for
@@ -2563,9 +2809,11 @@
 					</description>
 				</configOption>
 				<configOption name="norefersub" default="yes">
+					<since><version>13.27.0</version><version>16.4.0</version></since>
 					<synopsis>Advertise support for RFC4488 REFER subscription suppression</synopsis>
 				</configOption>
 				<configOption name="allow_sending_180_after_183" default="no">
+					<since><version>16.26.0</version><version>18.12.0</version><version>19.4.0</version></since>
 					<synopsis>Allow 180 after 183</synopsis>
 					<description><para>
 						Allow Asterisk to send 180 Ringing to an endpoint
@@ -2577,6 +2825,7 @@
 					</description>
 				</configOption>
 				<configOption name="all_codecs_on_empty_reinvite" default="no">
+					<since><version>16.30.0</version><version>18.16.0</version><version>19.8.0</version><version>20.1.0</version></since>
 					<synopsis>If we should return all codecs on re-INVITE without SDP</synopsis>
 					<description><para>
 						On reception of a re-INVITE without SDP Asterisk will send an SDP
@@ -2586,6 +2835,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="default_auth_algorithms_uas" default="no">
+					<since><version>20.12.0</version><version>21.7.0</version><version>22.2.0</version></since>
 					<synopsis>List of default authentication algorithms to support when Asterisk is UAS</synopsis>
 					<description><para>Valid values:</para>
 						<enumlist>
@@ -2597,6 +2847,7 @@
 					</description>
 				</configOption>
 				<configOption name="default_auth_algorithms_uac" default="no">
+					<since><version>20.12.0</version><version>21.7.0</version><version>22.2.0</version></since>
 					<synopsis>List of default authentication algorithms to support when Asterisk is UAC</synopsis>
 					<description><para>Valid values:</para>
 						<enumlist>

--- a/res/res_pjsip_acl.c
+++ b/res/res_pjsip_acl.c
@@ -57,8 +57,10 @@
 		</para></description>
 		<configFile name="pjsip.conf">
 			<configObject name="acl">
+				<since><version>12.0.0</version></since>
 				<synopsis>Access Control List</synopsis>
 				<configOption name="acl">
+					<since><version>12.2.0</version></since>
 					<synopsis>List of IP ACL section names in acl.conf</synopsis>
 					<description><para>
 						This matches sections configured in <literal>acl.conf</literal>. The value is
@@ -66,6 +68,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="contact_acl">
+					<since><version>12.2.0</version></since>
 					<synopsis>List of Contact ACL section names in acl.conf</synopsis>
 					<description><para>
 						This matches sections configured in <literal>acl.conf</literal>. The value is
@@ -73,6 +76,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="contact_deny">
+					<since><version>12.2.0</version></since>
 					<synopsis>List of Contact header addresses to deny</synopsis>
 					<description><para>
 						The value is a comma-delimited list of IP addresses. IP addresses may
@@ -82,6 +86,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="contact_permit">
+					<since><version>12.2.0</version></since>
 					<synopsis>List of Contact header addresses to permit</synopsis>
 					<description><para>
 						The value is a comma-delimited list of IP addresses. IP addresses may
@@ -91,6 +96,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="deny">
+					<since><version>12.2.0</version></since>
 					<synopsis>List of IP addresses to deny access from</synopsis>
 					<description><para>
 						The value is a comma-delimited list of IP addresses. IP addresses may
@@ -100,6 +106,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="permit">
+					<since><version>12.2.0</version></since>
 					<synopsis>List of IP addresses to permit access from</synopsis>
 					<description><para>
 						The value is a comma-delimited list of IP addresses. IP addresses may
@@ -109,6 +116,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="type">
+					<since><version>12.0.0</version></since>
 					<synopsis>Must be of type 'acl'.</synopsis>
 				</configOption>
 			</configObject>

--- a/res/res_pjsip_endpoint_identifier_ip.c
+++ b/res/res_pjsip_endpoint_identifier_ip.c
@@ -38,6 +38,7 @@
 		<synopsis>Module that identifies endpoints</synopsis>
 		<configFile name="pjsip.conf">
 			<configObject name="identify">
+				<since><version>13.14.0</version><version>14.3.0</version></since>
 				<synopsis>Identifies endpoints via some criteria.</synopsis>
 				<description>
 					<para>This module provides alternatives to matching inbound requests to
@@ -54,9 +55,11 @@
 					<emphasis>any</emphasis> of the criteria.</para></note>
 				</description>
 				<configOption name="endpoint">
+					<since><version>12.0.0</version></since>
 					<synopsis>Name of endpoint identified</synopsis>
 				</configOption>
 				<configOption name="match">
+					<since><version>12.2.0</version></since>
 					<synopsis>IP addresses or networks to match against.</synopsis>
 					<description>
 						<para>The value is a comma-delimited list of IP addresses or
@@ -83,6 +86,7 @@
 					</description>
 				</configOption>
 				<configOption name="srv_lookups" default="yes">
+					<since><version>13.14.0</version><version>14.3.0</version></since>
 					<synopsis>Perform SRV lookups for provided hostnames.</synopsis>
 					<description>
 						<para>When enabled, <replaceable>srv_lookups</replaceable> will
@@ -93,6 +97,7 @@
 					</description>
 				</configOption>
 				<configOption name="match_header">
+					<since><version>13.15.0</version><version>14.4.0</version></since>
 					<synopsis>Header/value pair to match against.</synopsis>
 					<description>
 						<para>A SIP header whose value is used to match against.  SIP
@@ -111,6 +116,7 @@
 					</description>
 				</configOption>
 				<configOption name="match_request_uri">
+					<since><version>18.23.0</version><version>20.8.0</version><version>21.3.0</version></since>
 					<synopsis>Request URI to match against.</synopsis>
 					<description>
 						<para>The SIP request URI is used to match against.
@@ -125,6 +131,7 @@
 					</description>
 				</configOption>
 				<configOption name="type">
+					<since><version>12.0.0</version></since>
 					<synopsis>Must be of type 'identify'.</synopsis>
 				</configOption>
 			</configObject>

--- a/res/res_pjsip_notify.c
+++ b/res/res_pjsip_notify.c
@@ -86,6 +86,7 @@
 				<synopsis>Unused, but reserved.</synopsis>
 			</configObject>
 			<configObject name="notify">
+				<since><version>12.0.0</version></since>
 				<synopsis>Configuration of a NOTIFY request.</synopsis>
 				<description>
 					<para>Each key-value pair in a <literal>notify</literal>

--- a/res/res_pjsip_outbound_publish.c
+++ b/res/res_pjsip_outbound_publish.c
@@ -47,6 +47,7 @@
 		</description>
 		<configFile name="pjsip.conf">
 			<configObject name="outbound-publish">
+				<since><version>13.0.0</version></since>
 				<synopsis>The configuration for outbound publish</synopsis>
 				<description><para>
 					Publish is <emphasis>COMPLETELY</emphasis> separate from the rest of
@@ -54,9 +55,11 @@
 					setting a <literal>server_uri</literal> and <literal>event</literal>.
 				</para></description>
 				<configOption name="expiration" default="3600">
+					<since><version>13.0.0</version></since>
 					<synopsis>Expiration time for publications in seconds</synopsis>
 				</configOption>
 				<configOption name="outbound_auth" default="">
+					<since><version>13.0.0</version></since>
 					<synopsis>Authentication object(s) to be used for outbound publishes.</synopsis>
 					<description><para>
 						This is a comma-delimited list of <replaceable>auth</replaceable>
@@ -71,9 +74,11 @@
 					</description>
 				</configOption>
 				<configOption name="outbound_proxy" default="">
+					<since><version>13.0.0</version></since>
 					<synopsis>Full SIP URI of the outbound proxy used to send publishes</synopsis>
 				</configOption>
 				<configOption name="server_uri">
+					<since><version>13.0.0</version></since>
 					<synopsis>SIP URI of the server and entity to publish to</synopsis>
 					<description><para>
 						This is the URI at which to find the entity and server to send the outbound PUBLISH to.
@@ -81,6 +86,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="from_uri">
+					<since><version>13.0.0</version></since>
 					<synopsis>SIP URI to use in the From header</synopsis>
 					<description><para>
 						This is the URI that will be placed into the From header of outgoing PUBLISH
@@ -89,6 +95,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="to_uri">
+					<since><version>13.0.0</version></since>
 					<synopsis>SIP URI to use in the To header</synopsis>
 					<description><para>
 						This is the URI that will be placed into the To header of outgoing PUBLISH
@@ -97,12 +104,15 @@
 					</para></description>
 				</configOption>
 				<configOption name="event" default="">
+					<since><version>13.0.0</version></since>
 					<synopsis>Event type of the PUBLISH.</synopsis>
 				</configOption>
 				<configOption name="max_auth_attempts" default="5">
+					<since><version>13.0.0</version></since>
 					<synopsis>Maximum number of authentication attempts before stopping the publication.</synopsis>
 				</configOption>
 				<configOption name="transport">
+					<since><version>13.9.0</version></since>
 					<synopsis>Transport used for outbound publish</synopsis>
 					<description>
 						<note><para>A <replaceable>transport</replaceable> configured in
@@ -110,10 +120,12 @@
 					</description>
 				</configOption>
 				<configOption name="multi_user" default="no">
+					<since><version>14.0.0</version></since>
 					<synopsis>Enable multi-user support</synopsis>
 					<description><para>When enabled the user portion of the server uri is replaced by a dynamically created user</para></description>
 				</configOption>
 				<configOption name="type">
+					<since><version>13.0.0</version></since>
 					<synopsis>Must be of type 'outbound-publish'.</synopsis>
 				</configOption>
 			</configObject>

--- a/res/res_pjsip_outbound_registration.c
+++ b/res/res_pjsip_outbound_registration.c
@@ -51,6 +51,7 @@
 		</description>
 		<configFile name="pjsip.conf">
 			<configObject name="registration">
+				<since><version>12.0.0</version></since>
 				<synopsis>The configuration for outbound registration</synopsis>
 				<description><para>
 					Registration is <emphasis>COMPLETELY</emphasis> separate from the rest of
@@ -58,12 +59,14 @@
 					setting a <literal>server_uri</literal>	and a <literal>client_uri</literal>.
 				</para></description>
 				<configOption name="auth_rejection_permanent" default="yes">
+					<since><version>12.0.0</version></since>
 					<synopsis>Determines whether failed authentication challenges are treated
 					as permanent failures.</synopsis>
 					<description><para>If this option is enabled and an authentication challenge fails,
 					registration will not be attempted again until the configuration is reloaded.</para></description>
 				</configOption>
 				<configOption name="client_uri">
+					<since><version>12.0.0</version></since>
 					<synopsis>Client SIP URI used when attemping outbound registration</synopsis>
 					<description><para>
 						This is the address-of-record for the outbound registration (i.e. the URI in
@@ -76,15 +79,19 @@
 					</para></description>
 				</configOption>
 				<configOption name="contact_user" default="s">
+					<since><version>12.0.0</version></since>
 					<synopsis>Contact User to use in request. If this value is not set, this defaults to 's'</synopsis>
 				</configOption>
 				<configOption name="contact_header_params">
+					<since><version>17.0.0</version></since>
 					<synopsis>Header parameters to place in the Contact header</synopsis>
 				</configOption>
 				<configOption name="expiration" default="3600">
+					<since><version>12.0.0</version></since>
 					<synopsis>Expiration time for registrations in seconds</synopsis>
 				</configOption>
 				<configOption name="max_retries" default="10">
+					<since><version>12.0.0</version></since>
 					<synopsis>Maximum number of registration attempts.</synopsis>
 					<description><para>
 						This sets the maximum number of registration attempts that are made before
@@ -93,6 +100,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="security_negotiation" default="no">
+					<since><version>21.0.0</version></since>
 					<synopsis>The kind of security agreement negotiation to use. Currently, only mediasec is supported.</synopsis>
 					<description>
 						<enumlist>
@@ -102,6 +110,7 @@
 					</description>
 				</configOption>
 				<configOption name="security_mechanisms">
+					<since><version>21.0.0</version></since>
 					<synopsis>List of security mechanisms supported.</synopsis>
 					<description><para>
 						This is a comma-delimited list of security mechanisms to use. Each security mechanism
@@ -109,6 +118,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="outbound_auth" default="">
+					<since><version>12.2.0</version></since>
 					<synopsis>Authentication object(s) to be used for outbound registrations.</synopsis>
 					<description><para>
 						This is a comma-delimited list of <replaceable>auth</replaceable>
@@ -123,9 +133,11 @@
 					</description>
 				</configOption>
 				<configOption name="outbound_proxy" default="">
+					<since><version>12.0.0</version></since>
 					<synopsis>Full SIP URI of the outbound proxy used to send registrations</synopsis>
 				</configOption>
 				<configOption name="max_random_initial_delay" default="10">
+					<since><version>16.27.0</version><version>18.13.0</version><version>19.5.0</version></since>
 					<synopsis>Maximum interval in seconds for which an initial registration may be randomly delayed</synopsis>
 					<description>
 						<para>By default, registrations are randomly delayed by a small amount to prevent
@@ -135,9 +147,11 @@
 					</description>
 				</configOption>
 				<configOption name="retry_interval" default="60">
+					<since><version>12.0.0</version></since>
 					<synopsis>Interval in seconds between retries if outbound registration is unsuccessful</synopsis>
 				</configOption>
 				<configOption name="forbidden_retry_interval" default="0">
+					<since><version>11.7.0</version></since>
 					<synopsis>Interval used when receiving a 403 Forbidden response.</synopsis>
 					<description><para>
 						If a 403 Forbidden is received, chan_pjsip will wait
@@ -149,6 +163,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="fatal_retry_interval" default="0">
+					<since><version>13.7.0</version></since>
 					<synopsis>Interval used when receiving a Fatal response.</synopsis>
 					<description><para>
 						If a fatal response is received, chan_pjsip will wait
@@ -164,6 +179,7 @@
 					</description>
 				</configOption>
 				<configOption name="server_uri">
+					<since><version>12.0.0</version></since>
 					<synopsis>SIP URI of the server to register against</synopsis>
 					<description><para>
 						This is the URI at which to find the registrar to send the outbound REGISTER. This URI
@@ -173,6 +189,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="transport">
+					<since><version>12.0.0</version></since>
 					<synopsis>Transport used for outbound authentication</synopsis>
 					<description>
 						<note><para>A <replaceable>transport</replaceable> configured in
@@ -180,6 +197,7 @@
 					</description>
 				</configOption>
 				<configOption name="line">
+					<since><version>13.4.0</version></since>
 					<synopsis>Whether to add a 'line' parameter to the Contact for inbound call matching</synopsis>
 					<description><para>
 						When enabled this option will cause a 'line' parameter to be added to the Contact
@@ -189,6 +207,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="endpoint">
+					<since><version>13.4.0</version></since>
 					<synopsis>Endpoint to use for incoming related calls</synopsis>
 					<description><para>
 						When line support is enabled this configured endpoint name is used for incoming calls
@@ -196,9 +215,11 @@
 					</para></description>
 				</configOption>
 				<configOption name="type">
+					<since><version>12.0.0</version></since>
 					<synopsis>Must be of type 'registration'.</synopsis>
 				</configOption>
 				<configOption name="support_path">
+					<since><version>12.1.0</version></since>
 					<synopsis>Enables advertising SIP Path support for outbound REGISTER requests.</synopsis>
 					<description><para>
 						When this option is enabled, outbound REGISTER requests will advertise
@@ -207,6 +228,7 @@
 					</para></description>
 				</configOption>
 				<configOption name="support_outbound">
+					<since><version>17.0.0</version></since>
 					<synopsis>Enables advertising SIP Outbound support (RFC5626) for outbound REGISTER requests.</synopsis>
 				</configOption>
 			</configObject>

--- a/res/res_pjsip_phoneprov_provider.c
+++ b/res/res_pjsip_phoneprov_provider.c
@@ -102,8 +102,10 @@
 
 		<configFile name="pjsip.conf">
 			<configObject name="phoneprov">
+				<since><version>12.7.0</version></since>
 				<synopsis>Provides variables for each user.</synopsis>
 				<configOption name="type">
+					<since><version>13.2.0</version></since>
 					<synopsis>Must be of type 'phoneprov'.</synopsis>
 				</configOption>
 				<configOption name="endpoint">

--- a/res/res_pjsip_publish_asterisk.c
+++ b/res/res_pjsip_publish_asterisk.c
@@ -48,30 +48,38 @@
 		</description>
 		<configFile name="pjsip.conf">
 			<configObject name="asterisk-publication">
+				<since><version>13.0.0</version></since>
 				<synopsis>The configuration for inbound Asterisk event publication</synopsis>
 				<description><para>
 					Publish is <emphasis>COMPLETELY</emphasis> separate from the rest of
 					<literal>pjsip.conf</literal>.
 				</para></description>
 				<configOption name="devicestate_publish">
+					<since><version>13.0.0</version></since>
 					<synopsis>Optional name of a publish item that can be used to publish a request for full device state information.</synopsis>
 				</configOption>
 				<configOption name="mailboxstate_publish">
+					<since><version>13.0.0</version></since>
 					<synopsis>Optional name of a publish item that can be used to publish a request for full mailbox state information.</synopsis>
 				</configOption>
 				<configOption name="device_state" default="no">
+					<since><version>13.0.0</version></since>
 					<synopsis>Whether we should permit incoming device state events.</synopsis>
 				</configOption>
 				<configOption name="device_state_filter">
+					<since><version>13.0.0</version></since>
 					<synopsis>Optional regular expression used to filter what devices we accept events for.</synopsis>
 				</configOption>
 				<configOption name="mailbox_state" default="no">
+					<since><version>13.0.0</version></since>
 					<synopsis>Whether we should permit incoming mailbox state events.</synopsis>
 				</configOption>
 				<configOption name="mailbox_state_filter">
+					<since><version>13.0.0</version></since>
 					<synopsis>Optional regular expression used to filter what mailboxes we accept events for.</synopsis>
 				</configOption>
 				<configOption name="type">
+					<since><version>13.0.0</version></since>
 					<synopsis>Must be of type 'asterisk-publication'.</synopsis>
 				</configOption>
 			</configObject>

--- a/res/res_pjsip_pubsub.c
+++ b/res/res_pjsip_pubsub.c
@@ -148,6 +148,7 @@
 				</configOption>
 			</configObject>
 			<configObject name="resource_list">
+				<since><version>13.0.0</version></since>
 				<synopsis>Resource list configuration parameters.</synopsis>
 				<description>
 					<para>This configuration object allows for RFC 4662 resource list subscriptions
@@ -160,9 +161,11 @@
 					</note>
 				</description>
 				<configOption name="type">
+					<since><version>13.0.0</version></since>
 					<synopsis>Must be of type 'resource_list'</synopsis>
 				</configOption>
 				<configOption name="event">
+					<since><version>13.0.0</version></since>
 					<synopsis>The SIP event package that the list resource belong to.</synopsis>
 					<description><para>
 						The SIP event package describes the types of resources that Asterisk reports
@@ -182,6 +185,7 @@
 					</description>
 				</configOption>
 				<configOption name="list_item">
+					<since><version>13.0.0</version></since>
 					<synopsis>The name of a resource to report state on</synopsis>
 					<description>
 						<para>In general Asterisk looks up list items in the following way:</para>
@@ -196,6 +200,7 @@
 					</description>
 				</configOption>
 				<configOption name="full_state" default="no">
+					<since><version>13.0.0</version></since>
 					<synopsis>Indicates if the entire list's state should be sent out.</synopsis>
 					<description>
 						<para>If this option is enabled, and a resource changes state, then Asterisk will construct
@@ -211,6 +216,7 @@
 					</description>
 				</configOption>
 				<configOption name="notification_batch_interval" default="0">
+					<since><version>13.0.0</version></since>
 					<synopsis>Time Asterisk should wait, in milliseconds, before sending notifications.</synopsis>
 					<description>
 						<para>When a resource's state changes, it may be desired to wait a certain amount before Asterisk
@@ -220,6 +226,7 @@
 					</description>
 				</configOption>
 				<configOption name="resource_display_name" default="no">
+					<since><version>16.25.0</version><version>18.11.0</version><version>19.3.0</version></since>
 					<synopsis>Indicates whether display name of resource or the resource name being reported.</synopsis>
 					<description>
 						<para>If this option is enabled, the Display Name will be reported as resource name.
@@ -230,11 +237,14 @@
 				</configOption>
 			</configObject>
 			<configObject name="inbound-publication">
+				<since><version>13.0.0</version></since>
 				<synopsis>The configuration for inbound publications</synopsis>
 				<configOption name="endpoint" default="">
+					<since><version>13.0.0</version></since>
 					<synopsis>Optional name of an endpoint that is only allowed to publish to this resource</synopsis>
 				</configOption>
 				<configOption name="type">
+					<since><version>13.0.0</version></since>
 					<synopsis>Must be of type 'inbound-publication'.</synopsis>
 				</configOption>
 			</configObject>

--- a/res/res_prometheus.c
+++ b/res/res_prometheus.c
@@ -36,6 +36,7 @@
 		<synopsis>Resource for integration with Prometheus</synopsis>
 		<configFile name="prometheus.conf">
 			<configObject name="general">
+				<since><version>17.0.0</version></since>
 				<synopsis>General settings.</synopsis>
 				<description>
 					<para>
@@ -49,6 +50,7 @@
 					</note>
 				</description>
 				<configOption name="enabled" default="no">
+					<since><version>17.0.0</version></since>
 					<synopsis>Enable or disable Prometheus statistics.</synopsis>
 					<description>
 						<enumlist>
@@ -58,6 +60,7 @@
 					</description>
 				</configOption>
 				<configOption name="core_metrics_enabled" default="yes">
+					<since><version>17.0.0</version></since>
 					<synopsis>Enable or disable core metrics.</synopsis>
 					<description>
 						<para>
@@ -75,9 +78,11 @@
 					</description>
 				</configOption>
 				<configOption name="uri" default="metrics">
+					<since><version>17.0.0</version></since>
 					<synopsis>The HTTP URI to serve metrics up on.</synopsis>
 				</configOption>
 				<configOption name="auth_username">
+					<since><version>17.0.0</version></since>
 					<synopsis>Username to use for Basic Auth.</synopsis>
 					<description>
 						<para>
@@ -101,6 +106,7 @@
 					</description>
 				</configOption>
 				<configOption name="auth_password">
+					<since><version>17.0.0</version></since>
 					<synopsis>Password to use for Basic Auth.</synopsis>
 					<description>
 						<para>
@@ -112,6 +118,7 @@
 					</description>
 				</configOption>
 				<configOption name="auth_realm" default="Asterisk Prometheus Metrics">
+					<since><version>17.0.0</version></since>
 					<synopsis>Auth realm used in challenge responses</synopsis>
 				</configOption>
 			</configObject>

--- a/res/res_resolver_unbound.c
+++ b/res/res_resolver_unbound.c
@@ -43,19 +43,23 @@
 	<configInfo name="res_resolver_unbound" language="en_US">
 		<configFile name="resolver_unbound.conf">
 			<configObject name="general">
+				<since><version>14.1.0</version></since>
 				<synopsis>General options for res_resolver_unbound</synopsis>
 				<configOption name="hosts">
+					<since><version>14.0.0</version></since>
 					<synopsis>Full path to an optional hosts file</synopsis>
 					<description><para>Hosts specified in a hosts file will be resolved within the resolver itself. If a value
 					of system is provided the system-specific file will be used.</para></description>
 				</configOption>
 				<configOption name="resolv">
+					<since><version>14.0.0</version></since>
 					<synopsis>Full path to an optional resolv.conf file</synopsis>
 					<description><para>The resolv.conf file specifies the nameservers to contact when resolving queries. If a
 					value of system is provided the system-specific file will be used. If provided alongside explicit nameservers the
 					nameservers contained within the resolv.conf file will be used after all others.</para></description>
 				</configOption>
 				<configOption name="nameserver">
+					<since><version>14.0.0</version></since>
 					<synopsis>Nameserver to use for queries</synopsis>
 					<description><para>An explicit nameserver can be specified which is used for resolving queries. If multiple
 					nameserver lines are specified the first will be the primary with failover occurring, in order, to the other
@@ -63,11 +67,13 @@
 					used before all others.</para></description>
 				</configOption>
 				<configOption name="debug">
+					<since><version>14.0.0</version></since>
 					<synopsis>Unbound debug level</synopsis>
 					<description><para>The debugging level for the unbound resolver. While there is no explicit range generally
 					the higher the number the more debug is output.</para></description>
 				</configOption>
 				<configOption name="ta_file">
+					<since><version>14.0.0</version></since>
 					<synopsis>Trust anchor file</synopsis>
 					<description><para>Full path to a file with DS and DNSKEY records in zone file format. This file is provided
 					to unbound and is used as a source for trust anchors.</para></description>

--- a/res/res_statsd.c
+++ b/res/res_statsd.c
@@ -43,22 +43,28 @@
 		</description>
 		<configFile name="statsd.conf">
 			<configObject name="global">
+				<since><version>12.0.0</version></since>
 				<synopsis>Global configuration settings</synopsis>
 				<configOption name="enabled">
+					<since><version>12.0.0</version></since>
 					<synopsis>Enable/disable the StatsD module</synopsis>
 				</configOption>
 				<configOption name="server">
+					<since><version>12.0.0</version></since>
 					<synopsis>Address of the StatsD server</synopsis>
 				</configOption>
 				<configOption name="prefix">
+					<since><version>12.0.0</version></since>
 					<synopsis>Prefix to prepend to every metric</synopsis>
 				</configOption>
 				<configOption name="add_newline">
+					<since><version>12.0.0</version></since>
 					<synopsis>Append a newline to every event. This is useful if
 					you want to fake out a server using netcat
 					(nc -lu 8125)</synopsis>
 				</configOption>
 				<configOption name="meter_support">
+					<since><version>16.20.0</version><version>18.6.0</version></since>
 					<synopsis>Enable/disable the non-standard StatsD Meter type,
 					if disabled falls back to counter and will append a "_meter" suffix to the metric name</synopsis>
 				</configOption>

--- a/res/res_stir_shaken/stir_shaken_doc.xml
+++ b/res/res_stir_shaken/stir_shaken_doc.xml
@@ -5,23 +5,29 @@
 		<synopsis>STIR/SHAKEN module for Asterisk</synopsis>
 		<configFile name="stir_shaken.conf">
 			<configObject name="attestation">
+				<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 				<synopsis>STIR/SHAKEN attestation options</synopsis>
 				<configOption name="global_disable" default="false">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>Globally disable verification</synopsis>
 				</configOption>
 				<configOption name="private_key_file" default="">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>File path to a certificate</synopsis>
 				</configOption>
 				<configOption name="public_cert_url" default="">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>URL to the public certificate</synopsis>
 					<description><para>
 					 Must be a valid http, or https, URL.
 					</para></description>
 				</configOption>
 				<configOption name="attest_level">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>Attestation level</synopsis>
 				</configOption>
 				<configOption name="unknown_tn_attest_level">
+					<since><version>20.12.0</version><version>21.7.0</version><version>22.2.0</version></since>
 					<synopsis>Attestation level to use for unknown TNs</synopsis>
 					<description><para>
 					Normally if a callerid TN isn't configured in stir_shaken.conf
@@ -34,47 +40,60 @@
 					</para></description>
 				</configOption>
 				<configOption name="check_tn_cert_public_url" default="false">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>On load, Retrieve all TN's certificates and validate their dates</synopsis>
 				</configOption>
 				<configOption name="send_mky" default="no">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>Send a media key (mky) grant in the attestation for DTLS calls.
 					(not common)</synopsis>
 				</configOption>
 			</configObject>
 			<configObject name="tn">
+				<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 				<synopsis>STIR/SHAKEN TN options</synopsis>
 				<configOption name="type">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>Must be of type 'tn'.</synopsis>
 				</configOption>
 				<configOption name="private_key_file" default="">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>File path to a certificate</synopsis>
 				</configOption>
 				<configOption name="public_cert_url" default="">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>URL to the public certificate</synopsis>
 					<description><para>
 					 Must be a valid http, or https, URL.
 					</para></description>
 				</configOption>
 				<configOption name="attest_level">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>Attestation level</synopsis>
 				</configOption>
 				<configOption name="check_tn_cert_public_url" default="false">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>On load, Retrieve all TN's certificates and validate their dates</synopsis>
 				</configOption>
 				<configOption name="send_mky" default="no">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>Send a media key (mky) grant in the attestation for DTLS calls.
 					(not common)</synopsis>
 				</configOption>
 			</configObject>
 			<configObject name="verification">
+				<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 				<synopsis>STIR/SHAKEN verification options</synopsis>
 				<configOption name="global_disable" default="false">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>Globally disable verification</synopsis>
 				</configOption>
 				<configOption name="load_system_certs" default="">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>A boolean indicating whether trusted CA certificates should be loaded from the system</synopsis>
 				</configOption>
 				<configOption name="ca_file" default="">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>Path to a file containing one or more CA certs in PEM format</synopsis>
 					<description>
 						<para>These certs are used to verify the chain of trust for the
@@ -88,6 +107,7 @@
 					</description>
 				</configOption>
 				<configOption name="ca_path" default="">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>Path to a directory containing one or more hashed CA certs</synopsis>
 					<description>
 						<xi:include xpointer="xpointer(/docs/configInfo[@name='res_stir_shaken']/configFile[@name='stir_shaken.conf']/configObject[@name='verification']/configOption[@name='ca_file']/description/node())" />
@@ -100,6 +120,7 @@
 					</description>
 				</configOption>
 				<configOption name="crl_file" default="">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>Path to a file containing one or more CRLs in PEM format</synopsis>
 					<description>
 						<para>If you with to check if the certificate in the X5U Identity header
@@ -111,6 +132,7 @@
 					</description>
 				</configOption>
 				<configOption name="crl_path" default="">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>Path to a directory containing one or more hashed CRLs</synopsis>
 					<description>
 						<xi:include xpointer="xpointer(/docs/configInfo[@name='res_stir_shaken']/configFile[@name='stir_shaken.conf']/configObject[@name='verification']/configOption[@name='crl_file']/description/node())" />
@@ -123,6 +145,7 @@
 					</description>
 				</configOption>
 				<configOption name="untrusted_cert_file" default="">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>Path to a file containing one or more untrusted cert in PEM format used to verify CRLs</synopsis>
 					<description>
 					<para>If you with to check if the certificate in the X5U Identity header
@@ -136,6 +159,7 @@
 					</description>
 				</configOption>
 				<configOption name="untrusted_cert_path" default="">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>Path to a directory containing one or more hashed untrusted certs used to verify CRLs</synopsis>
 					<description>
 						<xi:include xpointer="xpointer(/docs/configInfo[@name='res_stir_shaken']/configFile[@name='stir_shaken.conf']/configObject[@name='verification']/configOption[@name='untrusted_cert_file']/description/node())" />
@@ -148,24 +172,31 @@
 					</description>
 				</configOption>
 				<configOption name="cert_cache_dir" default="">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>Directory to cache retrieved verification certs</synopsis>
 				</configOption>
 				<configOption name="curl_timeout" default="2">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>Maximum time to wait to CURL certificates</synopsis>
 				</configOption>
 				<configOption name="max_cache_entry_age" default="60">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>Number of seconds a cache entry may be behind current time</synopsis>
 				</configOption>
 				<configOption name="max_cache_size" default="1000">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>Maximum size to use for caching public keys</synopsis>
 				</configOption>
 				<configOption name="max_iat_age" default="15">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>Number of seconds an iat grant may be behind current time</synopsis>
 				</configOption>
 				<configOption name="max_date_header_age" default="15">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>Number of seconds a SIP Date header may be behind current time</synopsis>
 				</configOption>
 				<configOption name="failure_action" default="continue">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>The default failure action when not set on a profile</synopsis>
 					<description>
 						<enumlist>
@@ -187,33 +218,41 @@
 					</description>
 				</configOption>
 				<configOption name="use_rfc9410_responses" default="no">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>RFC9410 uses the STIR protocol on Reason headers
 					instead of the SIP protocol</synopsis>
 				</configOption>
 				<configOption name="relax_x5u_port_scheme_restrictions" default="no">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>Relaxes check for "https" and port 443 or 8443
 					in incoming Identity header x5u URLs.</synopsis>
 				</configOption>
 				<configOption name="relax_x5u_path_restrictions" default="no">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>Relaxes check for query parameters, user/password, etc.
 					in incoming Identity header x5u URLs.</synopsis>
 				</configOption>
 				<configOption name="x5u_acl" default="">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>An existing ACL from acl.conf to use when checking
 					hostnames in incoming Identity header x5u URLs.</synopsis>
 				</configOption>
 				<configOption name="x5u_permit" default="">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>An IP or subnet to permit when checking
 					hostnames in incoming Identity header x5u URLs.</synopsis>
 				</configOption>
 				<configOption name="x5u_deny" default="">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>An IP or subnet to deny  checking
 					hostnames in incoming Identity header x5u URLs.</synopsis>
 				</configOption>
 			</configObject>
 			<configObject name="profile">
+				<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 				<synopsis>STIR/SHAKEN profile configuration options</synopsis>
 				<configOption name="type">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>Must be of type 'profile'.</synopsis>
 				</configOption>
 				<xi:include xpointer="xpointer(/docs/configInfo[@name='res_stir_shaken']/configFile[@name='stir_shaken.conf']/configObject[@name='verification']/configOption[@name='load_system_certs'])" />
@@ -243,6 +282,7 @@
 				<xi:include xpointer="xpointer(/docs/configInfo[@name='res_stir_shaken']/configFile[@name='stir_shaken.conf']/configObject[@name='attestation']/configOption[@name='unknown_tn_attest_level'])" />
 				<xi:include xpointer="xpointer(/docs/configInfo[@name='res_stir_shaken']/configFile[@name='stir_shaken.conf']/configObject[@name='attestation']/configOption[@name='send_mky'])" />
 				<configOption name="endpoint_behavior" default="off">
+					<since><version>18.22.0</version><version>20.7.0</version><version>21.2.0</version></since>
 					<synopsis>Actions performed when an endpoint references this profile</synopsis>
 					<description>
 						<enumlist>

--- a/res/res_xmpp.c
+++ b/res/res_xmpp.c
@@ -276,11 +276,14 @@
 		<synopsis>XMPP Messaging</synopsis>
 		<configFile name="xmpp.conf">
 			<configObject name="global">
+				<since><version>12.0.0</version></since>
 				<synopsis>Global configuration settings</synopsis>
 				<configOption name="debug">
+					<since><version>11.0.0</version></since>
 					<synopsis>Enable/disable XMPP message debugging</synopsis>
 				</configOption>
 				<configOption name="autoprune">
+					<since><version>11.0.0</version></since>
 					<synopsis>Auto-remove users from buddy list.</synopsis>
 					<description><para>Auto-remove users from buddy list. Depending on the setup
 					(e.g., using your personal Gtalk account for a test) this could cause loss of
@@ -288,54 +291,71 @@
 					</para></description>
 				</configOption>
 				<configOption name="autoregister">
+					<since><version>11.0.0</version></since>
 					<synopsis>Auto-register users from buddy list</synopsis>
 				</configOption>
 				<configOption name="collection_nodes">
+					<since><version>11.0.0</version></since>
 					<synopsis>Enable support for XEP-0248 for use with distributed device state</synopsis>
 				</configOption>
 				<configOption name="pubsub_autocreate">
+					<since><version>11.0.0</version></since>
 					<synopsis>Whether or not the PubSub server supports/is using auto-create for nodes</synopsis>
 				</configOption>
 				<configOption name="auth_policy">
+					<since><version>11.0.0</version></since>
 					<synopsis>Whether to automatically accept or deny users' subscription requests</synopsis>
 				</configOption>
 			</configObject>
 			<configObject name="client">
+				<since><version>12.0.0</version></since>
 				<synopsis>Configuration options for an XMPP client</synopsis>
 				<configOption name="username">
+					<since><version>11.0.0</version></since>
 					<synopsis>XMPP username with optional resource</synopsis>
 				</configOption>
 				<configOption name="secret">
+					<since><version>11.0.0</version></since>
 					<synopsis>XMPP password</synopsis>
 				</configOption>
 				<configOption name="refresh_token">
+					<since><version>13.18.0</version><version>14.7.0</version><version>15.1.0</version></since>
 					<synopsis>Google OAuth 2.0 refresh token</synopsis>
 				</configOption>
 				<configOption name="oauth_clientid">
+					<since><version>13.18.0</version><version>14.7.0</version><version>15.1.0</version></since>
 					<synopsis>Google OAuth 2.0 application's client id</synopsis>
 				</configOption>
 				<configOption name="oauth_secret">
+					<since><version>13.18.0</version><version>14.7.0</version><version>15.1.0</version></since>
 					<synopsis>Google OAuth 2.0 application's secret</synopsis>
 				</configOption>
 				<configOption name="serverhost">
+					<since><version>11.0.0</version></since>
 					<synopsis>Route to server, e.g. talk.google.com</synopsis>
 				</configOption>
 				<configOption name="statusmessage">
+					<since><version>11.0.0</version></since>
 					<synopsis>Custom status message</synopsis>
 				</configOption>
 				<configOption name="pubsub_node">
+					<since><version>11.0.0</version></since>
 					<synopsis>Node for publishing events via PubSub</synopsis>
 				</configOption>
 				<configOption name="context">
+					<since><version>11.0.0</version></since>
 					<synopsis>Dialplan context to send incoming messages to</synopsis>
 				</configOption>
 				<configOption name="priority">
+					<since><version>11.0.0</version></since>
 					<synopsis>XMPP resource priority</synopsis>
 				</configOption>
 				<configOption name="port">
+					<since><version>11.0.0</version></since>
 					<synopsis>XMPP server port</synopsis>
 				</configOption>
 				<configOption name="timeout">
+					<since><version>11.0.0</version></since>
 					<synopsis>Timeout in seconds to hold incoming messages</synopsis>
 					<description><para>Timeout (in seconds) on the message stack. Messages stored longer
 					than this value will be deleted by Asterisk. This option applies to incoming messages only
@@ -343,27 +363,35 @@
 					</para></description>
 				</configOption>
 				<configOption name="debug">
+					<since><version>11.0.0</version></since>
 					<synopsis>Enable debugging</synopsis>
 				</configOption>
 				<configOption name="type">
+					<since><version>11.0.0</version></since>
 					<synopsis>Connection is either a client or a component</synopsis>
 				</configOption>
 				<configOption name="distribute_events">
+					<since><version>11.0.0</version></since>
 					<synopsis>Whether or not to distribute events using this connection</synopsis>
 				</configOption>
 				<configOption name="usetls">
+					<since><version>11.0.0</version></since>
 					<synopsis>Whether to use TLS for the connection or not</synopsis>
 				</configOption>
 				<configOption name="usesasl">
+					<since><version>11.0.0</version></since>
 					<synopsis>Whether to use SASL for the connection or not</synopsis>
 				</configOption>
 				<configOption name="forceoldssl">
+					<since><version>11.0.0</version></since>
 					<synopsis>Force the use of old-style SSL for the connection</synopsis>
 				</configOption>
 				<configOption name="keepalive">
+					<since><version>11.0.0</version></since>
 					<synopsis>If enabled, periodically send an XMPP message from this client with an empty message</synopsis>
 				</configOption>
 				<configOption name="autoprune">
+					<since><version>11.18.0</version><version>13.4.0</version></since>
 					<synopsis>Auto-remove users from buddy list.</synopsis>
 					<description><para>Auto-remove users from buddy list. Depending on the setup
 					(e.g., using your personal Gtalk account for a test) this could cause loss of
@@ -371,15 +399,19 @@
 					</para></description>
 				</configOption>
 				<configOption name="autoregister">
+					<since><version>11.18.0</version><version>13.4.0</version></since>
 					<synopsis>Auto-register users bfrom buddy list</synopsis>
 				</configOption>
 				<configOption name="auth_policy">
+					<since><version>11.18.0</version><version>13.4.0</version></since>
 					<synopsis>Whether to automatically accept or deny users' subscription requests</synopsis>
 				</configOption>
 				<configOption name="sendtodialplan">
+					<since><version>11.0.0</version></since>
 					<synopsis>Send incoming messages into the dialplan</synopsis>
 				</configOption>
 				<configOption name="status">
+					<since><version>11.0.0</version></since>
 					<synopsis>Default XMPP status for the client</synopsis>
 					<description><para>Can be one of the following XMPP statuses:</para>
 						<enumlist>
@@ -392,6 +424,7 @@
 					</description>
 				</configOption>
 				<configOption name="buddy">
+					<since><version>11.0.0</version></since>
 					<synopsis>Manual addition of buddy to list</synopsis>
 					<description><para>
 					Manual addition of buddy to the buddy list. For distributed events, these buddies are


### PR DESCRIPTION
Most of the configObjects and configOptions that are implemented with
ACO or Sorcery now have `<since>/<version>` elements added.  There are
probably some that the script I used didn't catch.  The version tags were
determined by the following...
 * Do a git blame on the API call that created the object or option.
 * From the commit hash, grab the summary line.
 * Do a `git log --grep <summary>` to find the cherry-pick commits in all
   branches that match.
 * Do a `git patch-id` to ensure the commits are all related and didn't get
   a false match on the summary.
 * Do a `git tag --contains <commit>` to find the tags that contain each
   commit.
 * Weed out all tags not <major>.<minor>.0.
 * Sort and discard any <major>.0.0 and following tags where the commit
   appeared in an earlier branch.
 * The result is a single tag for each branch where the API was last touched.

configObjects and configOptions elements implemented with the base
ast_config APIs were just not possible to find due to the non-deterministic
way they are accessed.

Also note that if the API call was on modified after it was added, the
version will be the one it was last modified in.

Final note:  The configObject and configOption elements were introduced in
12.0.0 so options created before then may not have any XML documentation.
