### PR TITLE
docs: Add version information to application and function XML elements

### DIFF
--- a/apps/app_adsiprog.c
+++ b/apps/app_adsiprog.c
@@ -57,6 +57,7 @@ static const char app[] = "ADSIProg";
 
 /*** DOCUMENTATION
 	<application name="ADSIProg" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Load Asterisk ADSI Scripts into phone
 		</synopsis>

--- a/apps/app_agent_pool.c
+++ b/apps/app_agent_pool.c
@@ -57,6 +57,7 @@
 
 /*** DOCUMENTATION
 	<application name="AgentLogin" language="en_US">
+		<since><version>12.0.0</version></since>
 		<synopsis>
 			Login an agent.
 		</synopsis>
@@ -105,6 +106,7 @@
 		</see-also>
 	</application>
 	<application name="AgentRequest" language="en_US">
+		<since><version>12.0.0</version></since>
 		<synopsis>
 			Request an agent to connect with the channel.
 		</synopsis>
@@ -130,6 +132,7 @@
 		</see-also>
 	</application>
 	<function name="AGENT" language="en_US">
+		<since><version>12.0.0</version></since>
 		<synopsis>
 			Gets information about an Agent
 		</synopsis>

--- a/apps/app_alarmreceiver.c
+++ b/apps/app_alarmreceiver.c
@@ -146,6 +146,7 @@ struct timeval call_start_time;
 static const char app[] = "AlarmReceiver";
 /*** DOCUMENTATION
 	<application name="AlarmReceiver" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Provide support for receiving alarm reports from a burglar or fire alarm panel.
 		</synopsis>

--- a/apps/app_amd.c
+++ b/apps/app_amd.c
@@ -54,6 +54,7 @@
 
 /*** DOCUMENTATION
 	<application name="AMD" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Attempt to detect answering machines.
 		</synopsis>

--- a/apps/app_attended_transfer.c
+++ b/apps/app_attended_transfer.c
@@ -40,6 +40,7 @@
 
 /*** DOCUMENTATION
 	<application name="AttendedTransfer" language="en_US">
+		<since><version>13.28.0</version><version>16.5.0</version></since>
 		<synopsis>
 			Attended transfer to the extension provided and TRANSFER_CONTEXT
 		</synopsis>

--- a/apps/app_audiosocket.c
+++ b/apps/app_audiosocket.c
@@ -48,6 +48,7 @@
 
 /*** DOCUMENTATION
 	<application name="AudioSocket" language="en_US">
+		<since><version>18.0.0</version></since>
 		<synopsis>
 			Transmit and receive audio between channel and TCP socket
 		</synopsis>

--- a/apps/app_authenticate.c
+++ b/apps/app_authenticate.c
@@ -58,6 +58,7 @@ AST_APP_OPTIONS(auth_app_options, {
 static const char app[] = "Authenticate";
 /*** DOCUMENTATION
 	<application name="Authenticate" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Authenticate a user
 		</synopsis>

--- a/apps/app_blind_transfer.c
+++ b/apps/app_blind_transfer.c
@@ -39,6 +39,7 @@
 
 /*** DOCUMENTATION
 	<application name="BlindTransfer" language="en_US">
+		<since><version>13.28.0</version><version>16.5.0</version></since>
 		<synopsis>
 			Blind transfer channel(s) to the extension and context provided
 		</synopsis>

--- a/apps/app_bridgeaddchan.c
+++ b/apps/app_bridgeaddchan.c
@@ -39,6 +39,7 @@
 
 /*** DOCUMENTATION
 	<application name="BridgeAdd" language="en_US">
+		<since><version>14.0.0</version></since>
 		<synopsis>
 			Join a bridge that contains the specified channel.
 		</synopsis>

--- a/apps/app_bridgewait.c
+++ b/apps/app_bridgewait.c
@@ -50,6 +50,7 @@
 
 /*** DOCUMENTATION
 	<application name="BridgeWait" language="en_US">
+		<since><version>12.0.0</version></since>
 		<synopsis>
 			Put a call into the holding bridge.
 		</synopsis>

--- a/apps/app_broadcast.c
+++ b/apps/app_broadcast.c
@@ -46,6 +46,7 @@
 
 /*** DOCUMENTATION
 	<application name="Broadcast" language="en_US">
+		<since><version>18.17.0</version><version>20.2.0</version></since>
 		<synopsis>
 			Transmit or receive audio to or from multiple channels simultaneously
 		</synopsis>

--- a/apps/app_cdr.c
+++ b/apps/app_cdr.c
@@ -59,6 +59,7 @@
 		</see-also>
 	</application>
 	<application name="ResetCDR" language="en_US">
+		<since><version>12.0.0</version></since>
 		<synopsis>
 			Resets the Call Data Record.
 		</synopsis>

--- a/apps/app_celgenuserevent.c
+++ b/apps/app_celgenuserevent.c
@@ -36,6 +36,7 @@
 
 /*** DOCUMENTATION
 	<application name="CELGenUserEvent" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Generates a CEL User Defined Event.
 		</synopsis>

--- a/apps/app_chanisavail.c
+++ b/apps/app_chanisavail.c
@@ -47,6 +47,7 @@ static const char app[] = "ChanIsAvail";
 
 /*** DOCUMENTATION
 	<application name="ChanIsAvail" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Check channel availability
 		</synopsis>

--- a/apps/app_channelredirect.c
+++ b/apps/app_channelredirect.c
@@ -39,6 +39,7 @@
 
 /*** DOCUMENTATION
 	<application name="ChannelRedirect" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Redirects given channel to a dialplan target
 		</synopsis>

--- a/apps/app_chanspy.c
+++ b/apps/app_chanspy.c
@@ -62,6 +62,7 @@
 
 /*** DOCUMENTATION
 	<application name="ChanSpy" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Listen to a channel, and optionally whisper into it.
 		</synopsis>
@@ -204,6 +205,7 @@
 		</see-also>
 	</application>
 	<application name="ExtenSpy" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Listen to a channel, and optionally whisper into it.
 		</synopsis>
@@ -351,6 +353,7 @@
 		</see-also>
 	</application>
 	<application name="DAHDIScan" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Scan DAHDI channels to monitor calls.
 		</synopsis>

--- a/apps/app_confbridge.c
+++ b/apps/app_confbridge.c
@@ -76,6 +76,7 @@
 
 /*** DOCUMENTATION
 	<application name="ConfBridge" language="en_US">
+		<since><version>12.0.0</version></since>
 		<synopsis>
 			Conference bridge application.
 		</synopsis>
@@ -135,7 +136,6 @@
 		<since>
 			<version>16.19.0</version>
 			<version>18.5.0</version>
-			<version>19.0.0</version>
 		</since>
 		<synopsis>
 			Kicks channel(s) from the requested ConfBridge.
@@ -169,6 +169,7 @@
 		</see-also>
 	</application>
 	<function name="CONFBRIDGE" language="en_US">
+		<since><version>10.0.0</version></since>
 		<synopsis>
 			Set a custom dynamic bridge, user, or menu profile on a channel for the
 			ConfBridge application using the same options available in confbridge.conf.
@@ -224,6 +225,7 @@
 		</description>
 	</function>
 	<function name="CONFBRIDGE_INFO" language="en_US">
+		<since><version>10.0.0</version></since>
 		<synopsis>
 			Get information about a ConfBridge conference.
 		</synopsis>
@@ -262,9 +264,9 @@
 	</function>
 	<function name="CONFBRIDGE_CHANNELS" language="en_US">
 		<since>
-			<version>16.26.0</version>
-			<version>18.12.0</version>
-			<version>19.4.0</version>
+			<version>16.27.0</version>
+			<version>18.13.0</version>
+			<version>19.5.0</version>
 		</since>
 		<synopsis>
 			Get a list of channels in a ConfBridge conference.

--- a/apps/app_controlplayback.c
+++ b/apps/app_controlplayback.c
@@ -40,6 +40,7 @@
 
 /*** DOCUMENTATION
 	<application name="ControlPlayback" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Play a file with fast forward and rewind.
 		</synopsis>

--- a/apps/app_db.c
+++ b/apps/app_db.c
@@ -43,6 +43,7 @@
 
 /*** DOCUMENTATION
 	<application name="DBdeltree" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Delete a family or keytree from the asterisk database.
 		</synopsis>

--- a/apps/app_dial.c
+++ b/apps/app_dial.c
@@ -70,6 +70,7 @@
 
 /*** DOCUMENTATION
 	<application name="Dial" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Attempt to connect to another device or endpoint and bridge the call.
 		</synopsis>
@@ -668,6 +669,7 @@
 		</see-also>
 	</application>
 	<application name="RetryDial" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Place a call, retrying on failure allowing an optional exit extension.
 		</synopsis>

--- a/apps/app_dictate.c
+++ b/apps/app_dictate.c
@@ -45,6 +45,7 @@
 
 /*** DOCUMENTATION
 	<application name="Dictate" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Virtual Dictation Machine.
 		</synopsis>

--- a/apps/app_directed_pickup.c
+++ b/apps/app_directed_pickup.c
@@ -49,6 +49,7 @@
 
 /*** DOCUMENTATION
 	<application name="Pickup" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Directed extension call pickup.
 		</synopsis>
@@ -91,6 +92,7 @@
 		</description>
 	</application>
 	<application name="PickupChan" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Pickup a ringing channel.
 		</synopsis>

--- a/apps/app_directory.c
+++ b/apps/app_directory.c
@@ -43,6 +43,7 @@
 
 /*** DOCUMENTATION
 	<application name="Directory" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Provide directory of voicemail extensions.
 		</synopsis>

--- a/apps/app_disa.c
+++ b/apps/app_disa.c
@@ -50,6 +50,7 @@
 
 /*** DOCUMENTATION
 	<application name="DISA" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Direct Inward System Access.
 		</synopsis>

--- a/apps/app_dtmfstore.c
+++ b/apps/app_dtmfstore.c
@@ -44,7 +44,6 @@
 		<since>
 			<version>16.20.0</version>
 			<version>18.6.0</version>
-			<version>19.0.0</version>
 		</since>
 		<synopsis>
 			Stores DTMF digits transmitted or received on a channel.

--- a/apps/app_dumpchan.c
+++ b/apps/app_dumpchan.c
@@ -43,6 +43,7 @@
 
 /*** DOCUMENTATION
 	<application name="DumpChan" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Dump Info About The Calling Channel.
 		</synopsis>

--- a/apps/app_echo.c
+++ b/apps/app_echo.c
@@ -37,6 +37,7 @@
 
 /*** DOCUMENTATION
 	<application name="Echo" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Echo media, DTMF back to the calling party
 		</synopsis>

--- a/apps/app_exec.c
+++ b/apps/app_exec.c
@@ -39,6 +39,7 @@
 
 /*** DOCUMENTATION
 	<application name="Exec" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Executes dialplan application.
 		</synopsis>
@@ -58,6 +59,7 @@
 		</description>
 	</application>
 	<application name="TryExec" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Executes dialplan application, always returning.
 		</synopsis>
@@ -88,6 +90,7 @@
 		</description>
 	</application>
 	<application name="ExecIf" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Executes dialplan application, conditionally.
 		</synopsis>

--- a/apps/app_externalivr.c
+++ b/apps/app_externalivr.c
@@ -52,6 +52,7 @@
 
 /*** DOCUMENTATION
 	<application name="ExternalIVR" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Interfaces with an external IVR application.
 		</synopsis>

--- a/apps/app_festival.c
+++ b/apps/app_festival.c
@@ -69,6 +69,7 @@
 
 /*** DOCUMENTATION
 	<application name="Festival" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Say text to the user.
 		</synopsis>

--- a/apps/app_flash.c
+++ b/apps/app_flash.c
@@ -44,6 +44,7 @@
 
 /*** DOCUMENTATION
 	<application name="Flash" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Flashes a DAHDI Trunk.
 		</synopsis>

--- a/apps/app_followme.c
+++ b/apps/app_followme.c
@@ -68,6 +68,7 @@
 
 /*** DOCUMENTATION
 	<application name="FollowMe" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Find-Me/Follow-Me application.
 		</synopsis>

--- a/apps/app_forkcdr.c
+++ b/apps/app_forkcdr.c
@@ -43,6 +43,7 @@
 
 /*** DOCUMENTATION
 	<application name="ForkCDR" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Forks the current Call Data Record for this channel.
 		</synopsis>

--- a/apps/app_getcpeid.c
+++ b/apps/app_getcpeid.c
@@ -41,6 +41,7 @@
 
 /*** DOCUMENTATION
 	<application name="GetCPEID" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Get ADSI CPE ID.
 		</synopsis>

--- a/apps/app_if.c
+++ b/apps/app_if.c
@@ -37,6 +37,7 @@
 
 /*** DOCUMENTATION
 	<application name="If" language="en_US">
+		<since><version>18.16.0</version><version>20.1.0</version></since>
 		<synopsis>
 			Start an if branch.
 		</synopsis>
@@ -57,6 +58,7 @@
 		</see-also>
 	</application>
 	<application name="ElseIf" language="en_US">
+		<since><version>18.16.0</version><version>20.1.0</version></since>
 		<synopsis>
 			Start an else if branch.
 		</synopsis>
@@ -78,6 +80,7 @@
 		</see-also>
 	</application>
 	<application name="Else" language="en_US">
+		<since><version>18.16.0</version><version>20.1.0</version></since>
 		<synopsis>
 			Define an optional else branch.
 		</synopsis>
@@ -96,6 +99,7 @@
 		</see-also>
 	</application>
 	<application name="EndIf" language="en_US">
+		<since><version>18.16.0</version><version>20.1.0</version></since>
 		<synopsis>
 			End an if branch.
 		</synopsis>
@@ -111,6 +115,7 @@
 		</see-also>
 	</application>
 	<application name="ExitIf" language="en_US">
+		<since><version>18.16.0</version><version>20.1.0</version></since>
 		<synopsis>
 			End an If branch.
 		</synopsis>

--- a/apps/app_ivrdemo.c
+++ b/apps/app_ivrdemo.c
@@ -41,6 +41,7 @@
 
 /*** DOCUMENTATION
 	<application name="IVRDemo" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			IVR Demo Application.
 		</synopsis>

--- a/apps/app_jack.c
+++ b/apps/app_jack.c
@@ -76,6 +76,7 @@
 "                name.  Use this option to specify a custom client name.\n"
 /*** DOCUMENTATION
 	<application name="JACK" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Jack Audio Connection Kit
 		</synopsis>

--- a/apps/app_meetme.c
+++ b/apps/app_meetme.c
@@ -83,6 +83,7 @@
 
 /*** DOCUMENTATION
 	<application name="MeetMe" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			MeetMe conference bridge.
 		</synopsis>
@@ -267,6 +268,7 @@
 		</see-also>
 	</application>
 	<application name="MeetMeCount" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			MeetMe participant count.
 		</synopsis>
@@ -288,6 +290,7 @@
 		</see-also>
 	</application>
 	<application name="MeetMeAdmin" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			MeetMe conference administration.
 		</synopsis>
@@ -385,6 +388,7 @@
 		</see-also>
 	</application>
 	<application name="MeetMeChannelAdmin" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			MeetMe conference Administration (channel specific).
 		</synopsis>
@@ -471,6 +475,7 @@
 		</description>
 	</application>
 	<function name="MEETME_INFO" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Query a given conference of various properties.
 		</synopsis>

--- a/apps/app_mf.c
+++ b/apps/app_mf.c
@@ -43,9 +43,8 @@
 /*** DOCUMENTATION
 	<application name="ReceiveMF" language="en_US">
 		<since>
-			<version>16.21.0</version>
-			<version>18.7.0</version>
-			<version>19.0.0</version>
+			<version>16.24.0</version>
+			<version>18.10.0</version>
 		</since>
 		<synopsis>
 			Detects MF digits on a channel and saves them to a variable.
@@ -121,7 +120,6 @@
 		<since>
 			<version>16.21.0</version>
 			<version>18.7.0</version>
-			<version>19.0.0</version>
 		</since>
 		<synopsis>
 			Sends arbitrary MF digits on the current or specified channel.

--- a/apps/app_milliwatt.c
+++ b/apps/app_milliwatt.c
@@ -39,6 +39,7 @@
 
 /*** DOCUMENTATION
 	<application name="Milliwatt" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Generates a 1004 Hz test tone at 0dbm (mu-law).
 		</synopsis>

--- a/apps/app_minivm.c
+++ b/apps/app_minivm.c
@@ -183,6 +183,7 @@
 
 /*** DOCUMENTATION
 <application name="MinivmRecord" language="en_US">
+    <since><version>1.8.0</version></since>
 	<synopsis>
 		Receive Mini-Voicemail and forward via e-mail.
 	</synopsis>
@@ -233,6 +234,7 @@
 	</description>
 </application>
 <application name="MinivmGreet" language="en_US">
+    <since><version>1.8.0</version></since>
 	<synopsis>
 		Play Mini-Voicemail prompts.
 	</synopsis>
@@ -275,6 +277,7 @@
 	</description>
 </application>
 <application name="MinivmNotify" language="en_US">
+    <since><version>1.8.0</version></since>
 	<synopsis>
 		Notify voicemail owner about new messages.
 	</synopsis>
@@ -314,6 +317,7 @@
 	</description>
 </application>
 <application name="MinivmDelete" language="en_US">
+    <since><version>1.8.0</version></since>
 	<synopsis>
 		Delete Mini-Voicemail voicemail messages.
 	</synopsis>
@@ -336,6 +340,7 @@
 </application>
 
 <application name="MinivmAccMess" language="en_US">
+    <since><version>1.8.0</version></since>
 	<synopsis>
 		Record account specific messages.
 	</synopsis>
@@ -381,6 +386,7 @@
 	</description>
 </application>
 <application name="MinivmMWI" language="en_US">
+    <since><version>1.8.0</version></since>
 	<synopsis>
 		Send Message Waiting Notification to subscriber(s) of mailbox.
 	</synopsis>
@@ -410,6 +416,7 @@
 	</description>
 </application>
 <function name="MINIVMCOUNTER" language="en_US">
+    <since><version>1.8.0</version></since>
 	<synopsis>
 		Reads or sets counters for MiniVoicemail message.
 	</synopsis>
@@ -444,6 +451,7 @@
 	</see-also>
 </function>
 <function name="MINIVMACCOUNT" language="en_US">
+    <since><version>1.8.0</version></since>
 	<synopsis>
 		Gets MiniVoicemail account information.
 	</synopsis>

--- a/apps/app_mixmonitor.c
+++ b/apps/app_mixmonitor.c
@@ -63,6 +63,7 @@
 
 /*** DOCUMENTATION
 	<application name="MixMonitor" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Record a call and mix the audio during the recording.  Use of StopMixMonitor is required
 			to guarantee the audio file is available for processing during dialplan execution.
@@ -195,6 +196,7 @@
 		</see-also>
 	</application>
 	<application name="StopMixMonitor" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Stop recording a call through MixMonitor, and free the recording's file handle.
 		</synopsis>
@@ -304,6 +306,7 @@
 		</description>
 	</manager>
 	<function name="MIXMONITOR" language="en_US">
+		<since><version>13.0.0</version></since>
 		<synopsis>
 			Retrieve data pertaining to specific instances of MixMonitor on a channel.
 		</synopsis>

--- a/apps/app_morsecode.c
+++ b/apps/app_morsecode.c
@@ -41,6 +41,7 @@
 
 /*** DOCUMENTATION
 	<application name="Morsecode" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Plays morse code.
 		</synopsis>

--- a/apps/app_mp3.c
+++ b/apps/app_mp3.c
@@ -53,6 +53,7 @@
 
 /*** DOCUMENTATION
 	<application name="MP3Player" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Play an MP3 file or M3U playlist file or stream.
 		</synopsis>

--- a/apps/app_originate.c
+++ b/apps/app_originate.c
@@ -46,6 +46,7 @@ static const char app_originate[] = "Originate";
 
 /*** DOCUMENTATION
 	<application name="Originate" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Originate a call.
 		</synopsis>

--- a/apps/app_page.c
+++ b/apps/app_page.c
@@ -44,6 +44,7 @@
 
 /*** DOCUMENTATION
 	<application name="Page" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Page series of phones
 		</synopsis>

--- a/apps/app_playback.c
+++ b/apps/app_playback.c
@@ -43,6 +43,7 @@
 
 /*** DOCUMENTATION
 	<application name="Playback" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Play a file.
 		</synopsis>

--- a/apps/app_playtones.c
+++ b/apps/app_playtones.c
@@ -41,6 +41,7 @@ static const char stopplaytones_app[] = "StopPlayTones";
 
 /*** DOCUMENTATION
 	<application name="PlayTones" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Play a tone list.
 		</synopsis>
@@ -61,6 +62,7 @@ static const char stopplaytones_app[] = "StopPlayTones";
 		</see-also>
 	</application>
 	<application name="StopPlayTones" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Stop playing a tone list.
 		</synopsis>

--- a/apps/app_privacy.c
+++ b/apps/app_privacy.c
@@ -44,6 +44,7 @@
 
 /*** DOCUMENTATION
 	<application name="PrivacyManager" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Require phone number to be entered, if no CallerID sent
 		</synopsis>

--- a/apps/app_queue.c
+++ b/apps/app_queue.c
@@ -126,6 +126,7 @@
 
 /*** DOCUMENTATION
 	<application name="Queue" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Queue a call for a call queue.
 		</synopsis>
@@ -331,6 +332,7 @@
 		</see-also>
 	</application>
 	<application name="AddQueueMember" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Dynamically adds queue members.
 		</synopsis>
@@ -384,6 +386,7 @@
 		</see-also>
 	</application>
 	<application name="RemoveQueueMember" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Dynamically removes queue members.
 		</synopsis>
@@ -424,6 +427,7 @@
 		</see-also>
 	</application>
 	<application name="PauseQueueMember" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Pauses a queue member.
 		</synopsis>
@@ -471,6 +475,7 @@
 		</see-also>
 	</application>
 	<application name="UnpauseQueueMember" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Unpauses a queue member.
 		</synopsis>
@@ -515,6 +520,7 @@
 		</see-also>
 	</application>
 	<application name="QueueLog" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Writes to the queue_log file.
 		</synopsis>
@@ -549,6 +555,7 @@
 		</see-also>
 	</application>
 	<application name="QueueUpdate" language="en_US">
+		<since><version>15.0.0</version></since>
 		<synopsis>
 			Writes to the queue_log file for outbound calls and updates Realtime Data.
 			Is used at h extension to be able to have all the parameters.
@@ -569,6 +576,7 @@
 		</description>
 	</application>
 	<function name="QUEUE_VARIABLES" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Return Queue information in variables.
 		</synopsis>
@@ -624,6 +632,7 @@
 		</see-also>
 	</function>
 	<function name="QUEUE_MEMBER" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Provides a count of queue members based on the provided criteria, or updates a
 			queue member's settings.
@@ -689,6 +698,7 @@
 		</see-also>
 	</function>
 	<function name="QUEUE_MEMBER_COUNT" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Count number of members answering a queue.
 		</synopsis>
@@ -717,6 +727,7 @@
 		</see-also>
 	</function>
 	<function name="QUEUE_EXISTS" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Check if a named queue exists on this server
 		</synopsis>
@@ -744,6 +755,7 @@
 		</see-also>
 	</function>
 	<function name="QUEUE_GET_CHANNEL" language="en_US">
+		<since><version>14.0.0</version></since>
 		<synopsis>
 			Return caller at the specified position in a queue.
 		</synopsis>
@@ -772,6 +784,7 @@
 		</see-also>
 	</function>
 	<function name="QUEUE_WAITING_COUNT" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Count number of calls currently waiting in a queue.
 		</synopsis>
@@ -799,6 +812,7 @@
 		</see-also>
 	</function>
 	<function name="QUEUE_MEMBER_LIST" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Returns a list of interfaces on a queue.
 		</synopsis>
@@ -826,6 +840,7 @@
 		</see-also>
 	</function>
 	<function name="QUEUE_MEMBER_PENALTY" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Gets or sets queue members penalty.
 		</synopsis>

--- a/apps/app_read.c
+++ b/apps/app_read.c
@@ -40,6 +40,7 @@
 
 /*** DOCUMENTATION
 	<application name="Read" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Read a variable.
 		</synopsis>

--- a/apps/app_readexten.c
+++ b/apps/app_readexten.c
@@ -39,6 +39,7 @@
 
 /*** DOCUMENTATION
 	<application name="ReadExten" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Read an extension into a variable.
 		</synopsis>

--- a/apps/app_record.c
+++ b/apps/app_record.c
@@ -42,6 +42,7 @@
 
 /*** DOCUMENTATION
 	<application name="Record" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Record to a file.
 		</synopsis>

--- a/apps/app_reload.c
+++ b/apps/app_reload.c
@@ -42,7 +42,6 @@
 		<since>
 			<version>16.20.0</version>
 			<version>18.6.0</version>
-			<version>19.0.0</version>
 		</since>
 		<synopsis>
 			Reloads an Asterisk module, blocking the channel until the reload has completed.

--- a/apps/app_saycounted.c
+++ b/apps/app_saycounted.c
@@ -31,6 +31,7 @@
 
 /*** DOCUMENTATION
 	<application name="SayCountedNoun" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Say a noun in declined form in order to count things
 		</synopsis>
@@ -71,6 +72,7 @@
 		</see-also>
 	</application>
 	<application name="SayCountedAdj" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Say a adjective in declined form in order to count things
 		</synopsis>

--- a/apps/app_sayunixtime.c
+++ b/apps/app_sayunixtime.c
@@ -40,6 +40,7 @@
 
 /*** DOCUMENTATION
 	<application name="SayUnixTime" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Says a specified time in a custom format.
 		</synopsis>
@@ -76,6 +77,7 @@
 		</see-also>
 	</application>
 	<application name="DateTime" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Says a specified time in a custom format.
 		</synopsis>

--- a/apps/app_senddtmf.c
+++ b/apps/app_senddtmf.c
@@ -39,6 +39,7 @@
 
 /*** DOCUMENTATION
 	<application name="SendDTMF" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Sends arbitrary DTMF digits
 		</synopsis>

--- a/apps/app_sendtext.c
+++ b/apps/app_sendtext.c
@@ -43,6 +43,7 @@
 
 /*** DOCUMENTATION
 	<application name="SendText" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Send a Text Message on a channel.
 		</synopsis>

--- a/apps/app_signal.c
+++ b/apps/app_signal.c
@@ -40,6 +40,7 @@
 
 /*** DOCUMENTATION
 	<application name="Signal" language="en_US">
+		<since><version>18.17.0</version><version>20.2.0</version></since>
 		<synopsis>
 			Sends a signal to any waiting channels.
 		</synopsis>
@@ -76,6 +77,7 @@
 		</see-also>
 	</application>
 	<application name="WaitForSignal" language="en_US">
+		<since><version>18.17.0</version><version>20.2.0</version></since>
 		<synopsis>
 			Waits for a named signal on a channel.
 		</synopsis>

--- a/apps/app_skel.c
+++ b/apps/app_skel.c
@@ -63,6 +63,7 @@
 
 /*** DOCUMENTATION
 	<application name="SkelGuessNumber" language="en_US">
+		<since><version>11.0.0</version></since>
 		<synopsis>
 			An example number guessing game
 		</synopsis>

--- a/apps/app_sms.c
+++ b/apps/app_sms.c
@@ -58,6 +58,7 @@
 
 /*** DOCUMENTATION
 	<application name="SMS" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Communicates with SMS service centres and SMS capable analogue phones.
 		</synopsis>

--- a/apps/app_softhangup.c
+++ b/apps/app_softhangup.c
@@ -40,6 +40,7 @@
 
 /*** DOCUMENTATION
 	<application name="SoftHangup" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Hangs up the requested channel.
 		</synopsis>

--- a/apps/app_speech_utils.c
+++ b/apps/app_speech_utils.c
@@ -42,6 +42,7 @@
 
 /*** DOCUMENTATION
 	<application name="SpeechCreate" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Create a Speech Structure.
 		</synopsis>
@@ -56,6 +57,7 @@
 		</description>
 	</application>
 	<application name="SpeechActivateGrammar" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Activate a grammar.
 		</synopsis>
@@ -70,6 +72,7 @@
 		</description>
 	</application>
 	<application name="SpeechStart" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Start recognizing voice in the audio stream.
 		</synopsis>
@@ -81,6 +84,7 @@
 		</description>
 	</application>
 	<application name="SpeechBackground" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Play a sound file and wait for speech to be recognized.
 		</synopsis>
@@ -124,6 +128,7 @@
 		</description>
 	</application>
 	<application name="SpeechDeactivateGrammar" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Deactivate a grammar.
 		</synopsis>
@@ -138,6 +143,7 @@
 		</description>
 	</application>
 	<application name="SpeechProcessingSound" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Change background processing sound.
 		</synopsis>
@@ -151,6 +157,7 @@
 		</description>
 	</application>
 	<application name="SpeechDestroy" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			End speech recognition.
 		</synopsis>
@@ -163,6 +170,7 @@
 		</description>
 	</application>
 	<application name="SpeechLoadGrammar" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Load a grammar.
 		</synopsis>
@@ -176,6 +184,7 @@
 		</description>
 	</application>
 	<application name="SpeechUnloadGrammar" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Unload a grammar.
 		</synopsis>
@@ -188,6 +197,7 @@
 		</description>
 	</application>
 	<function name="SPEECH_SCORE" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Gets the confidence score of a result.
 		</synopsis>
@@ -200,6 +210,7 @@
 		</description>
 	</function>
 	<function name="SPEECH_TEXT" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Gets the recognized text of a result.
 		</synopsis>
@@ -212,6 +223,7 @@
 		</description>
 	</function>
 	<function name="SPEECH_GRAMMAR" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Gets the matched grammar of a result if available.
 		</synopsis>
@@ -224,6 +236,7 @@
 		</description>
 	</function>
 	<function name="SPEECH_ENGINE" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Get or change a speech engine specific attribute.
 		</synopsis>
@@ -235,6 +248,7 @@
 		</description>
 	</function>
 	<function name="SPEECH_RESULTS_TYPE" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Sets the type of results that will be returned.
 		</synopsis>
@@ -244,6 +258,7 @@
 		</description>
 	</function>
 	<function name="SPEECH" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Gets information about speech recognition results.
 		</synopsis>

--- a/apps/app_stack.c
+++ b/apps/app_stack.c
@@ -42,6 +42,7 @@
 
 /*** DOCUMENTATION
 	<application name="Gosub" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Jump to label, saving return address.
 		</synopsis>
@@ -65,6 +66,7 @@
 		</see-also>
 	</application>
 	<application name="GosubIf" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Conditionally jump to label, saving return address.
 		</synopsis>
@@ -100,6 +102,7 @@
 		</see-also>
 	</application>
 	<application name="Return" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Return from gosub routine.
 		</synopsis>
@@ -118,6 +121,7 @@
 		</see-also>
 	</application>
 	<application name="StackPop" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Remove one address from gosub stack.
 		</synopsis>
@@ -131,6 +135,7 @@
 		</see-also>
 	</application>
 	<function name="LOCAL" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Manage variables local to the gosub stack frame.
 		</synopsis>
@@ -148,6 +153,7 @@
 		</see-also>
 	</function>
 	<function name="LOCAL_PEEK" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Retrieve variables hidden by the local gosub stack frame.
 		</synopsis>
@@ -170,6 +176,7 @@
 		</see-also>
 	</function>
 	<function name="STACK_PEEK" language="en_US">
+		<since><version>10.3.0</version></since>
 		<synopsis>
 			View info about the location which called Gosub
 		</synopsis>

--- a/apps/app_stasis.c
+++ b/apps/app_stasis.c
@@ -38,6 +38,7 @@
 
 /*** DOCUMENTATION
 	<application name="Stasis" language="en_US">
+		<since><version>12.0.0</version></since>
 		<synopsis>Invoke an external Stasis application.</synopsis>
 		<syntax>
 			<parameter name="app_name" required="true">

--- a/apps/app_statsd.c
+++ b/apps/app_statsd.c
@@ -35,6 +35,7 @@
 
 /*** DOCUMENTATION
 	<application name="StatsD" language="en_US">
+		<since><version>13.20.0</version><version>15.3.0</version></since>
 		<synopsis>
 			Allow statistics to be passed to the StatsD server from the dialplan.
 		</synopsis>

--- a/apps/app_stream_echo.c
+++ b/apps/app_stream_echo.c
@@ -38,6 +38,7 @@
 
 /*** DOCUMENTATION
 	<application name="StreamEcho" language="en_US">
+		<since><version>15.0.0</version></since>
 		<synopsis>
 			Echo media, up to 'N' streams of a type, and DTMF back to the calling party
 		</synopsis>

--- a/apps/app_system.c
+++ b/apps/app_system.c
@@ -40,6 +40,7 @@
 
 /*** DOCUMENTATION
 	<application name="System" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Execute a system command.
 		</synopsis>
@@ -70,6 +71,7 @@
 		</description>
 	</application>
 	<application name="TrySystem" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Try executing a system command.
 		</synopsis>

--- a/apps/app_talkdetect.c
+++ b/apps/app_talkdetect.c
@@ -45,6 +45,7 @@
 
 /*** DOCUMENTATION
 	<application name="BackgroundDetect" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Background a file with talk detect.
 		</synopsis>

--- a/apps/app_test.c
+++ b/apps/app_test.c
@@ -46,6 +46,7 @@
 
 /*** DOCUMENTATION
 	<application name="TestServer" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Execute Interface Test Server.
 		</synopsis>
@@ -59,6 +60,7 @@
 		</see-also>
 	</application>
 	<application name="TestClient" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Execute Interface Test Client.
 		</synopsis>

--- a/apps/app_transfer.c
+++ b/apps/app_transfer.c
@@ -40,6 +40,7 @@
 
 /*** DOCUMENTATION
 	<application name="Transfer" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Transfer caller to remote extension.
 		</synopsis>

--- a/apps/app_userevent.c
+++ b/apps/app_userevent.c
@@ -36,6 +36,7 @@
 
 /*** DOCUMENTATION
 	<application name="UserEvent" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Send an arbitrary user-defined event to parties interested in a channel (AMI users and relevant res_stasis applications).
 		</synopsis>

--- a/apps/app_verbose.c
+++ b/apps/app_verbose.c
@@ -40,6 +40,7 @@ static char *app_log = "Log";
 
 /*** DOCUMENTATION
 	<application name="Verbose" language="en_US">
+		<since><version>1.8.0</version></since>
  		<synopsis>
 			Send arbitrary text to verbose output.
 		</synopsis>
@@ -56,6 +57,7 @@ static char *app_log = "Log";
 		</description>
 	</application>
 	<application name="Log" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Send arbitrary text to a selected log level.
 		</synopsis>

--- a/apps/app_voicemail.c
+++ b/apps/app_voicemail.c
@@ -111,6 +111,7 @@
 
 /*** DOCUMENTATION
 	<application name="VoiceMail" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Leave a Voicemail message.
 		</synopsis>
@@ -200,6 +201,7 @@
 		</see-also>
 	</application>
 	<application name="VoiceMailMain" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Check Voicemail messages.
 		</synopsis>
@@ -265,6 +267,7 @@
 		</see-also>
 	</application>
 	<application name="VMAuthenticate" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Authenticate with Voicemail passwords.
 		</synopsis>
@@ -297,6 +300,7 @@
 		</description>
 	</application>
 	<application name="VoiceMailPlayMsg" language="en_US">
+		<since><version>11.0.0</version></since>
 		<synopsis>
 			Play a single voice mail msg from a mailbox by msg id.
 		</synopsis>
@@ -321,6 +325,7 @@
 		</description>
 	</application>
 	<application name="VMSayName" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Play the name of a voicemail user
 		</synopsis>
@@ -339,6 +344,7 @@
 		</description>
 	</application>
 	<function name="VM_INFO" language="en_US">
+		<since><version>11.0.0</version></since>
 		<synopsis>
 			Returns the selected attribute from a mailbox.
 		</synopsis>

--- a/apps/app_waitforcond.c
+++ b/apps/app_waitforcond.c
@@ -42,7 +42,6 @@
 		<since>
 			<version>16.20.0</version>
 			<version>18.6.0</version>
-			<version>19.0.0</version>
 		</since>
 		<synopsis>
 			Wait (sleep) until the given condition is true.

--- a/apps/app_waitforring.c
+++ b/apps/app_waitforring.c
@@ -39,6 +39,7 @@
 
 /*** DOCUMENTATION
 	<application name="WaitForRing" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Wait for Ring Application.
 		</synopsis>

--- a/apps/app_waitforsilence.c
+++ b/apps/app_waitforsilence.c
@@ -51,6 +51,7 @@
 
 /*** DOCUMENTATION
 	<application name="WaitForSilence" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Waits for a specified amount of silence.
 		</synopsis>
@@ -101,6 +102,7 @@
 		</see-also>
 	</application>
 	<application name="WaitForNoise" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Waits for a specified amount of noise.
 		</synopsis>

--- a/apps/app_waituntil.c
+++ b/apps/app_waituntil.c
@@ -38,6 +38,7 @@
 
 /*** DOCUMENTATION
 	<application name="WaitUntil" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Wait (sleep) until the current time is the given epoch.
 		</synopsis>

--- a/apps/app_while.c
+++ b/apps/app_while.c
@@ -37,6 +37,7 @@
 
 /*** DOCUMENTATION
 	<application name="While" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Start a while loop.
 		</synopsis>
@@ -54,6 +55,7 @@
 		</see-also>
 	</application>
 	<application name="EndWhile" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			End a while loop.
 		</synopsis>
@@ -68,6 +70,7 @@
 		</see-also>
 	</application>
 	<application name="ExitWhile" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			End a While loop.
 		</synopsis>
@@ -82,6 +85,7 @@
 		</see-also>
 	</application>
 	<application name="ContinueWhile" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Restart a While loop.
 		</synopsis>

--- a/apps/app_zapateller.c
+++ b/apps/app_zapateller.c
@@ -41,6 +41,7 @@
 
 /*** DOCUMENTATION
 	<application name="Zapateller" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Block telemarketers with SIT.
 		</synopsis>

--- a/channels/chan_dahdi.c
+++ b/channels/chan_dahdi.c
@@ -131,6 +131,7 @@
 
 /*** DOCUMENTATION
 	<application name="DAHDISendKeypadFacility" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Send digits out of band over a PRI.
 		</synopsis>
@@ -143,6 +144,7 @@
 		</description>
 	</application>
 	<application name="DAHDISendCallreroutingFacility" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Send an ISDN call rerouting/deflection facility message.
 		</synopsis>
@@ -164,6 +166,7 @@
 		</description>
 	</application>
 	<application name="DAHDIAcceptR2Call" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Accept an R2 call if its not already accepted (you still need to answer it)
 		</synopsis>
@@ -178,6 +181,7 @@
 		</description>
 	</application>
 	<function name="POLARITY" language="en_US">
+		<since><version>16.28.0</version><version>18.14.0</version><version>19.6.0</version></since>
 		<synopsis>
 			Set or get the polarity of a DAHDI channel.
 		</synopsis>

--- a/channels/chan_iax2.c
+++ b/channels/chan_iax2.c
@@ -125,6 +125,7 @@
 
 /*** DOCUMENTATION
 	<application name="IAX2Provision" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Provision a calling IAXy with a given template.
 		</synopsis>
@@ -140,6 +141,7 @@
 		</description>
 	</application>
 	<function name="IAXPEER" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Gets IAX peer information.
 		</synopsis>
@@ -194,6 +196,7 @@
 		</description>
 	</function>
 	<function name="IAXVAR" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Sets or retrieves a remote variable.
 		</synopsis>

--- a/channels/pjsip/dialplan_functions_doc.xml
+++ b/channels/pjsip/dialplan_functions_doc.xml
@@ -2,6 +2,7 @@
 <!DOCTYPE docs SYSTEM "appdocsxml.dtd">
 <docs xmlns:xi="http://www.w3.org/2001/XInclude">
 	<application name="PJSIPHangup" language="en_US">
+		<since><version>18.21.0</version><version>20.6.0</version><version>21.1.0</version></since>
 		<synopsis>
 			Hangup an incoming PJSIP channel with a SIP response code
 		</synopsis>
@@ -56,6 +57,7 @@
 	</application>
 
 	<application name="PJSIPNotify" language="en_US">
+		<since><version>18.25.0</version><version>20.10.0</version><version>21.5.0</version></since>
 		<synopsis>
 			Send a NOTIFY to either an arbitrary URI, or inside a SIP dialog.
 		</synopsis>
@@ -147,6 +149,7 @@
 	</manager>
 
 	<function name="PJSIP_DIAL_CONTACTS" language="en_US">
+		<since><version>12.0.0</version></since>
 		<synopsis>
 			Return a dial string for dialing all contacts on an AOR.
 		</synopsis>
@@ -166,6 +169,7 @@
 		</description>
 	</function>
 	<function name="PJSIP_MEDIA_OFFER" language="en_US">
+		<since><version>12.0.0</version></since>
 		<synopsis>
 			Media and codec offerings to be set on an outbound SIP channel prior to dialing.
 		</synopsis>
@@ -197,7 +201,6 @@
 			<version>13.18.0</version>
 			<version>14.7.0</version>
 			<version>15.1.0</version>
-			<version>16.0.0</version>
 		</since>
 		<synopsis>
 			Get or change the DTMF mode for a SIP call.
@@ -211,6 +214,7 @@
 		</description>
 	</function>
 	<function name="PJSIP_MOH_PASSTHROUGH" language="en_US">
+		<since><version>13.30.0</version><version>16.7.0</version><version>17.1.0</version></since>
 		<synopsis>
 			Get or change the on-hold behavior for a SIP call.
 		</synopsis>
@@ -227,7 +231,6 @@
 		<since>
 			<version>13.12.0</version>
 			<version>14.1.0</version>
-			<version>15.0.0</version>
 		</since>
 		<synopsis>
 			W/O: Initiate a session refresh via an UPDATE or re-INVITE on an established media session
@@ -273,7 +276,6 @@
 		<since>
 			<version>13.24.0</version>
 			<version>16.1.0</version>
-			<version>17.0.0</version>
 		</since>
 		<synopsis>
 			Parse a URI and return a type part of the URI.

--- a/funcs/func_aes.c
+++ b/funcs/func_aes.c
@@ -39,6 +39,7 @@
 
 /*** DOCUMENTATION
 	<function name="AES_ENCRYPT" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Encrypt a string with AES given a 16 character key.
 		</synopsis>
@@ -60,6 +61,7 @@
 		</see-also>
 	</function>
 	<function name="AES_DECRYPT" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Decrypt a string encoded in base64 with AES given a 16 character key.
 		</synopsis>

--- a/funcs/func_base64.c
+++ b/funcs/func_base64.c
@@ -35,6 +35,7 @@
 
 /*** DOCUMENTATION
 	<function name="BASE64_ENCODE" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Encode a string in base64.
 		</synopsis>
@@ -53,6 +54,7 @@
 		</see-also>
 	</function>
 	<function name="BASE64_DECODE" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Decode a base64 string.
 		</synopsis>

--- a/funcs/func_blacklist.c
+++ b/funcs/func_blacklist.c
@@ -39,6 +39,7 @@
 
 /*** DOCUMENTATION
 	<function name="BLACKLIST" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Check if the callerid is on the blacklist.
 		</synopsis>

--- a/funcs/func_callcompletion.c
+++ b/funcs/func_callcompletion.c
@@ -34,6 +34,7 @@
 
 /*** DOCUMENTATION
 	<function name="CALLCOMPLETION" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Get or set a call completion configuration parameter for a channel.
 		</synopsis>

--- a/funcs/func_callerid.c
+++ b/funcs/func_callerid.c
@@ -70,6 +70,7 @@
  */
 /*** DOCUMENTATION
 	<function name="CALLERID" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Gets or sets Caller*ID data on the channel.
 		</synopsis>
@@ -202,6 +203,7 @@
 		</description>
 	</function>
 	<function name="CONNECTEDLINE" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Gets or sets Connected Line data on the channel.
 		</synopsis>
@@ -299,6 +301,7 @@
 		</description>
 	</function>
 	<function name="REDIRECTING" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Gets or sets Redirecting data on the channel.
 		</synopsis>

--- a/funcs/func_cdr.c
+++ b/funcs/func_cdr.c
@@ -42,6 +42,7 @@
 
 /*** DOCUMENTATION
 	<function name="CDR" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Gets or sets a CDR variable.
 		</synopsis>
@@ -167,6 +168,7 @@
 		</description>
 	</function>
 	<function name="CDR_PROP" language="en_US">
+		<since><version>12.0.0</version></since>
 		<synopsis>
 			Set a property on a channel's CDR.
 		</synopsis>

--- a/funcs/func_channel.c
+++ b/funcs/func_channel.c
@@ -49,6 +49,7 @@
 
 /*** DOCUMENTATION
 	<function name="CHANNELS" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Gets the list of channels, optionally filtering by a regular expression.
 		</synopsis>
@@ -67,7 +68,6 @@
 		<since>
 			<version>16.22.0</version>
 			<version>18.8.0</version>
-			<version>19.0.0</version>
 		</since>
 		<synopsis>
 			Checks if the specified channel exists.
@@ -82,6 +82,7 @@
 		</description>
 	</function>
 	<function name="MASTER_CHANNEL" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Gets or sets variables on the master channel
 		</synopsis>
@@ -94,6 +95,7 @@
 		</description>
 	</function>
 	<function name="CHANNEL" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Gets/sets various pieces of information about the channel.
 		</synopsis>

--- a/funcs/func_config.c
+++ b/funcs/func_config.c
@@ -40,6 +40,7 @@
 
 /*** DOCUMENTATION
 	<function name="AST_CONFIG" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Retrieve a variable from a configuration file.
 		</synopsis>

--- a/funcs/func_curl.c
+++ b/funcs/func_curl.c
@@ -53,6 +53,7 @@
 
 /*** DOCUMENTATION
 	<function name="CURL" language="en_US">
+		<since><version>10.0.0</version></since>
 		<synopsis>
 			Retrieve content from a remote web or ftp server
 		</synopsis>
@@ -95,6 +96,7 @@
 		</see-also>
 	</function>
 	<function name="CURLOPT" language="en_US">
+		<since><version>10.0.0</version></since>
 		<synopsis>
 			Sets various options for future invocations of CURL.
 		</synopsis>

--- a/funcs/func_cut.c
+++ b/funcs/func_cut.c
@@ -38,6 +38,7 @@
 
 /*** DOCUMENTATION
 	<function name="SORT" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Sorts a list of key/vals into a list of keys, based upon the vals.
 		</synopsis>
@@ -58,6 +59,7 @@
 		</description>
 	</function>
 	<function name="CUT" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Slices and dices strings, based upon a named delimiter.
 		</synopsis>

--- a/funcs/func_db.c
+++ b/funcs/func_db.c
@@ -44,6 +44,7 @@
 
 /*** DOCUMENTATION
 	<function name="DB" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Read from or write to the Asterisk database.
 		</synopsis>
@@ -66,6 +67,7 @@
 		</see-also>
 	</function>
 	<function name="DB_EXISTS" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Check to see if a key exists in the Asterisk database.
 		</synopsis>
@@ -84,6 +86,7 @@
 		</see-also>
 	</function>
 	<function name="DB_KEYS" language="en_US">
+		<since><version>10.0.0</version></since>
 		<synopsis>
 			Obtain a list of keys within the Asterisk database.
 		</synopsis>
@@ -100,6 +103,7 @@
 		</see-also>
 	</function>
 	<function name="DB_KEYCOUNT" language="en_US">
+		<since><version>16.26.0</version><version>18.12.0</version><version>19.4.0</version></since>
 		<synopsis>
 			Obtain the number of keys at a prefix within the Asterisk database.
 		</synopsis>
@@ -116,6 +120,7 @@
 		</see-also>
 	</function>
 	<function name="DB_DELETE" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Return a value from the database and delete it.
 		</synopsis>

--- a/funcs/func_devstate.c
+++ b/funcs/func_devstate.c
@@ -48,6 +48,7 @@
 
 /*** DOCUMENTATION
 	<function name="DEVICE_STATE" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Get or Set a device state.
 		</synopsis>
@@ -72,6 +73,7 @@
 		</description>
 	</function>
 	<function name="HINT" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Get the devices set for a dialplan hint.
 		</synopsis>

--- a/funcs/func_dialgroup.c
+++ b/funcs/func_dialgroup.c
@@ -43,6 +43,7 @@
 
 /*** DOCUMENTATION
 	<function name="DIALGROUP" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Manages a group of users for dialing.
 		</synopsis>

--- a/funcs/func_dialplan.c
+++ b/funcs/func_dialplan.c
@@ -37,6 +37,7 @@
 
 /*** DOCUMENTATION
 	<function name="DIALPLAN_EXISTS" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Checks the existence of a dialplan target.
 		</synopsis>
@@ -50,6 +51,7 @@
 		</description>
 	</function>
 	<function name="VALID_EXTEN" language="en_US">
+		<since><version>11.0.0</version></since>
 		<synopsis>
 			Determine whether an extension exists or not.
 		</synopsis>

--- a/funcs/func_enum.c
+++ b/funcs/func_enum.c
@@ -50,6 +50,7 @@
 
 /*** DOCUMENTATION
 	<function name="ENUMQUERY" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Initiate an ENUM query.
 		</synopsis>
@@ -69,6 +70,7 @@
 		</description>
 	</function>
 	<function name="ENUMRESULT" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Retrieve results from a ENUMQUERY.
 		</synopsis>
@@ -89,6 +91,7 @@
 		</description>
 	</function>
 	<function name="ENUMLOOKUP" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			General or specific querying of NAPTR records for ENUM or ENUM-like DNS pointers.
 		</synopsis>
@@ -133,6 +136,7 @@
 		</description>
 	</function>
 	<function name="TXTCIDNAME" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			TXTCIDNAME looks up a caller name via DNS.
 		</synopsis>

--- a/funcs/func_env.c
+++ b/funcs/func_env.c
@@ -39,6 +39,7 @@
 
 /*** DOCUMENTATION
 	<function name="ENV" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Gets or sets the environment variable specified.
 		</synopsis>
@@ -101,6 +102,7 @@
 		</description>
 	</function>
 	<function name="STAT" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Does a check on the specified file.
 		</synopsis>
@@ -127,6 +129,7 @@
 		</description>
 	</function>
 	<function name="FILE" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Read or write text file.
 		</synopsis>
@@ -245,6 +248,7 @@
 		</see-also>
 	</function>
 	<function name="FILE_COUNT_LINE" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Obtains the number of lines of a text file.
 		</synopsis>
@@ -280,6 +284,7 @@
 		</see-also>
 	</function>
 	<function name="FILE_FORMAT" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Return the newline format of a text file.
 		</synopsis>
@@ -307,7 +312,6 @@
 		<since>
 			<version>16.21.0</version>
 			<version>18.7.0</version>
-			<version>19.0.0</version>
 		</since>
 		<synopsis>
 			Return the name of a file.
@@ -330,7 +334,6 @@
 		<since>
 			<version>16.21.0</version>
 			<version>18.7.0</version>
-			<version>19.0.0</version>
 		</since>
 		<synopsis>
 			Return the directory of a file.

--- a/funcs/func_evalexten.c
+++ b/funcs/func_evalexten.c
@@ -37,6 +37,7 @@
 
 /*** DOCUMENTATION
 	<function name="EVAL_EXTEN" language="en_US">
+		<since><version>16.26.0</version><version>18.12.0</version><version>19.4.0</version></since>
 		<synopsis>
 			Evaluates the contents of a dialplan extension and returns it as a string.
 		</synopsis>
@@ -90,6 +91,7 @@
 		</see-also>
 	</function>
 	<function name="EVAL_SUB" language="en_US">
+		<since><version>20.11.0</version><version>21.6.0</version><version>22.1.0</version></since>
 		<synopsis>
 			Executes a Gosub and provides its return value as a string
 		</synopsis>

--- a/funcs/func_export.c
+++ b/funcs/func_export.c
@@ -38,6 +38,7 @@
 
 /*** DOCUMENTATION
 	<function name="EXPORT" language="en_US">
+		<since><version>16.30.0</version><version>18.16.0</version><version>19.8.0</version><version>20.1.0</version></since>
 		<synopsis>
 			Set variables or dialplan functions on any arbitrary channel that exists.
 		</synopsis>

--- a/funcs/func_extstate.c
+++ b/funcs/func_extstate.c
@@ -40,6 +40,7 @@
 
 /*** DOCUMENTATION
 	<function name="EXTENSION_STATE" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Get an extension's state.
 		</synopsis>

--- a/funcs/func_frame_drop.c
+++ b/funcs/func_frame_drop.c
@@ -41,7 +41,6 @@
 		<since>
 			<version>16.21.0</version>
 			<version>18.7.0</version>
-			<version>19.0.0</version>
 		</since>
 		<synopsis>
 			Drops specific frame types in the TX or RX direction on a channel.

--- a/funcs/func_frame_trace.c
+++ b/funcs/func_frame_trace.c
@@ -39,6 +39,7 @@
 
 /*** DOCUMENTATION
 	<function name="FRAME_TRACE" language="en_US">
+		<since><version>10.0.0</version></since>
 		<synopsis>
 			View internal ast_frames as they are read and written on a channel.
 		</synopsis>

--- a/funcs/func_global.c
+++ b/funcs/func_global.c
@@ -41,6 +41,7 @@
 
 /*** DOCUMENTATION
 	<function name="GLOBAL" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Gets or sets the global variable specified.
 		</synopsis>
@@ -54,6 +55,7 @@
 		</description>
 	</function>
 	<function name="GLOBAL_DELETE" language="en_US">
+		<since><version>18.21.0</version><version>20.6.0</version><version>21.1.0</version></since>
 		<synopsis>
 			Deletes a specified global variable.
 		</synopsis>
@@ -72,6 +74,7 @@
 		</see-also>
 	</function>
 	<function name="GLOBAL_EXISTS" language="en_US">
+		<since><version>18.21.0</version><version>20.6.0</version><version>21.1.0</version></since>
 		<synopsis>
 			Check if a global variable exists or not.
 		</synopsis>
@@ -88,6 +91,7 @@
 		</see-also>
 	</function>
 	<function name="SHARED" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Gets or sets the shared variable specified.
 		</synopsis>

--- a/funcs/func_groupcount.c
+++ b/funcs/func_groupcount.c
@@ -35,6 +35,7 @@
 
 /*** DOCUMENTATION
 	<function name="GROUP_COUNT" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Counts the number of channels in the specified group.
 		</synopsis>
@@ -52,6 +53,7 @@
 		</description>
 	</function>
 	<function name="GROUP_MATCH_COUNT" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Counts the number of channels in the groups matching the specified pattern.
 		</synopsis>
@@ -70,6 +72,7 @@
 		</description>
 	</function>
 	<function name="GROUP" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Gets or sets the channel group.
 		</synopsis>
@@ -84,6 +87,7 @@
 		</description>
 	</function>
 	<function name="GROUP_LIST" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Gets a list of the groups set on a channel.
 		</synopsis>

--- a/funcs/func_hangupcause.c
+++ b/funcs/func_hangupcause.c
@@ -41,6 +41,7 @@
 
 /*** DOCUMENTATION
 	<function name="HANGUPCAUSE" language="en_US">
+		<since><version>11.0.0</version></since>
 		<synopsis>
 			Gets per-channel hangupcause information from the channel.
 		</synopsis>
@@ -66,6 +67,7 @@
 		</see-also>
 	</function>
 	<function name="HANGUPCAUSE_KEYS" language="en_US">
+		<since><version>11.0.0</version></since>
 		<synopsis>
 			Gets the list of channels for which hangup causes are available.
 		</synopsis>
@@ -78,6 +80,7 @@
 		</see-also>
 	</function>
 	<application name="HangupCauseClear" language="en_US">
+		<since><version>11.0.0</version></since>
 		<synopsis>
 			Clears hangup cause information from the channel that is available through HANGUPCAUSE.
 		</synopsis>

--- a/funcs/func_holdintercept.c
+++ b/funcs/func_holdintercept.c
@@ -41,6 +41,7 @@
 
 /*** DOCUMENTATION
 	<function name="HOLD_INTERCEPT" language="en_US">
+		<since><version>13.7.0</version></since>
 		<synopsis>
 			Intercepts hold frames on a channel and raises an event instead of passing the frame on
 		</synopsis>

--- a/funcs/func_iconv.c
+++ b/funcs/func_iconv.c
@@ -42,6 +42,7 @@
 
 /*** DOCUMENTATION
 	<function name="ICONV" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Converts charsets of strings.
 		</synopsis>

--- a/funcs/func_jitterbuffer.c
+++ b/funcs/func_jitterbuffer.c
@@ -42,6 +42,7 @@
 
 /*** DOCUMENTATION
 	<function name="JITTERBUFFER" language="en_US">
+		<since><version>10.0.0</version></since>
 		<synopsis>
 			Add a Jitterbuffer to the Read side of the channel. This dejitters the audio stream before it reaches the Asterisk core. This is a write only function.
 		</synopsis>

--- a/funcs/func_lock.c
+++ b/funcs/func_lock.c
@@ -46,6 +46,7 @@
 
 /*** DOCUMENTATION
 	<function name="LOCK" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Attempt to obtain a named mutex.
 		</synopsis>
@@ -70,6 +71,7 @@
 		</see-also>
 	</function>
 	<function name="TRYLOCK" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Attempt to obtain a named mutex.
 		</synopsis>
@@ -92,6 +94,7 @@
 		</see-also>
 	</function>
 	<function name="UNLOCK" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Unlocks a named mutex.
 		</synopsis>

--- a/funcs/func_logic.c
+++ b/funcs/func_logic.c
@@ -38,6 +38,7 @@
 
 /*** DOCUMENTATION
 	<function name="ISNULL" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Check if a value is NULL.
 		</synopsis>
@@ -49,6 +50,7 @@
 		</description>
 	</function>
 	<function name="SET" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			SET assigns a value to a channel variable.
 		</synopsis>
@@ -60,6 +62,7 @@
 		</description>
 	</function>
 	<function name="EXISTS" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Test the existence of a value.
 		</synopsis>
@@ -71,6 +74,7 @@
 		</description>
 	</function>
 	<function name="IF" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Check for an expression.
 		</synopsis>
@@ -86,6 +90,7 @@
 		</description>
 	</function>
 	<function name="IFTIME" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Temporal Conditional.
 		</synopsis>
@@ -101,6 +106,7 @@
 		</description>
 	</function>
 	<function name="IMPORT" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Retrieve the value of a variable from another channel.
 		</synopsis>
@@ -112,6 +118,7 @@
 		</description>
 	</function>
 	<function name="DELETE" language="en_US">
+		<since><version>18.21.0</version><version>20.6.0</version><version>21.1.0</version></since>
 		<synopsis>
 			Deletes a specified channel variable.
 		</synopsis>
@@ -129,6 +136,7 @@
 		</see-also>
 	</function>
 	<function name="VARIABLE_EXISTS" language="en_US">
+		<since><version>18.21.0</version><version>20.6.0</version><version>21.1.0</version></since>
 		<synopsis>
 			Check if a dialplan variable exists or not.
 		</synopsis>

--- a/funcs/func_math.c
+++ b/funcs/func_math.c
@@ -49,6 +49,7 @@
 
 /*** DOCUMENTATION
 	<function name="MATH" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Performs Mathematical Functions.
 		</synopsis>
@@ -77,6 +78,7 @@
 		</description>
 	</function>
 	<function name="INC" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Increments the value of a variable, while returning the updated value to the dialplan
 		</synopsis>
@@ -94,6 +96,7 @@
 		</description>
 	</function>
 	<function name="DEC" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Decrements the value of a variable, while returning the updated value to the dialplan
 		</synopsis>
@@ -116,7 +119,6 @@
 		<since>
 			<version>16.19.0</version>
 			<version>18.5.0</version>
-			<version>19.0.0</version>
 		</since>
 		<synopsis>
 			Returns the minimum of two numbers.
@@ -136,7 +138,6 @@
 		<since>
 			<version>16.19.0</version>
 			<version>18.5.0</version>
-			<version>19.0.0</version>
 		</since>
 		<synopsis>
 			Returns the maximum of two numbers.
@@ -156,7 +157,6 @@
 		<since>
 			<version>16.19.0</version>
 			<version>18.5.0</version>
-			<version>19.0.0</version>
 		</since>
 		<synopsis>
 			Returns absolute value of a number.

--- a/funcs/func_md5.c
+++ b/funcs/func_md5.c
@@ -37,6 +37,7 @@
 
 /*** DOCUMENTATION
 	<function name="MD5" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Computes an MD5 digest.
 		</synopsis>

--- a/funcs/func_module.c
+++ b/funcs/func_module.c
@@ -33,6 +33,7 @@
 
 /*** DOCUMENTATION
 	<function name="IFMODULE" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Checks if an Asterisk module is loaded in memory.
 		</synopsis>

--- a/funcs/func_odbc.c
+++ b/funcs/func_odbc.c
@@ -48,6 +48,7 @@
 
 /*** DOCUMENTATION
 	<function name="ODBC_FETCH" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Fetch a row from a multirow query.
 		</synopsis>
@@ -72,6 +73,7 @@
 		</description>
 	</function>
 	<application name="ODBCFinish" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Clear the resultset of a sucessful multirow query.
 		</synopsis>
@@ -84,6 +86,7 @@
 		</description>
 	</application>
 	<function name="SQL_ESC" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Escapes single ticks for use in SQL statements.
 		</synopsis>
@@ -99,6 +102,7 @@
 		</description>
 	</function>
 	<function name="SQL_ESC_BACKSLASHES" language="en_US">
+		<since><version>16.26.0</version><version>18.12.0</version><version>19.4.0</version></since>
 		<synopsis>
 			Escapes backslashes for use in SQL statements.
 		</synopsis>

--- a/funcs/func_periodic_hook.c
+++ b/funcs/func_periodic_hook.c
@@ -46,6 +46,7 @@
 
 /*** DOCUMENTATION
 	<function name="PERIODIC_HOOK" language="en_US">
+		<since><version>13.0.0</version></since>
 		<synopsis>
 			Execute a periodic dialplan hook into the audio of a call.
 		</synopsis>

--- a/funcs/func_pitchshift.c
+++ b/funcs/func_pitchshift.c
@@ -73,6 +73,7 @@
 
 /*** DOCUMENTATION
 	<function name="PITCH_SHIFT" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Pitch shift both tx and rx audio streams on a channel.
 		</synopsis>

--- a/funcs/func_pjsip_aor.c
+++ b/funcs/func_pjsip_aor.c
@@ -45,6 +45,7 @@
 
 /*** DOCUMENTATION
 	<function name="PJSIP_AOR" language="en_US">
+		<since><version>13.2.0</version></since>
 		<synopsis>
 			Get information about a PJSIP AOR
 		</synopsis>

--- a/funcs/func_pjsip_contact.c
+++ b/funcs/func_pjsip_contact.c
@@ -45,6 +45,7 @@
 
 /*** DOCUMENTATION
 	<function name="PJSIP_CONTACT" language="en_US">
+		<since><version>13.2.0</version></since>
 		<synopsis>
 			Get information about a PJSIP contact
 		</synopsis>

--- a/funcs/func_pjsip_endpoint.c
+++ b/funcs/func_pjsip_endpoint.c
@@ -46,6 +46,7 @@
 
 /*** DOCUMENTATION
 	<function name="PJSIP_ENDPOINT" language="en_US">
+		<since><version>12.0.0</version></since>
 		<synopsis>
 			Get information about a PJSIP endpoint
 		</synopsis>

--- a/funcs/func_presencestate.c
+++ b/funcs/func_presencestate.c
@@ -44,6 +44,7 @@
 
 /*** DOCUMENTATION
 	<function name="PRESENCE_STATE" language="en_US">
+		<since><version>11.0.0</version></since>
 		<synopsis>
 			Get or Set a presence state.
 		</synopsis>

--- a/funcs/func_rand.c
+++ b/funcs/func_rand.c
@@ -38,6 +38,7 @@
 
 /*** DOCUMENTATION
 	<function name="RAND" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Choose a random number in a range.
 		</synopsis>

--- a/funcs/func_realtime.c
+++ b/funcs/func_realtime.c
@@ -41,6 +41,7 @@
 
 /*** DOCUMENTATION
 	<function name="REALTIME" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			RealTime Read/Write Functions.
 		</synopsis>
@@ -77,6 +78,7 @@
 		</see-also>
 	</function>
 	<function name="REALTIME_STORE" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			RealTime Store Function.
 		</synopsis>
@@ -100,6 +102,7 @@
 		</see-also>
 	</function>
 	<function name="REALTIME_DESTROY" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			RealTime Destroy Function.
 		</synopsis>
@@ -128,6 +131,7 @@
 		</see-also>
 	</function>
 	<function name="REALTIME_FIELD" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			RealTime query function.
 		</synopsis>
@@ -151,6 +155,7 @@
 		</see-also>
 	</function>
 	<function name="REALTIME_HASH" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			RealTime query function.
 		</synopsis>

--- a/funcs/func_sayfiles.c
+++ b/funcs/func_sayfiles.c
@@ -45,7 +45,6 @@
 		<since>
 			<version>16.21.0</version>
 			<version>18.7.0</version>
-			<version>19.0.0</version>
 		</since>
 		<synopsis>
 			Returns the ampersand-delimited file names that would be played by the Say applications (e.g. SayAlpha, SayDigits).

--- a/funcs/func_scramble.c
+++ b/funcs/func_scramble.c
@@ -35,7 +35,6 @@
 		<since>
 			<version>16.21.0</version>
 			<version>18.7.0</version>
-			<version>19.0.0</version>
 		</since>
 		<synopsis>
 			Scrambles audio on a channel.

--- a/funcs/func_sha1.c
+++ b/funcs/func_sha1.c
@@ -35,6 +35,7 @@
 
 /*** DOCUMENTATION
 	<function name="SHA1" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Computes a SHA1 digest.
 		</synopsis>

--- a/funcs/func_shell.c
+++ b/funcs/func_shell.c
@@ -76,6 +76,7 @@ static int shell_helper(struct ast_channel *chan, const char *cmd, char *data,
 
 /*** DOCUMENTATION
 	<function name="SHELL" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Executes a command using the system shell and captures its output.
 		</synopsis>

--- a/funcs/func_sorcery.c
+++ b/funcs/func_sorcery.c
@@ -39,6 +39,7 @@
 
 /*** DOCUMENTATION
 	<function name="AST_SORCERY" language="en_US">
+		<since><version>12.2.0</version></since>
 		<synopsis>
 			Get a field from a sorcery object
 		</synopsis>

--- a/funcs/func_speex.c
+++ b/funcs/func_speex.c
@@ -50,6 +50,7 @@
 
 /*** DOCUMENTATION
 	<function name="AGC" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Apply automatic gain control to audio on a channel.
 		</synopsis>
@@ -73,6 +74,7 @@
 		</description>
 	</function>
 	<function name="DENOISE" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Apply noise reduction to audio on a channel.
 		</synopsis>

--- a/funcs/func_sprintf.c
+++ b/funcs/func_sprintf.c
@@ -43,6 +43,7 @@ AST_THREADSTORAGE(result_buf);
 
 /*** DOCUMENTATION
 	<function name="SPRINTF" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Format a variable according to a format string.
 		</synopsis>

--- a/funcs/func_srv.c
+++ b/funcs/func_srv.c
@@ -38,6 +38,7 @@
 
 /*** DOCUMENTATION
 	<function name="SRVQUERY" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Initiate an SRV query.
 		</synopsis>
@@ -52,6 +53,7 @@
 		</description>
 	</function>
 	<function name="SRVRESULT" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Retrieve results from an SRVQUERY.
 		</synopsis>

--- a/funcs/func_strings.c
+++ b/funcs/func_strings.c
@@ -49,6 +49,7 @@ AST_THREADSTORAGE(tmp_buf);
 
 /*** DOCUMENTATION
 	<function name="FIELDQTY" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Count the fields with an arbitrary delimiter
 		</synopsis>
@@ -69,6 +70,7 @@ AST_THREADSTORAGE(tmp_buf);
 		</description>
 	</function>
 	<function name="FIELDNUM" language="en_US">
+		<since><version>10.0.0</version></since>
 		<synopsis>
 			Return the 1-based offset of a field in a list
 		</synopsis>
@@ -93,6 +95,7 @@ AST_THREADSTORAGE(tmp_buf);
 		</description>
 	</function>
 	<function name="LISTFILTER" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>Remove an item from a list, by name.</synopsis>
 		<syntax>
 			<parameter name="varname" required="true" />
@@ -106,6 +109,7 @@ AST_THREADSTORAGE(tmp_buf);
 		</description>
 	</function>
 	<function name="FILTER" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Filter the string to include only the allowed characters
 		</synopsis>
@@ -125,6 +129,7 @@ AST_THREADSTORAGE(tmp_buf);
 		</description>
 	</function>
 	<function name="REPLACE" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Replace a set of characters in a given string with another character.
 		</synopsis>
@@ -143,6 +148,7 @@ AST_THREADSTORAGE(tmp_buf);
 		</description>
 	</function>
 	<function name="STRREPLACE" language="en_US">
+		<since><version>10.0.0</version></since>
 		<synopsis>
 			Replace instances of a substring within a string with another string.
 		</synopsis>
@@ -164,7 +170,6 @@ AST_THREADSTORAGE(tmp_buf);
 		<since>
 			<version>16.21.0</version>
 			<version>18.7.0</version>
-			<version>19.0.0</version>
 		</since>
 		<synopsis>
 			Inserts a substring between each character in a string.
@@ -184,6 +189,7 @@ AST_THREADSTORAGE(tmp_buf);
 		</description>
 	</function>
 	<function name="TRIM" language="en_US">
+		<since><version>16.30.0</version><version>18.16.0</version><version>19.8.0</version><version>20.1.0</version></since>
 		<synopsis>
 			Trim leading and trailing whitespace in a string
 		</synopsis>
@@ -199,6 +205,7 @@ AST_THREADSTORAGE(tmp_buf);
 		</see-also>
 	</function>
 	<function name="LTRIM" language="en_US">
+		<since><version>16.30.0</version><version>18.16.0</version><version>19.8.0</version><version>20.1.0</version></since>
 		<synopsis>
 			Trim leading whitespace in a string
 		</synopsis>
@@ -214,6 +221,7 @@ AST_THREADSTORAGE(tmp_buf);
 		</see-also>
 	</function>
 	<function name="RTRIM" language="en_US">
+		<since><version>16.30.0</version><version>18.16.0</version><version>19.8.0</version><version>20.1.0</version></since>
 		<synopsis>
 			Trim trailing whitespace in a string
 		</synopsis>
@@ -229,6 +237,7 @@ AST_THREADSTORAGE(tmp_buf);
 		</see-also>
 	</function>
 	<function name="PASSTHRU" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Pass the given argument back as a value.
 		</synopsis>
@@ -248,6 +257,7 @@ AST_THREADSTORAGE(tmp_buf);
 		</description>
 	</function>
 	<function name="REGEX" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Check string against a regular expression.
 		</synopsis>
@@ -264,6 +274,7 @@ AST_THREADSTORAGE(tmp_buf);
 		</description>
 	</function>
 	<application name="ClearHash" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Clear the keys from a specified hashname.
 		</synopsis>
@@ -275,6 +286,7 @@ AST_THREADSTORAGE(tmp_buf);
 		</description>
 	</application>
 	<function name="HASH" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Implementation of a dialplan associative array
 		</synopsis>
@@ -289,6 +301,7 @@ AST_THREADSTORAGE(tmp_buf);
 		</description>
 	</function>
 	<function name="HASHKEYS" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Retrieve the keys of the HASH() function.
 		</synopsis>
@@ -303,6 +316,7 @@ AST_THREADSTORAGE(tmp_buf);
 		</description>
 	</function>
 	<function name="KEYPADHASH" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Hash the letters in string into equivalent keypad numbers.
 		</synopsis>
@@ -316,6 +330,7 @@ AST_THREADSTORAGE(tmp_buf);
 		</description>
 	</function>
 	<function name="ARRAY" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Allows setting multiple variables at once.
 		</synopsis>
@@ -334,6 +349,7 @@ AST_THREADSTORAGE(tmp_buf);
 		</description>
 	</function>
 	<function name="STRPTIME" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Returns the epoch of the arbitrary date/time string structured as described by the format.
 		</synopsis>
@@ -352,6 +368,7 @@ AST_THREADSTORAGE(tmp_buf);
 		</description>
 	</function>
 	<function name="STRFTIME" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Returns the current date/time in the specified format.
 		</synopsis>
@@ -374,6 +391,7 @@ AST_THREADSTORAGE(tmp_buf);
 		</see-also>
 	</function>
 	<function name="EVAL" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Evaluate stored variables
 		</synopsis>
@@ -395,6 +413,7 @@ AST_THREADSTORAGE(tmp_buf);
 		</description>
 	</function>
 	<function name="TOUPPER" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Convert string to all uppercase letters.
 		</synopsis>
@@ -408,6 +427,7 @@ AST_THREADSTORAGE(tmp_buf);
 		</description>
 	</function>
 	<function name="TOLOWER" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Convert string to all lowercase letters.
 		</synopsis>
@@ -421,6 +441,7 @@ AST_THREADSTORAGE(tmp_buf);
 		</description>
 	</function>
 	<function name="LEN" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Return the length of the string given.
 		</synopsis>
@@ -434,6 +455,7 @@ AST_THREADSTORAGE(tmp_buf);
 		</description>
 	</function>
 	<function name="QUOTE" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Quotes a given string, escaping embedded quotes as necessary
 		</synopsis>
@@ -445,6 +467,7 @@ AST_THREADSTORAGE(tmp_buf);
 		</description>
 	</function>
 	<function name="CSV_QUOTE" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Quotes a given string for use in a CSV file, escaping embedded quotes as necessary
 		</synopsis>
@@ -456,6 +479,7 @@ AST_THREADSTORAGE(tmp_buf);
 		</description>
 	</function>
 	<function name="SHIFT" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Removes and returns the first item off of a variable containing delimited text
 		</synopsis>
@@ -477,6 +501,7 @@ AST_THREADSTORAGE(tmp_buf);
 		</description>
 	</function>
 	<function name="POP" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Removes and returns the last item off of a variable containing delimited text
 		</synopsis>
@@ -498,6 +523,7 @@ AST_THREADSTORAGE(tmp_buf);
 		</description>
 	</function>
 	<function name="PUSH" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Appends one or more values to the end of a variable containing delimited text
 		</synopsis>
@@ -516,6 +542,7 @@ AST_THREADSTORAGE(tmp_buf);
 		</description>
 	</function>
 	<function name="UNSHIFT" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Inserts one or more values to the beginning of a variable containing delimited text
 		</synopsis>

--- a/funcs/func_sysinfo.c
+++ b/funcs/func_sysinfo.c
@@ -40,6 +40,7 @@
 
 /*** DOCUMENTATION
 	<function name="SYSINFO" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Returns system information specified by parameter.
 		</synopsis>

--- a/funcs/func_timeout.c
+++ b/funcs/func_timeout.c
@@ -38,6 +38,7 @@
 
 /*** DOCUMENTATION
 	<function name="TIMEOUT" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Gets or sets timeouts on the channel. Timeout values are in seconds.
 		</synopsis>

--- a/funcs/func_uri.c
+++ b/funcs/func_uri.c
@@ -42,6 +42,7 @@
 
 /*** DOCUMENTATION
 	<function name="URIENCODE" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Encodes a string to URI-safe encoding according to RFC 2396.
 		</synopsis>
@@ -55,6 +56,7 @@
 		</description>
 	</function>
 	<function name="URIDECODE" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Decodes a URI-encoded string according to RFC 2396.
 		</synopsis>

--- a/funcs/func_version.c
+++ b/funcs/func_version.c
@@ -38,6 +38,7 @@
 
 /*** DOCUMENTATION
 	<function name="VERSION" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Return the Version info for this Asterisk.
 		</synopsis>

--- a/funcs/func_vmcount.c
+++ b/funcs/func_vmcount.c
@@ -43,6 +43,7 @@
 
 /*** DOCUMENTATION
 	<function name="VMCOUNT" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Count the voicemails in a specified mailbox or mailboxes.
 		</synopsis>

--- a/funcs/func_volume.c
+++ b/funcs/func_volume.c
@@ -41,6 +41,7 @@
 
 /*** DOCUMENTATION
 	<function name="VOLUME" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Set or get the TX or RX volume of a channel.
 		</synopsis>

--- a/main/ccss.c
+++ b/main/ccss.c
@@ -54,6 +54,7 @@
 
 /*** DOCUMENTATION
 	<application name="CallCompletionRequest" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Request call completion service for previous call
 		</synopsis>
@@ -79,6 +80,7 @@
 		</description>
 	</application>
 	<application name="CallCompletionCancel" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Cancel call completion service
 		</synopsis>

--- a/main/features.c
+++ b/main/features.c
@@ -80,6 +80,7 @@
 
 /*** DOCUMENTATION
 	<application name="Bridge" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Bridge two channels.
 		</synopsis>

--- a/main/features_config.c
+++ b/main/features_config.c
@@ -306,6 +306,7 @@
 		</configFile>
 	</configInfo>
 	<function name="FEATURE" language="en_US">
+		<since><version>12.0.0</version></since>
 		<synopsis>
 			Get or set a feature option on a channel.
 		</synopsis>
@@ -349,6 +350,7 @@
 		</see-also>
 	</function>
 	<function name="FEATUREMAP" language="en_US">
+		<since><version>12.0.0</version></since>
 		<synopsis>
 			Get or set a feature map to a given value on a specific channel.
 		</synopsis>

--- a/main/logger_doc.xml
+++ b/main/logger_doc.xml
@@ -3,6 +3,7 @@
 <?xml-stylesheet type="text/xsl" href="appdocsxml.xslt"?>
 <docs xmlns:xi="http://www.w3.org/2001/XInclude">
 	<function name="LOG_GROUP" language="en_US">
+		<since><version>18.21.0</version><version>20.6.0</version><version>21.1.0</version></since>
 		<synopsis>
 			Set the channel group name for log filtering on this channel
 		</synopsis>

--- a/main/manager_doc.xml
+++ b/main/manager_doc.xml
@@ -1394,6 +1394,7 @@
 		</see-also>
 	</manager>
 	<function name="AMI_CLIENT" language="en_US">
+		<since><version>11.0.0</version></since>
 		<synopsis>
 			Checks attributes of manager accounts
 		</synopsis>

--- a/main/message.c
+++ b/main/message.c
@@ -44,6 +44,7 @@
 
 /*** DOCUMENTATION
 	<function name="MESSAGE" language="en_US">
+		<since><version>10.0.0</version></since>
 		<synopsis>
 			Create a message or read fields from a message.
 		</synopsis>
@@ -104,6 +105,7 @@
 		</see-also>
 	</function>
 	<function name="MESSAGE_DATA" language="en_US">
+		<since><version>10.0.0</version></since>
 		<synopsis>
 			Read or write custom data attached to a message.
 		</synopsis>
@@ -127,6 +129,7 @@
 		</see-also>
 	</function>
 	<application name="MessageSend" language="en_US">
+		<since><version>10.0.0</version></since>
 		<synopsis>
 			Send a text message.
 		</synopsis>

--- a/main/pbx.c
+++ b/main/pbx.c
@@ -96,6 +96,7 @@
 
 /*** DOCUMENTATION
 	<function name="EXCEPTION" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Retrieve the details of the current dialplan exception.
 		</synopsis>
@@ -127,6 +128,7 @@
 		</see-also>
 	</function>
 	<function name="TESTTIME" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Sets a time to be used with the channel to test logical conditions.
 		</synopsis>

--- a/main/pbx_builtins.c
+++ b/main/pbx_builtins.c
@@ -42,6 +42,7 @@
 
 /*** DOCUMENTATION
 	<application name="Answer" language="en_US">
+		<since><version>13.8.0</version></since>
 		<synopsis>
 			Answer a channel if ringing.
 		</synopsis>
@@ -72,6 +73,7 @@
 		</see-also>
 	</application>
 	<application name="BackGround" language="en_US">
+		<since><version>13.8.0</version></since>
 		<synopsis>
 			Play an audio file while waiting for digits of an extension to go to.
 		</synopsis>
@@ -138,6 +140,7 @@
 		</see-also>
 	</application>
 	<application name="Busy" language="en_US">
+		<since><version>13.8.0</version></since>
 		<synopsis>
 			Indicate the Busy condition.
 		</synopsis>
@@ -158,6 +161,7 @@
 		</see-also>
 	</application>
 	<application name="Congestion" language="en_US">
+		<since><version>13.8.0</version></since>
 		<synopsis>
 			Indicate the Congestion condition.
 		</synopsis>
@@ -178,6 +182,7 @@
 		</see-also>
 	</application>
 	<application name="ExecIfTime" language="en_US">
+		<since><version>13.8.0</version></since>
 		<synopsis>
 			Conditional application execution based on the current time.
 		</synopsis>
@@ -205,6 +210,7 @@
 		</see-also>
 	</application>
 	<application name="Goto" language="en_US">
+		<since><version>13.8.0</version></since>
 		<synopsis>
 			Jump to a particular priority, extension, or context.
 		</synopsis>
@@ -238,6 +244,7 @@
 		</see-also>
 	</application>
 	<application name="GotoIf" language="en_US">
+		<since><version>13.8.0</version></since>
 		<synopsis>
 			Conditional goto.
 		</synopsis>
@@ -277,6 +284,7 @@
 		</see-also>
 	</application>
 	<application name="GotoIfTime" language="en_US">
+		<since><version>13.8.0</version></since>
 		<synopsis>
 			Conditional Goto based on the current time.
 		</synopsis>
@@ -340,6 +348,7 @@
 		</see-also>
 	</application>
 	<application name="Hangup" language="en_US">
+		<since><version>13.8.0</version></since>
 		<synopsis>
 			Hang up the calling channel.
 		</synopsis>
@@ -359,6 +368,7 @@
 		</see-also>
 	</application>
 	<application name="Incomplete" language="en_US">
+		<since><version>13.8.0</version></since>
 		<synopsis>
 			Returns AST_PBX_INCOMPLETE value.
 		</synopsis>
@@ -376,6 +386,7 @@
 		</description>
 	</application>
 	<application name="NoOp" language="en_US">
+		<since><version>13.8.0</version></since>
 		<synopsis>
 			Do Nothing (No Operation).
 		</synopsis>
@@ -394,6 +405,7 @@
 		</see-also>
 	</application>
 	<application name="Proceeding" language="en_US">
+		<since><version>13.8.0</version></since>
 		<synopsis>
 			Indicate proceeding.
 		</synopsis>
@@ -403,6 +415,7 @@
 		</description>
 	</application>
 	<application name="Progress" language="en_US">
+		<since><version>13.8.0</version></since>
 		<synopsis>
 			Indicate progress.
 		</synopsis>
@@ -418,6 +431,7 @@
 		</see-also>
 	</application>
 	<application name="RaiseException" language="en_US">
+		<since><version>13.8.0</version></since>
 		<synopsis>
 			Handle an exceptional condition.
 		</synopsis>
@@ -433,6 +447,7 @@
 		</see-also>
 	</application>
 	<application name="Ringing" language="en_US">
+		<since><version>13.8.0</version></since>
 		<synopsis>
 			Indicate ringing tone.
 		</synopsis>
@@ -448,6 +463,7 @@
 		</see-also>
 	</application>
 	<application name="SayAlpha" language="en_US">
+		<since><version>13.8.0</version></since>
 		<synopsis>
 			Say Alpha.
 		</synopsis>
@@ -472,6 +488,7 @@
 		</see-also>
 	</application>
 	<application name="SayAlphaCase" language="en_US">
+		<since><version>13.8.0</version></since>
 		<synopsis>
 			Say Alpha.
 		</synopsis>
@@ -516,6 +533,7 @@
 		</see-also>
 	</application>
 	<application name="SayDigits" language="en_US">
+		<since><version>13.8.0</version></since>
 		<synopsis>
 			Say Digits.
 		</synopsis>
@@ -540,6 +558,7 @@
 		</see-also>
 	</application>
 	<application name="SayMoney" language="en_US">
+		<since><version>16.21.0</version><version>18.7.0</version></since>
 		<synopsis>
 			Say Money.
 		</synopsis>
@@ -563,6 +582,7 @@
 		</see-also>
 	</application>
 	<application name="SayNumber" language="en_US">
+		<since><version>13.8.0</version></since>
 		<synopsis>
 			Say Number.
 		</synopsis>
@@ -588,6 +608,7 @@
 		</see-also>
 	</application>
 	<application name="SayOrdinal" language="en_US">
+		<since><version>16.21.0</version><version>18.7.0</version></since>
 		<synopsis>
 			Say Ordinal Number.
 		</synopsis>
@@ -615,6 +636,7 @@
 		</see-also>
 	</application>
 	<application name="SayPhonetic" language="en_US">
+		<since><version>13.8.0</version></since>
 		<synopsis>
 			Say Phonetic.
 		</synopsis>
@@ -653,6 +675,7 @@
 		</see-also>
 	</application>
 	<application name="Wait" language="en_US">
+		<since><version>13.8.0</version></since>
 		<synopsis>
 			Waits for some time.
 		</synopsis>
@@ -667,6 +690,7 @@
 		</description>
 	</application>
 	<application name="WaitDigit" language="en_US">
+		<since><version>15.0.0</version></since>
 		<synopsis>
 			Waits for a digit to be entered.
 		</synopsis>
@@ -703,6 +727,7 @@
 		</see-also>
 	</application>
 	<application name="WaitExten" language="en_US">
+		<since><version>13.8.0</version></since>
 		<synopsis>
 			Waits for an extension to be entered.
 		</synopsis>

--- a/main/pbx_variables.c
+++ b/main/pbx_variables.c
@@ -45,6 +45,7 @@
 
 /*** DOCUMENTATION
 	<application name="Set" language="en_US">
+		<since><version>13.8.0</version></since>
 		<synopsis>
 			Set channel variable or function value.
 		</synopsis>
@@ -75,6 +76,7 @@
 		</see-also>
 	</application>
 	<application name="MSet" language="en_US">
+		<since><version>13.8.0</version></since>
 		<synopsis>
 			Set channel variable(s) or function value(s).
 		</synopsis>

--- a/pbx/pbx_ael.c
+++ b/pbx/pbx_ael.c
@@ -49,6 +49,7 @@
 
 /*** DOCUMENTATION
 	<application name="AELSub" language="en_US">
+		<since><version>10.0.0</version></since>
 		<synopsis>
 			Launch subroutine built with AEL
 		</synopsis>

--- a/pbx/pbx_dundi.c
+++ b/pbx/pbx_dundi.c
@@ -76,6 +76,7 @@
 
 /*** DOCUMENTATION
 	<function name="DUNDILOOKUP" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Do a DUNDi lookup of a phone number.
 		</synopsis>
@@ -101,6 +102,7 @@
 
 
 	<function name="DUNDIQUERY" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Initiate a DUNDi query.
 		</synopsis>
@@ -125,6 +127,7 @@
 	</function>
 
 	<function name="DUNDIRESULT" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Retrieve results from a DUNDIQUERY.
 		</synopsis>

--- a/res/parking/parking_applications.c
+++ b/res/parking/parking_applications.c
@@ -39,6 +39,7 @@
 
 /*** DOCUMENTATION
 	<application name="Park" language="en_US">
+		<since><version>12.0.0</version></since>
 		<synopsis>
 			Park yourself.
 		</synopsis>
@@ -136,6 +137,7 @@
 	</application>
 
 	<application name="ParkedCall" language="en_US">
+		<since><version>12.0.0</version></since>
 		<synopsis>
 			Retrieve a parked call.
 		</synopsis>
@@ -171,6 +173,7 @@
 	</application>
 
 	<application name="ParkAndAnnounce" language="en_US">
+		<since><version>12.0.0</version></since>
 		<synopsis>
 			Park and Announce.
 		</synopsis>

--- a/res/parking/parking_bridge_features.c
+++ b/res/parking/parking_bridge_features.c
@@ -46,6 +46,7 @@
 
 /*** DOCUMENTATION
 	<function name="PARK_GET_CHANNEL" language="en_US">
+		<since><version>16.0.0</version></since>
 		<synopsis>
 			Get the channel name of an occupied parking space in a parking lot.
 		</synopsis>

--- a/res/res_agi.c
+++ b/res/res_agi.c
@@ -1117,6 +1117,7 @@
 		</see-also>
 	</agi>
 	<application name="AGI" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Executes an AGI compliant application.
 		</synopsis>
@@ -1218,6 +1219,7 @@
 		</see-also>
 	</application>
 	<application name="EAGI" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Executes an EAGI compliant application.
 		</synopsis>
@@ -1239,6 +1241,7 @@
 		</see-also>
 	</application>
 	<application name="DeadAGI" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Executes AGI on a hungup channel.
 		</synopsis>

--- a/res/res_calendar.c
+++ b/res/res_calendar.c
@@ -57,6 +57,7 @@
 
 /*** DOCUMENTATION
 	<function name="CALENDAR_BUSY" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Determine if the calendar is marked busy at this time.
 		</synopsis>
@@ -74,6 +75,7 @@
 		</see-also>
 	</function>
 	<function name="CALENDAR_EVENT" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Get calendar event notification data from a notification call.
 		</synopsis>
@@ -106,6 +108,7 @@
 		</see-also>
 	</function>
 	<function name="CALENDAR_QUERY" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>Query a calendar server and store the data on a channel
 		</synopsis>
 		<syntax>
@@ -131,6 +134,7 @@
 		</see-also>
 	</function>
 	<function name="CALENDAR_QUERY_RESULT" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Retrieve data from a previously run CALENDAR_QUERY() call
 		</synopsis>
@@ -172,6 +176,7 @@
 		</see-also>
 	</function>
 	<function name="CALENDAR_WRITE" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>Write an event to a calendar</synopsis>
 		<syntax>
 			<parameter name="calendar" required="true">

--- a/res/res_fax.c
+++ b/res/res_fax.c
@@ -91,6 +91,7 @@
 
 /*** DOCUMENTATION
 	<application name="ReceiveFAX" language="en_US" module="res_fax">
+		<since><version>11.0.0</version></since>
 		<synopsis>
 			Receive a FAX and save as a TIFF/F file.
 		</synopsis>
@@ -123,6 +124,7 @@
 		</see-also>
 	</application>
 	<application name="SendFAX" language="en_US" module="res_fax">
+		<since><version>11.0.0</version></since>
 		<synopsis>
 			Sends a specified TIFF/F file as a FAX.
 		</synopsis>
@@ -162,6 +164,7 @@
 		</see-also>
 	</application>
 	<function name="FAXOPT" language="en_US" module="res_fax">
+		<since><version>11.0.0</version></since>
 		<synopsis>
 			Gets/sets various pieces of information about a fax session.
 		</synopsis>

--- a/res/res_geolocation/geoloc_doc.xml
+++ b/res/res_geolocation/geoloc_doc.xml
@@ -231,6 +231,7 @@
 		</configFile>
 	</configInfo>
 	<function name="GEOLOC_PROFILE" language="en_US">
+		<since><version>16.28.0</version><version>18.14.0</version><version>19.6.0</version></since>
 		<synopsis>
 			Get or Set a field in a geolocation profile
 		</synopsis>

--- a/res/res_musiconhold.c
+++ b/res/res_musiconhold.c
@@ -79,6 +79,7 @@
 
 /*** DOCUMENTATION
 	<application name="MusicOnHold" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Play Music On Hold indefinitely.
 		</synopsis>
@@ -97,6 +98,7 @@
 		</description>
 	</application>
 	<application name="StartMusicOnHold" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Play Music On Hold.
 		</synopsis>
@@ -110,6 +112,7 @@
 		</description>
 	</application>
 	<application name="StopMusicOnHold" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Stop playing Music On Hold.
 		</synopsis>

--- a/res/res_mutestream.c
+++ b/res/res_mutestream.c
@@ -49,6 +49,7 @@
 
 /*** DOCUMENTATION
 	<function name="MUTEAUDIO" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Muting audio streams in the channel
 		</synopsis>

--- a/res/res_odbc_transaction.c
+++ b/res/res_odbc_transaction.c
@@ -32,6 +32,7 @@
 
 /*** DOCUMENTATION
 	<function name="ODBC" language="en_US">
+		<since><version>13.8.0</version></since>
 		<synopsis>
 			Controls ODBC transaction properties.
 		</synopsis>
@@ -66,6 +67,7 @@
 		</description>
 	</function>
 	<application name="ODBC_Commit" language="en_US">
+		<since><version>13.8.0</version></since>
 		<synopsis>
 			Commits a currently open database transaction.
 		</synopsis>
@@ -78,6 +80,7 @@
 		</description>
 	</application>
 	<application name="ODBC_Rollback" language="en_US">
+		<since><version>13.8.0</version></since>
 		<synopsis>
 			Rollback a currently open database transaction.
 		</synopsis>

--- a/res/res_phoneprov.c
+++ b/res/res_phoneprov.c
@@ -87,6 +87,7 @@
 
 /*** DOCUMENTATION
 	<function name="PP_EACH_EXTENSION" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Execute specified template for each extension.
 		</synopsis>
@@ -99,6 +100,7 @@
 		</description>
 	</function>
 	<function name="PP_EACH_USER" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Generate a string for each phoneprov user.
 		</synopsis>

--- a/res/res_pjsip_header_funcs.c
+++ b/res/res_pjsip_header_funcs.c
@@ -40,6 +40,7 @@
 
 /*** DOCUMENTATION
 	<function name="PJSIP_HEADER" language="en_US">
+		<since><version>12.0.0</version></since>
 		<synopsis>
 			Gets headers from an inbound PJSIP channel. Adds, updates or removes the
 			specified SIP header from an outbound PJSIP channel.
@@ -145,7 +146,6 @@
 		<since>
 			<version>16.20.0</version>
 			<version>18.6.0</version>
-			<version>19.0.0</version>
 		</since>
 		<synopsis>
 			Gets the list of SIP header names from an INVITE message.
@@ -169,6 +169,7 @@
 		</see-also>
 	</function>
 	<function name="PJSIP_RESPONSE_HEADER" language="en_US">
+		<since><version>16.28.0</version><version>18.14.0</version><version>19.6.0</version></since>
 		<synopsis>
 			Gets headers of 200 response from an outbound PJSIP channel.
 		</synopsis>
@@ -229,6 +230,7 @@
 		</see-also>
 	</function>
 	<function name="PJSIP_RESPONSE_HEADERS" language="en_US">
+		<since><version>16.28.0</version><version>18.14.0</version><version>19.6.0</version></since>
 		<synopsis>
 			Gets the list of SIP header names from the 200 response of INVITE message.
 		</synopsis>
@@ -252,6 +254,7 @@
 		</see-also>
 	</function>
 	<function name="PJSIP_HEADER_PARAM" language="en_US">
+		<since><version>18.16.0</version><version>20.1.0</version></since>
 		<synopsis>
 			Get or set header/URI parameters on a PJSIP channel.
 		</synopsis>

--- a/res/res_smdi.c
+++ b/res/res_smdi.c
@@ -71,6 +71,7 @@
 /*** DOCUMENTATION
 
 	<function name="SMDI_MSG_RETRIEVE" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Retrieve an SMDI message.
 		</synopsis>
@@ -108,6 +109,7 @@
 		</see-also>
 	</function>
 	<function name="SMDI_MSG" language="en_US">
+		<since><version>1.8.0</version></since>
 		<synopsis>
 			Retrieve details about an SMDI message.
 		</synopsis>

--- a/res/res_stir_shaken/stir_shaken_doc.xml
+++ b/res/res_stir_shaken/stir_shaken_doc.xml
@@ -265,6 +265,7 @@
 		</configFile>
 	</configInfo>
 	<function name="STIR_SHAKEN" language="en_US">
+		<since><version>16.15.0</version></since>
 		<synopsis>
 			Gets the number of STIR/SHAKEN results or a specific STIR/SHAKEN value from a result on the channel.
 		</synopsis>

--- a/res/res_tonedetect.c
+++ b/res/res_tonedetect.c
@@ -49,7 +49,6 @@
 		<since>
 			<version>16.21.0</version>
 			<version>18.7.0</version>
-			<version>19.0.0</version>
 		</since>
 		<synopsis>
 			Wait for tone
@@ -182,7 +181,6 @@
 		<since>
 			<version>16.21.0</version>
 			<version>18.7.0</version>
-			<version>19.0.0</version>
 		</since>
 		<synopsis>
 			Asynchronously detects a tone

--- a/res/res_xmpp.c
+++ b/res/res_xmpp.c
@@ -64,6 +64,7 @@
 
 /*** DOCUMENTATION
 	<application name="JabberSend" language="en_US" module="res_xmpp">
+		<since><version>12.0.0</version></since>
 		<synopsis>
 			Sends an XMPP message to a buddy.
 		</synopsis>
@@ -97,6 +98,7 @@
 		</see-also>
 	</application>
 	<function name="JABBER_RECEIVE" language="en_US" module="res_xmpp">
+		<since><version>12.0.0</version></since>
 		<synopsis>
 			Reads XMPP messages.
 		</synopsis>
@@ -129,6 +131,7 @@
 		</see-also>
 	</function>
 	<function name="JABBER_STATUS" language="en_US" module="res_xmpp">
+		<since><version>12.0.0</version></since>
 		<synopsis>
 			Retrieves a buddy's status.
 		</synopsis>
@@ -176,6 +179,7 @@
 		</see-also>
 	</function>
 	<application name="JabberSendGroup" language="en_US" module="res_xmpp">
+		<since><version>12.0.0</version></since>
 		<synopsis>
 			Send a Jabber Message to a specified chat room
 		</synopsis>
@@ -199,6 +203,7 @@
 		</description>
 	</application>
 	<application name="JabberJoin" language="en_US" module="res_xmpp">
+		<since><version>12.0.0</version></since>
 		<synopsis>
 			Join a chat room
 		</synopsis>
@@ -219,6 +224,7 @@
 		</description>
 	</application>
 	<application name="JabberLeave" language="en_US" module="res_xmpp">
+		<since><version>12.0.0</version></since>
 		<synopsis>
 			Leave a chat room
 		</synopsis>


### PR DESCRIPTION
* Do a git blame on the embedded XML application or function element.

* From the commit hash, grab the summary line.

* Do a git log --grep <summary> to find the cherry-pick commits in all
  branches that match.

* Do a git patch-id to ensure the commits are all related and didn't get
  a false match on the summary.

* Do a git tag --contains <commit> to find the tags that contain each
  commit.

* Weed out all tags not ..0.

* Sort and discard any .0.0 and following tags where the commit
  appeared in an earlier branch.

* The result is a single tag for each branch where the application or function
  was defined.

The applications and functions defined in the following files were done by
hand because the XML was extracted from the C source file relatively recently.
* channels/pjsip/dialplan_functions_doc.xml
* main/logger_doc.xml
* main/manager_doc.xml
* res/res_geolocation/geoloc_doc.xml
* res/res_stir_shaken/stir_shaken_doc.xml
