### PR TITLE
docs: Add version information to manager event instance XML elements

### DIFF
--- a/apps/app_agent_pool.c
+++ b/apps/app_agent_pool.c
@@ -181,6 +181,7 @@
 	</manager>
 	<managerEvent language="en_US" name="Agents">
 		<managerEventInstance class="EVENT_FLAG_AGENT">
+			<since><version>12.0.0</version></since>
 			<synopsis>
 				Response event in a series to the Agents AMI action containing
 				information about a defined agent.
@@ -226,6 +227,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="AgentsComplete">
 		<managerEventInstance class="EVENT_FLAG_AGENT">
+			<since><version>12.0.0</version></since>
 			<synopsis>
 				Final response event in a series of events to the Agents AMI action.
 			</synopsis>

--- a/apps/app_confbridge.c
+++ b/apps/app_confbridge.c
@@ -322,6 +322,7 @@
 	</manager>
 	<managerEvent language="en_US" name="ConfbridgeList">
 		<managerEventInstance class="EVENT_FLAG_REPORTING">
+			<since><version>13.20.0</version><version>15.3.0</version></since>
 			<synopsis>Raised as part of the ConfbridgeList action response list.</synopsis>
 			<syntax>
 				<parameter name="Conference">
@@ -401,6 +402,7 @@
 	</manager>
 	<managerEvent language="en_US" name="ConfbridgeListRooms">
 		<managerEventInstance class="EVENT_FLAG_REPORTING">
+			<since><version>16.29.0</version><version>18.15.0</version><version>19.7.0</version></since>
 			<synopsis>Raised as part of the ConfbridgeListRooms action response list.</synopsis>
 			<syntax>
 				<parameter name="Conference">

--- a/apps/app_meetme.c
+++ b/apps/app_meetme.c
@@ -506,6 +506,7 @@
 	</manager>
 	<managerEvent language="en_US" name="MeetmeJoin">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a user joins a MeetMe conference.</synopsis>
 			<syntax>
 				<parameter name="Meetme">
@@ -524,6 +525,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="MeetmeLeave">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a user leaves a MeetMe conference.</synopsis>
 			<syntax>
 				<xi:include xpointer="xpointer(/docs/managerEvent[@name='MeetmeJoin']/managerEventInstance/syntax/parameter)" />
@@ -539,6 +541,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="MeetmeEnd">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a MeetMe conference ends.</synopsis>
 			<syntax>
 				<xi:include xpointer="xpointer(/docs/managerEvent[@name='MeetmeJoin']/managerEventInstance/syntax/parameter[@name='Meetme'])" />
@@ -550,6 +553,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="MeetmeTalkRequest">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a MeetMe user has started talking.</synopsis>
 			<syntax>
 				<xi:include xpointer="xpointer(/docs/managerEvent[@name='MeetmeJoin']/managerEventInstance/syntax/parameter)" />
@@ -568,6 +572,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="MeetmeTalking">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a MeetMe user begins or ends talking.</synopsis>
 			<syntax>
 				<xi:include xpointer="xpointer(/docs/managerEvent[@name='MeetmeJoin']/managerEventInstance/syntax/parameter)" />
@@ -578,6 +583,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="MeetmeMute">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a MeetMe user is muted or unmuted.</synopsis>
 			<syntax>
 				<xi:include xpointer="xpointer(/docs/managerEvent[@name='MeetmeJoin']/managerEventInstance/syntax/parameter)" />
@@ -588,6 +594,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="MeetmeList">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>16.29.0</version><version>18.15.0</version><version>19.7.0</version></since>
 			<synopsis>Raised in response to a MeetmeList command.</synopsis>
 			<syntax>
 				<parameter name="Conference">
@@ -635,6 +642,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="MeetmeListRooms">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>16.29.0</version><version>18.15.0</version><version>19.7.0</version></since>
 			<synopsis>Raised in response to a MeetmeListRooms command.</synopsis>
 			<syntax>
 				<parameter name="Conference">

--- a/apps/app_minivm.c
+++ b/apps/app_minivm.c
@@ -503,6 +503,7 @@
 </function>
 	<managerEvent language="en_US" name="MiniVoiceMail">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a notification is sent out by a MiniVoiceMail application</synopsis>
 			<syntax>
 				<channel_snapshot/>

--- a/apps/app_mixmonitor.c
+++ b/apps/app_mixmonitor.c
@@ -319,6 +319,7 @@
 	</function>
 	<managerEvent language="en_US" name="MixMonitorStart">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>16.17.0</version><version>18.3.0</version></since>
 			<synopsis>Raised when monitoring has started on a channel.</synopsis>
 			<syntax>
 				<channel_snapshot/>
@@ -332,6 +333,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="MixMonitorStop">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>16.17.0</version><version>18.3.0</version></since>
 		<synopsis>Raised when monitoring has stopped on a channel.</synopsis>
 		<syntax>
 			<channel_snapshot/>
@@ -345,6 +347,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="MixMonitorMute">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>16.17.0</version><version>18.3.0</version></since>
 		<synopsis>Raised when monitoring is muted or unmuted on a channel.</synopsis>
 		<syntax>
 			<channel_snapshot/>

--- a/apps/app_queue.c
+++ b/apps/app_queue.c
@@ -1134,6 +1134,7 @@
 
 	<managerEvent language="en_US" name="QueueParams">
 		<managerEventInstance class="EVENT_FLAG_AGENT">
+			<since><version>16.24.0</version><version>18.10.0</version><version>19.2.0</version></since>
 			<synopsis>Raised in response to the QueueStatus action.</synopsis>
 			<syntax>
 				<parameter name="Max">
@@ -1172,6 +1173,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="QueueEntry">
 		<managerEventInstance class="EVENT_FLAG_AGENT">
+			<since><version>16.24.0</version><version>18.10.0</version><version>19.2.0</version></since>
 			<synopsis>Raised in response to the QueueStatus action.</synopsis>
 			<syntax>
 				<parameter name="Queue">
@@ -1213,6 +1215,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="QueueMemberStatus">
 		<managerEventInstance class="EVENT_FLAG_AGENT">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a Queue member's status has changed.</synopsis>
 			<syntax>
 				<parameter name="Queue">
@@ -1293,6 +1296,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="QueueMemberAdded">
 		<managerEventInstance class="EVENT_FLAG_AGENT">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a member is added to the queue.</synopsis>
 			<syntax>
 				<xi:include xpointer="xpointer(/docs/managerEvent[@name='QueueMemberStatus']/managerEventInstance/syntax/parameter)" />
@@ -1305,6 +1309,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="QueueMemberRemoved">
 		<managerEventInstance class="EVENT_FLAG_AGENT">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a member is removed from the queue.</synopsis>
 			<syntax>
 				<xi:include xpointer="xpointer(/docs/managerEvent[@name='QueueMemberStatus']/managerEventInstance/syntax/parameter)" />
@@ -1317,6 +1322,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="QueueMemberPause">
 		<managerEventInstance class="EVENT_FLAG_AGENT">
+			<since><version>12.2.0</version></since>
 			<synopsis>Raised when a member is paused/unpaused in the queue.</synopsis>
 			<syntax>
 				<xi:include xpointer="xpointer(/docs/managerEvent[@name='QueueMemberStatus']/managerEventInstance/syntax/parameter)" />
@@ -1329,6 +1335,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="QueueMemberPenalty">
 		<managerEventInstance class="EVENT_FLAG_AGENT">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a member's penalty is changed.</synopsis>
 			<syntax>
 				<xi:include xpointer="xpointer(/docs/managerEvent[@name='QueueMemberStatus']/managerEventInstance/syntax/parameter)" />
@@ -1340,6 +1347,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="QueueMemberRinginuse">
 		<managerEventInstance class="EVENT_FLAG_AGENT">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a member's ringinuse setting is changed.</synopsis>
 			<syntax>
 				<xi:include xpointer="xpointer(/docs/managerEvent[@name='QueueMemberStatus']/managerEventInstance/syntax/parameter)" />
@@ -1351,6 +1359,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="QueueCallerJoin">
 		<managerEventInstance class="EVENT_FLAG_AGENT">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a caller joins a Queue.</synopsis>
 			<syntax>
 				<channel_snapshot/>
@@ -1370,6 +1379,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="QueueCallerLeave">
 		<managerEventInstance class="EVENT_FLAG_AGENT">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a caller leaves a Queue.</synopsis>
 			<syntax>
 				<channel_snapshot/>
@@ -1384,6 +1394,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="QueueCallerAbandon">
 		<managerEventInstance class="EVENT_FLAG_AGENT">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a caller abandons the queue.</synopsis>
 			<syntax>
 				<channel_snapshot/>
@@ -1400,6 +1411,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="AgentCalled">
 		<managerEventInstance class="EVENT_FLAG_AGENT">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when an queue member is notified of a caller in the queue.</synopsis>
 			<syntax>
 				<channel_snapshot/>
@@ -1417,6 +1429,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="AgentRingNoAnswer">
 		<managerEventInstance class="EVENT_FLAG_AGENT">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a queue member is notified of a caller in the queue and fails to answer.</synopsis>
 			<syntax>
 				<channel_snapshot/>
@@ -1435,6 +1448,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="AgentComplete">
 		<managerEventInstance class="EVENT_FLAG_AGENT">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a queue member has finished servicing a caller in the queue.</synopsis>
 			<syntax>
 				<channel_snapshot/>
@@ -1462,6 +1476,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="AgentDump">
 		<managerEventInstance class="EVENT_FLAG_AGENT">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a queue member hangs up on a caller in the queue.</synopsis>
 			<syntax>
 				<channel_snapshot/>
@@ -1478,6 +1493,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="AgentConnect">
 		<managerEventInstance class="EVENT_FLAG_AGENT">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a queue member answers and is bridged to a caller in the queue.</synopsis>
 			<syntax>
 				<channel_snapshot/>

--- a/apps/app_stack.c
+++ b/apps/app_stack.c
@@ -205,6 +205,7 @@
 	</agi>
 	<managerEvent language="en_US" name="VarSet">
 		<managerEventInstance class="EVENT_FLAG_DIALPLAN">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a variable local to the gosub stack frame is set due to a subroutine call.</synopsis>
 			<syntax>
 				<channel_snapshot/>

--- a/apps/app_voicemail.c
+++ b/apps/app_voicemail.c
@@ -573,6 +573,7 @@
 	</manager>
 	<managerEvent language="en_US" name="VoicemailPasswordChange">
 		<managerEventInstance class="EVENT_FLAG_USER">
+			<since><version>18.21.0</version><version>20.6.0</version><version>21.1.0</version></since>
 			<synopsis>Raised in response to a mailbox password change.</synopsis>
 			<syntax>
 				<parameter name="Context">

--- a/apps/confbridge/confbridge_manager.c
+++ b/apps/confbridge/confbridge_manager.c
@@ -39,6 +39,7 @@
 /*** DOCUMENTATION
 	<managerEvent language="en_US" name="ConfbridgeStart">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a conference starts.</synopsis>
 			<syntax>
 				<parameter name="Conference">
@@ -54,6 +55,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="ConfbridgeEnd">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a conference ends.</synopsis>
 			<syntax>
 				<parameter name="Conference">
@@ -69,6 +71,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="ConfbridgeJoin">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a channel joins a Confbridge conference.</synopsis>
 			<syntax>
 				<parameter name="Conference">
@@ -99,6 +102,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="ConfbridgeLeave">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a channel leaves a Confbridge conference.</synopsis>
 			<syntax>
 				<parameter name="Conference">
@@ -122,6 +126,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="ConfbridgeRecord">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a conference starts recording.</synopsis>
 			<syntax>
 				<parameter name="Conference">
@@ -137,6 +142,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="ConfbridgeStopRecord">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a conference that was recording stops recording.</synopsis>
 			<syntax>
 				<parameter name="Conference">
@@ -152,6 +158,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="ConfbridgeMute">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a Confbridge participant mutes.</synopsis>
 			<syntax>
 				<parameter name="Conference">
@@ -175,6 +182,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="ConfbridgeUnmute">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a confbridge participant unmutes.</synopsis>
 			<syntax>
 				<parameter name="Conference">
@@ -198,6 +206,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="ConfbridgeTalking">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a confbridge participant begins or ends talking.</synopsis>
 			<syntax>
 				<parameter name="Conference">

--- a/build_tools/get_documentation
+++ b/build_tools/get_documentation
@@ -1,3 +1,3 @@
 /\/\*\*\* DOCUMENTATION/ {printit=1; next}
-/\*\*\*\// {if (printit) exit}
+/\*\*\*\// {if (printit) printit=0}
 {if (printit) print}

--- a/cdr/cdr_manager.c
+++ b/cdr/cdr_manager.c
@@ -41,6 +41,7 @@
 /*** DOCUMENTATION
 	<managerEvent language="en_US" name="Cdr">
 		<managerEventInstance class="EVENT_FLAG_CDR">
+			<since><version>13.2.0</version></since>
 			<synopsis>Raised when a CDR is generated.</synopsis>
 			<syntax>
 				<parameter name="AccountCode">

--- a/cel/cel_manager.c
+++ b/cel/cel_manager.c
@@ -36,6 +36,7 @@
 /*** DOCUMENTATION
 	<managerEvent language="en_US" name="CEL">
 		<managerEventInstance class="EVENT_FLAG_CEL">
+			<since><version>13.2.0</version></since>
 			<synopsis>Raised when a Channel Event Log is generated for a channel.</synopsis>
 			<syntax>
 				<parameter name="EventName">

--- a/channels/chan_dahdi.c
+++ b/channels/chan_dahdi.c
@@ -556,6 +556,7 @@
 	</manager>
 	<managerEvent language="en_US" name="AlarmClear">
 		<managerEventInstance class="EVENT_FLAG_SYSTEM">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when an alarm is cleared on a DAHDI channel.</synopsis>
 			<syntax>
 				<parameter name="DAHDIChannel">
@@ -567,6 +568,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="SpanAlarmClear">
 		<managerEventInstance class="EVENT_FLAG_SYSTEM">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when an alarm is cleared on a DAHDI span.</synopsis>
 			<syntax>
 				<parameter name="Span">
@@ -577,6 +579,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="DNDState">
 		<managerEventInstance class="EVENT_FLAG_SYSTEM">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when the Do Not Disturb state is changed on a DAHDI channel.</synopsis>
 			<syntax>
 				<parameter name="DAHDIChannel">
@@ -594,6 +597,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="Alarm">
 		<managerEventInstance class="EVENT_FLAG_SYSTEM">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when an alarm is set on a DAHDI channel.</synopsis>
 			<syntax>
 				<parameter name="DAHDIChannel">
@@ -608,6 +612,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="SpanAlarm">
 		<managerEventInstance class="EVENT_FLAG_SYSTEM">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when an alarm is set on a DAHDI span.</synopsis>
 			<syntax>
 				<parameter name="Span">
@@ -621,6 +626,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="DAHDIChannel">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a DAHDI channel is created or an underlying technology is associated with a DAHDI channel.</synopsis>
 			<syntax>
 				<channel_snapshot/>

--- a/channels/sig_pri.c
+++ b/channels/sig_pri.c
@@ -29,6 +29,7 @@
 /*** DOCUMENTATION
 	<managerEvent language="en_US" name="MCID">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Published when a malicious call ID request arrives.</synopsis>
 			<syntax>
 				<channel_snapshot/>

--- a/funcs/func_global.c
+++ b/funcs/func_global.c
@@ -117,6 +117,7 @@
 	</function>
 	<managerEvent language="en_US" name="VarSet">
 		<managerEventInstance class="EVENT_FLAG_DIALPLAN">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a variable is shared between channels.</synopsis>
 			<syntax>
 				<channel_snapshot/>

--- a/main/aoc.c
+++ b/main/aoc.c
@@ -41,6 +41,7 @@
 /*** DOCUMENTATION
 	<managerEvent language="en_US" name="AOC-S">
 		<managerEventInstance class="EVENT_FLAG_AOC">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when an Advice of Charge message is sent at the beginning of a call.</synopsis>
 			<syntax>
 				<channel_snapshot/>
@@ -92,6 +93,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="AOC-D">
 		<managerEventInstance class="EVENT_FLAG_AOC">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when an Advice of Charge message is sent during a call.</synopsis>
 			<syntax>
 				<channel_snapshot/>
@@ -150,6 +152,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="AOC-E">
 		<managerEventInstance class="EVENT_FLAG_AOC">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when an Advice of Charge message is sent at the end of a call.</synopsis>
 			<syntax>
 				<channel_snapshot/>

--- a/main/asterisk.c
+++ b/main/asterisk.c
@@ -249,6 +249,7 @@ int daemon(int, int);  /* defined in libresolv of all places */
 /*** DOCUMENTATION
 	<managerEvent language="en_US" name="FullyBooted">
 		<managerEventInstance class="EVENT_FLAG_SYSTEM">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when all Asterisk initialization procedures have finished.</synopsis>
 			<syntax>
 				<parameter name="Status">
@@ -265,6 +266,7 @@ int daemon(int, int);  /* defined in libresolv of all places */
 	</managerEvent>
 	<managerEvent language="en_US" name="Shutdown">
 		<managerEventInstance class="EVENT_FLAG_SYSTEM">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when Asterisk is shutdown or restarted.</synopsis>
 			<syntax>
 				<parameter name="Shutdown">

--- a/main/channel.c
+++ b/main/channel.c
@@ -6763,6 +6763,7 @@ static void __ast_change_name_nolink(struct ast_channel *chan, const char *newna
 	/*** DOCUMENTATION
 		<managerEvent language="en_US" name="Rename">
 			<managerEventInstance class="EVENT_FLAG_CALL">
+				<since><version>16.24.0</version><version>18.10.0</version><version>19.2.0</version></since>
 				<synopsis>Raised when the name of a channel is changed.</synopsis>
 			</managerEventInstance>
 		</managerEvent>

--- a/main/core_local.c
+++ b/main/core_local.c
@@ -73,6 +73,7 @@
 	</manager>
 	<managerEvent language="en_US" name="LocalBridge">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when two halves of a Local Channel form a bridge.</synopsis>
 			<syntax>
 				<channel_snapshot prefix="LocalOne"/>
@@ -94,6 +95,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="LocalOptimizationBegin">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when two halves of a Local Channel begin to optimize
 			themselves out of the media path.</synopsis>
 			<syntax>
@@ -115,6 +117,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="LocalOptimizationEnd">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when two halves of a Local Channel have finished optimizing
 			themselves out of the media path.</synopsis>
 			<syntax>

--- a/main/devicestate.c
+++ b/main/devicestate.c
@@ -120,6 +120,7 @@
 /*** DOCUMENTATION
 	<managerEvent language="en_US" name="DeviceStateChange">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>13.0.0</version></since>
 			<synopsis>Raised when a device state changes</synopsis>
 			<syntax>
 				<parameter name="Device">

--- a/main/loader.c
+++ b/main/loader.c
@@ -58,6 +58,7 @@
 /*** DOCUMENTATION
 	<managerEvent language="en_US" name="Reload">
 		<managerEventInstance class="EVENT_FLAG_SYSTEM">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a module has been reloaded in Asterisk.</synopsis>
 			<syntax>
 				<parameter name="Module">
@@ -82,6 +83,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="Load">
 		<managerEventInstance class="EVENT_FLAG_SYSTEM">
+			<since><version>16.0.0</version></since>
 			<synopsis>Raised when a module has been loaded in Asterisk.</synopsis>
 			<syntax>
 				<parameter name="Module">
@@ -100,6 +102,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="Unload">
 		<managerEventInstance class="EVENT_FLAG_SYSTEM">
+			<since><version>16.0.0</version></since>
 			<synopsis>Raised when a module has been unloaded in Asterisk.</synopsis>
 			<syntax>
 				<parameter name="Module">

--- a/main/lock.c
+++ b/main/lock.c
@@ -322,6 +322,7 @@ int __ast_pthread_mutex_lock(const char *filename, int lineno, const char *func,
 						/*** DOCUMENTATION
 							<managerEvent language="en_US" name="DeadlockStart">
 								<managerEventInstance class="EVENT_FLAG_SYSTEM">
+									<since><version>16.29.0</version><version>18.15.0</version><version>19.7.0</version></since>
 									<synopsis>Raised when a probable deadlock has started.
 									Delivery of this event is attempted but not guaranteed,
                                                                         and could fail for example if the manager itself is deadlocked.

--- a/main/logger.c
+++ b/main/logger.c
@@ -71,9 +71,6 @@
 #include "asterisk/backtrace.h"
 #include "asterisk/json.h"
 
-/*** DOCUMENTATION
- ***/
-
 static int logger_register_level(const char *name);
 static int logger_unregister_level(const char *name);
 static int logger_get_dynamic_level(const char *name);
@@ -1239,18 +1236,6 @@ static int reload_logger(int rotate, const char *altconf)
 	AST_RWLIST_TRAVERSE(&logchannels, f, list) {
 		if (f->disabled) {
 			f->disabled = 0;	/* Re-enable logging at reload */
-			/*** DOCUMENTATION
-				<managerEvent language="en_US" name="LogChannel">
-					<managerEventInstance class="EVENT_FLAG_SYSTEM">
-						<synopsis>Raised when a logging channel is re-enabled after a reload operation.</synopsis>
-						<syntax>
-							<parameter name="Channel">
-								<para>The name of the logging channel.</para>
-							</parameter>
-						</syntax>
-					</managerEventInstance>
-				</managerEvent>
-			***/
 			manager_event(EVENT_FLAG_SYSTEM, "LogChannel", "Channel: %s\r\nEnabled: Yes\r\n", f->filename);
 		}
 		if (f->fileptr && (f->fileptr != stdout) && (f->fileptr != stderr)) {
@@ -1983,16 +1968,6 @@ static void logger_print_normal(struct logmsg *logmsg)
 							fprintf(stderr, "Logger Warning: Unable to write to log file '%s': %s (disabled)\n", chan->filename, strerror(errno));
 						}
 
-						/*** DOCUMENTATION
-							<managerEventInstance>
-								<synopsis>Raised when a logging channel is disabled.</synopsis>
-								<syntax>
-									<parameter name="Channel">
-										<para>The name of the logging channel.</para>
-									</parameter>
-								</syntax>
-							</managerEventInstance>
-						***/
 						manager_event(EVENT_FLAG_SYSTEM, "LogChannel", "Channel: %s\r\nEnabled: No\r\nReason: %d - %s\r\n", chan->filename, errno, strerror(errno));
 						chan->disabled = 1;
 					}

--- a/main/logger_doc.xml
+++ b/main/logger_doc.xml
@@ -34,4 +34,24 @@
 			<ref type="application">Log</ref>
 		</see-also>
 	</function>
+	<managerEvent language="en_US" name="LogChannel">
+		<managerEventInstance class="EVENT_FLAG_SYSTEM">
+			<since><version>16.24.0</version><version>18.10.0</version><version>19.2.0</version></since>
+			<synopsis>Raised when a logging channel is re-enabled after a reload operation.</synopsis>
+			<syntax>
+				<parameter name="Channel">
+					<para>The name of the logging channel.</para>
+				</parameter>
+			</syntax>
+		</managerEventInstance>
+		<managerEventInstance class="EVENT_FLAG_SYSTEM">
+			<since><version>16.24.0</version><version>18.10.0</version><version>19.2.0</version></since>
+			<synopsis>Raised when a logging channel is disabled.</synopsis>
+			<syntax>
+				<parameter name="Channel">
+					<para>The name of the logging channel.</para>
+				</parameter>
+			</syntax>
+		</managerEventInstance>
+	</managerEvent>
 </docs>

--- a/main/manager_bridges.c
+++ b/main/manager_bridges.c
@@ -36,6 +36,7 @@ static struct stasis_message_router *bridge_state_router;
 /*** DOCUMENTATION
 	<managerEvent language="en_US" name="BridgeCreate">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a bridge is created.</synopsis>
 			<syntax>
 				<bridge_snapshot/>
@@ -49,6 +50,7 @@ static struct stasis_message_router *bridge_state_router;
 	</managerEvent>
 	<managerEvent language="en_US" name="BridgeDestroy">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a bridge is destroyed.</synopsis>
 			<syntax>
 				<bridge_snapshot/>
@@ -62,6 +64,7 @@ static struct stasis_message_router *bridge_state_router;
 	</managerEvent>
 	<managerEvent language="en_US" name="BridgeEnter">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a channel enters a bridge.</synopsis>
 			<syntax>
 				<bridge_snapshot/>
@@ -79,6 +82,7 @@ static struct stasis_message_router *bridge_state_router;
 	</managerEvent>
 	<managerEvent language="en_US" name="BridgeLeave">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a channel leaves a bridge.</synopsis>
 			<syntax>
 				<bridge_snapshot/>
@@ -93,6 +97,7 @@ static struct stasis_message_router *bridge_state_router;
 	</managerEvent>
 	<managerEvent language="en_US" name="BridgeVideoSourceUpdate">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>13.13.0</version><version>14.2.0</version></since>
 			<synopsis>Raised when the channel that is the source of video in a bridge changes.</synopsis>
 			<syntax>
 				<bridge_snapshot/>
@@ -155,6 +160,7 @@ static struct stasis_message_router *bridge_state_router;
 			<list-elements>
 				<managerEvent language="en_US" name="BridgeInfoChannel">
 					<managerEventInstance class="EVENT_FLAG_COMMAND">
+						<since><version>13.0.0</version></since>
 						<synopsis>Information about a channel in a bridge.</synopsis>
 						<syntax>
 							<channel_snapshot/>
@@ -164,6 +170,7 @@ static struct stasis_message_router *bridge_state_router;
 			</list-elements>
 			<managerEvent language="en_US" name="BridgeInfoComplete">
 				<managerEventInstance class="EVENT_FLAG_COMMAND">
+					<since><version>13.0.0</version></since>
 					<synopsis>Information about a bridge.</synopsis>
 					<syntax>
 						<bridge_snapshot/>
@@ -390,6 +397,7 @@ static void bridge_merge_cb(void *data, struct stasis_subscription *sub,
 	/*** DOCUMENTATION
 		<managerEvent language="en_US" name="BridgeMerge">
 			<managerEventInstance class="EVENT_FLAG_CALL">
+				<since><version>16.24.0</version><version>18.10.0</version><version>19.2.0</version></since>
 				<synopsis>Raised when two bridges are merged.</synopsis>
 				<syntax>
 					<bridge_snapshot prefix="To"/>

--- a/main/manager_channels.c
+++ b/main/manager_channels.c
@@ -38,6 +38,7 @@
 /*** DOCUMENTATION
 	<managerEvent language="en_US" name="Newchannel">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a new channel is created.</synopsis>
 			<syntax>
 				<channel_snapshot/>
@@ -50,6 +51,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="Newstate">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a channel's state changes.</synopsis>
 			<syntax>
 				<channel_snapshot/>
@@ -62,6 +64,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="Hangup">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a channel is hung up.</synopsis>
 			<syntax>
 				<channel_snapshot/>
@@ -82,6 +85,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="HangupRequest">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a hangup is requested.</synopsis>
 			<syntax>
 				<channel_snapshot/>
@@ -95,6 +99,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="SoftHangupRequest">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a soft hangup is requested with a specific cause code.</synopsis>
 			<syntax>
 				<channel_snapshot/>
@@ -108,6 +113,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="NewExten">
 		<managerEventInstance class="EVENT_FLAG_DIALPLAN">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a channel enters a new context, extension, priority.</synopsis>
 			<syntax>
 				<channel_snapshot/>
@@ -127,6 +133,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="NewCallerid">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a channel receives new Caller ID information.</synopsis>
 			<syntax>
 				<channel_snapshot/>
@@ -141,6 +148,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="NewConnectedLine">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>13.13.0</version><version>14.2.0</version></since>
 			<synopsis>Raised when a channel's connected line information is changed.</synopsis>
 			<syntax>
 				<channel_snapshot/>
@@ -152,6 +160,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="NewAccountCode">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a Channel's AccountCode is changed.</synopsis>
 			<syntax>
 				<channel_snapshot/>
@@ -166,6 +175,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="DialBegin">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a dial action has started.</synopsis>
 			<syntax>
 				<channel_snapshot/>
@@ -184,6 +194,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="DialState">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>14.0.0</version></since>
 			<synopsis>Raised when dial status has changed.</synopsis>
 			<syntax>
 				<channel_snapshot/>
@@ -211,6 +222,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="DialEnd">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a dial action has completed.</synopsis>
 			<syntax>
 				<channel_snapshot/>
@@ -267,6 +279,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="Hold">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a channel goes on hold.</synopsis>
 			<syntax>
 				<channel_snapshot/>
@@ -281,6 +294,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="Unhold">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a channel goes off hold.</synopsis>
 			<syntax>
 				<channel_snapshot/>
@@ -292,6 +306,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="ChanSpyStart">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when one channel begins spying on another channel.</synopsis>
 			<syntax>
 				<channel_snapshot prefix="Spyer"/>
@@ -305,6 +320,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="ChanSpyStop">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a channel has stopped spying.</synopsis>
 			<syntax>
 				<channel_snapshot prefix="Spyer"/>
@@ -318,6 +334,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="HangupHandlerRun">
 		<managerEventInstance class="EVENT_FLAG_DIALPLAN">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a hangup handler is about to be called.</synopsis>
 			<syntax>
 				<channel_snapshot/>
@@ -332,6 +349,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="HangupHandlerPop">
 		<managerEventInstance class="EVENT_FLAG_DIALPLAN">
+			<since><version>12.0.0</version></since>
 			<synopsis>
 				Raised when a hangup handler is removed from the handler stack
 				by the CHANNEL() function.
@@ -348,6 +366,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="HangupHandlerPush">
 		<managerEventInstance class="EVENT_FLAG_DIALPLAN">
+			<since><version>12.0.0</version></since>
 			<synopsis>
 				Raised when a hangup handler is added to the handler stack by
 				the CHANNEL() function.
@@ -364,6 +383,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="FAXStatus">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>
 				Raised periodically during a fax transmission.
 			</synopsis>
@@ -386,6 +406,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="ReceiveFAX">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>
 				Raised when a receive fax operation has completed.
 			</synopsis>
@@ -414,6 +435,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="SendFAX">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>
 				Raised when a send fax operation has completed.
 			</synopsis>
@@ -425,6 +447,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="MusicOnHoldStart">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when music on hold has started on a channel.</synopsis>
 			<syntax>
 				<channel_snapshot/>
@@ -441,6 +464,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="MusicOnHoldStop">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when music on hold has stopped on a channel.</synopsis>
 			<syntax>
 				<channel_snapshot/>
@@ -871,6 +895,7 @@ static void channel_dtmf_begin_cb(void *data, struct stasis_subscription *sub,
 	/*** DOCUMENTATION
 		<managerEvent language="en_US" name="DTMFBegin">
 			<managerEventInstance class="EVENT_FLAG_DTMF">
+				<since><version>16.24.0</version><version>18.10.0</version><version>19.2.0</version></since>
 				<synopsis>Raised when a DTMF digit has started on a channel.</synopsis>
 					<syntax>
 						<channel_snapshot/>
@@ -919,6 +944,7 @@ static void channel_dtmf_end_cb(void *data, struct stasis_subscription *sub,
 	/*** DOCUMENTATION
 		<managerEvent language="en_US" name="DTMFEnd">
 			<managerEventInstance class="EVENT_FLAG_DTMF">
+				<since><version>16.24.0</version><version>18.10.0</version><version>19.2.0</version></since>
 				<synopsis>Raised when a DTMF digit has ended on a channel.</synopsis>
 					<syntax>
 						<channel_snapshot/>
@@ -964,6 +990,7 @@ static void channel_flash_cb(void *data, struct stasis_subscription *sub,
 	/*** DOCUMENTATION
 		<managerEvent language="en_US" name="Flash">
 			<managerEventInstance class="EVENT_FLAG_CALL">
+				<since><version>16.24.0</version><version>18.10.0</version><version>19.2.0</version></since>
 				<synopsis>Raised when a hook flash occurs on a channel.</synopsis>
 					<syntax>
 						<channel_snapshot/>
@@ -992,6 +1019,7 @@ static void channel_wink_cb(void *data, struct stasis_subscription *sub,
 	/*** DOCUMENTATION
 		<managerEvent language="en_US" name="Wink">
 			<managerEventInstance class="EVENT_FLAG_CALL">
+				<since><version>16.24.0</version><version>18.10.0</version><version>19.2.0</version></since>
 				<synopsis>Raised when a wink occurs on a channel.</synopsis>
 					<syntax>
 						<channel_snapshot/>

--- a/main/manager_doc.xml
+++ b/main/manager_doc.xml
@@ -192,6 +192,7 @@
 	</manager>
 	<managerEvent language="en_US" name="Status">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>18.26.0</version><version>20.11.0</version><version>21.6.0</version><version>22.1.0</version></since>
 			<synopsis>Raised in response to a Status command.</synopsis>
 			<syntax>
 				<parameter name="ActionID" required="false"/>
@@ -250,6 +251,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="StatusComplete">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>18.26.0</version><version>20.11.0</version><version>21.6.0</version><version>22.1.0</version></since>
 			<synopsis>Raised in response to a Status command.</synopsis>
 			<syntax>
 				<parameter name="Items">
@@ -702,6 +704,7 @@
 	</manager>
 	<managerEvent language="en_US" name="OriginateResponse">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>18.26.0</version><version>20.11.0</version><version>21.6.0</version><version>22.1.0</version></since>
 			<synopsis>Raised in response to an Originate command.</synopsis>
 			<syntax>
 				<parameter name="ActionID" required="false"/>
@@ -1001,6 +1004,7 @@
 	</manager>
 	<managerEvent language="en_US" name="CoreShowChannel">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>18.26.0</version><version>20.11.0</version><version>21.6.0</version><version>22.1.0</version></since>
 			<synopsis>Raised in response to a CoreShowChannels command.</synopsis>
 			<syntax>
 				<xi:include xpointer="xpointer(/docs/manager[@name='Login']/syntax/parameter[@name='ActionID'])" />
@@ -1026,6 +1030,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="CoreShowChannelsComplete">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>18.26.0</version><version>20.11.0</version><version>21.6.0</version><version>22.1.0</version></since>
 			<synopsis>Raised at the end of the CoreShowChannel list produced by the CoreShowChannels command.</synopsis>
 			<syntax>
 				<xi:include xpointer="xpointer(/docs/manager[@name='Login']/syntax/parameter[@name='ActionID'])" />
@@ -1064,6 +1069,7 @@
 	</manager>
 	<managerEvent language="en_US" name="CoreShowChannelMapComplete">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>18.26.0</version><version>20.11.0</version><version>21.6.0</version><version>22.1.0</version></since>
 			<synopsis>Raised at the end of the CoreShowChannelMap list produced by the CoreShowChannelMap command.</synopsis>
 			<syntax>
 				<parameter name="EventList">
@@ -1576,6 +1582,7 @@
 	</manager>
 	<managerEvent name="ExtensionStatus" language="en_US">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>18.26.0</version><version>20.11.0</version><version>21.6.0</version><version>22.1.0</version></since>
 			<synopsis>Raised when a hint changes due to a device state change.</synopsis>
 			<syntax>
 				<parameter name="Exten">
@@ -1656,6 +1663,7 @@
 	</managerEvent>
 	<managerEvent name="PresenceStatus" language="en_US">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>18.26.0</version><version>20.11.0</version><version>21.6.0</version><version>22.1.0</version></since>
 			<synopsis>Raised when a hint changes due to a presence state change.</synopsis>
 			<syntax>
 				<parameter name="Exten" />

--- a/main/manager_mwi.c
+++ b/main/manager_mwi.c
@@ -105,6 +105,7 @@ static void mwi_update_cb(void *data, struct stasis_subscription *sub,
 	/*** DOCUMENTATION
 		<managerEvent language="en_US" name="MessageWaiting">
 			<managerEventInstance class="EVENT_FLAG_CALL">
+				<since><version>16.24.0</version><version>18.10.0</version><version>19.2.0</version></since>
 				<synopsis>Raised when the state of messages in a voicemail mailbox
 				has changed or when a channel has finished interacting with a
 				mailbox.</synopsis>

--- a/main/pbx.c
+++ b/main/pbx.c
@@ -199,6 +199,7 @@
 			</list-elements>
 			<managerEvent name="ExtensionStateListComplete" language="en_US">
 				<managerEventInstance class="EVENT_FLAG_COMMAND">
+					<since><version>13.0.0</version></since>
 					<synopsis>
 						Indicates the end of the list the current known extension states.
 					</synopsis>

--- a/main/pickup.c
+++ b/main/pickup.c
@@ -36,6 +36,7 @@
 /*** DOCUMENTATION
 	<managerEvent language="en_US" name="Pickup">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a call pickup occurs.</synopsis>
 			<syntax>
 				<channel_snapshot/>

--- a/main/presencestate.c
+++ b/main/presencestate.c
@@ -28,6 +28,7 @@
 /*** DOCUMENTATION
 	<managerEvent language="en_US" name="PresenceStateChange">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>13.0.0</version></since>
 			<synopsis>Raised when a presence state changes</synopsis>
 			<syntax>
 				<parameter name="Presentity">

--- a/main/rtp_engine.c
+++ b/main/rtp_engine.c
@@ -30,6 +30,7 @@
 /*** DOCUMENTATION
 	<managerEvent language="en_US" name="RTCPSent">
 		<managerEventInstance class="EVENT_FLAG_REPORTING">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when an RTCP packet is sent.</synopsis>
 			<syntax>
 				<channel_snapshot/>
@@ -109,6 +110,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="RTCPReceived">
 		<managerEventInstance class="EVENT_FLAG_REPORTING">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when an RTCP packet is received.</synopsis>
 			<syntax>
 				<channel_snapshot/>

--- a/main/security_events.c
+++ b/main/security_events.c
@@ -31,6 +31,7 @@
 /*** DOCUMENTATION
 	<managerEvent language="en_US" name="FailedACL">
 		<managerEventInstance class="EVENT_FLAG_SECURITY">
+			<since><version>12.1.0</version></since>
 			<synopsis>Raised when a request violates an ACL check.</synopsis>
 			<syntax>
 				<parameter name="EventTV">
@@ -79,6 +80,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="InvalidAccountID">
 		<managerEventInstance class="EVENT_FLAG_SECURITY">
+			<since><version>12.1.0</version></since>
 			<synopsis>Raised when a request fails an authentication check due to an invalid account ID.</synopsis>
 			<syntax>
 				<xi:include xpointer="xpointer(/docs/managerEvent[@name='FailedACL']/managerEventInstance/syntax/parameter[@name='EventTV'])" />
@@ -96,6 +98,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="SessionLimit">
 		<managerEventInstance class="EVENT_FLAG_SECURITY">
+			<since><version>12.1.0</version></since>
 			<synopsis>Raised when a request fails due to exceeding the number of allowed concurrent sessions for that service.</synopsis>
 			<syntax>
 				<xi:include xpointer="xpointer(/docs/managerEvent[@name='FailedACL']/managerEventInstance/syntax/parameter[@name='EventTV'])" />
@@ -113,6 +116,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="MemoryLimit">
 		<managerEventInstance class="EVENT_FLAG_SECURITY">
+			<since><version>12.1.0</version></since>
 			<synopsis>Raised when a request fails due to an internal memory allocation failure.</synopsis>
 			<syntax>
 				<xi:include xpointer="xpointer(/docs/managerEvent[@name='FailedACL']/managerEventInstance/syntax/parameter[@name='EventTV'])" />
@@ -130,6 +134,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="LoadAverageLimit">
 		<managerEventInstance class="EVENT_FLAG_SECURITY">
+			<since><version>12.1.0</version></since>
 			<synopsis>Raised when a request fails because a configured load average limit has been reached.</synopsis>
 			<syntax>
 				<xi:include xpointer="xpointer(/docs/managerEvent[@name='FailedACL']/managerEventInstance/syntax/parameter[@name='EventTV'])" />
@@ -147,6 +152,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="RequestNotSupported">
 		<managerEventInstance class="EVENT_FLAG_SECURITY">
+			<since><version>12.1.0</version></since>
 			<synopsis>Raised when a request fails due to some aspect of the requested item not being supported by the service.</synopsis>
 			<syntax>
 				<xi:include xpointer="xpointer(/docs/managerEvent[@name='FailedACL']/managerEventInstance/syntax/parameter[@name='EventTV'])" />
@@ -167,6 +173,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="RequestNotAllowed">
 		<managerEventInstance class="EVENT_FLAG_SECURITY">
+			<since><version>12.1.0</version></since>
 			<synopsis>Raised when a request is not allowed by the service.</synopsis>
 			<syntax>
 				<xi:include xpointer="xpointer(/docs/managerEvent[@name='FailedACL']/managerEventInstance/syntax/parameter[@name='EventTV'])" />
@@ -188,6 +195,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="AuthMethodNotAllowed">
 		<managerEventInstance class="EVENT_FLAG_SECURITY">
+			<since><version>12.1.0</version></since>
 			<synopsis>Raised when a request used an authentication method not allowed by the service.</synopsis>
 			<syntax>
 				<xi:include xpointer="xpointer(/docs/managerEvent[@name='FailedACL']/managerEventInstance/syntax/parameter[@name='EventTV'])" />
@@ -208,6 +216,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="RequestBadFormat">
 		<managerEventInstance class="EVENT_FLAG_SECURITY">
+			<since><version>12.1.0</version></since>
 			<synopsis>Raised when a request is received with bad formatting.</synopsis>
 			<syntax>
 				<xi:include xpointer="xpointer(/docs/managerEvent[@name='FailedACL']/managerEventInstance/syntax/parameter[@name='EventTV'])" />
@@ -230,6 +239,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="SuccessfulAuth">
 		<managerEventInstance class="EVENT_FLAG_SECURITY">
+			<since><version>12.1.0</version></since>
 			<synopsis>Raised when a request successfully authenticates with a service.</synopsis>
 			<syntax>
 				<xi:include xpointer="xpointer(/docs/managerEvent[@name='FailedACL']/managerEventInstance/syntax/parameter[@name='EventTV'])" />
@@ -250,6 +260,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="UnexpectedAddress">
 		<managerEventInstance class="EVENT_FLAG_SECURITY">
+			<since><version>12.1.0</version></since>
 			<synopsis>Raised when a request has a different source address then what is expected for a session already in progress with a service.</synopsis>
 			<syntax>
 				<xi:include xpointer="xpointer(/docs/managerEvent[@name='FailedACL']/managerEventInstance/syntax/parameter[@name='EventTV'])" />
@@ -270,6 +281,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="ChallengeResponseFailed">
 		<managerEventInstance class="EVENT_FLAG_SECURITY">
+			<since><version>12.1.0</version></since>
 			<synopsis>Raised when a request's attempt to authenticate has been challenged, and the request failed the authentication challenge.</synopsis>
 			<syntax>
 				<xi:include xpointer="xpointer(/docs/managerEvent[@name='FailedACL']/managerEventInstance/syntax/parameter[@name='EventTV'])" />
@@ -296,6 +308,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="InvalidPassword">
 		<managerEventInstance class="EVENT_FLAG_SECURITY">
+			<since><version>12.1.0</version></since>
 			<synopsis>Raised when a request provides an invalid password during an authentication attempt.</synopsis>
 			<syntax>
 				<xi:include xpointer="xpointer(/docs/managerEvent[@name='FailedACL']/managerEventInstance/syntax/parameter[@name='EventTV'])" />
@@ -322,6 +335,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="ChallengeSent">
 		<managerEventInstance class="EVENT_FLAG_SECURITY">
+			<since><version>12.1.0</version></since>
 			<synopsis>Raised when an Asterisk service sends an authentication challenge to a request.</synopsis>
 			<syntax>
 				<xi:include xpointer="xpointer(/docs/managerEvent[@name='FailedACL']/managerEventInstance/syntax/parameter[@name='EventTV'])" />
@@ -340,6 +354,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="InvalidTransport">
 		<managerEventInstance class="EVENT_FLAG_SECURITY">
+			<since><version>12.1.0</version></since>
 			<synopsis>Raised when a request attempts to use a transport not allowed by the Asterisk service.</synopsis>
 			<syntax>
 				<xi:include xpointer="xpointer(/docs/managerEvent[@name='FailedACL']/managerEventInstance/syntax/parameter[@name='EventTV'])" />

--- a/main/stasis.c
+++ b/main/stasis.c
@@ -46,6 +46,7 @@
 /*** DOCUMENTATION
 	<managerEvent language="en_US" name="UserEvent">
 		<managerEventInstance class="EVENT_FLAG_USER">
+			<since><version>12.3.0</version></since>
 			<synopsis>A user defined event raised from the dialplan.</synopsis>
 			<syntax>
 				<channel_snapshot/>

--- a/main/stasis_bridges.c
+++ b/main/stasis_bridges.c
@@ -46,6 +46,7 @@
 /*** DOCUMENTATION
 	<managerEvent language="en_US" name="BlindTransfer">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a blind transfer is complete.</synopsis>
 			<syntax>
 				<parameter name="Result">
@@ -84,6 +85,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="AttendedTransfer">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when an attended transfer is complete.</synopsis>
 			<syntax>
 				<xi:include xpointer="xpointer(docs/managerEvent[@name='BlindTransfer']/managerEventInstance/syntax/parameter[@name='Result'])" />

--- a/main/stasis_channels.c
+++ b/main/stasis_channels.c
@@ -44,6 +44,7 @@
 /*** DOCUMENTATION
 	<managerEvent language="en_US" name="VarSet">
 		<managerEventInstance class="EVENT_FLAG_DIALPLAN">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a variable is set to a particular value.</synopsis>
 			<syntax>
 				<channel_snapshot/>
@@ -58,6 +59,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="AgentLogin">
 		<managerEventInstance class="EVENT_FLAG_AGENT">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when an Agent has logged in.</synopsis>
 			<syntax>
 				<channel_snapshot/>
@@ -73,6 +75,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="AgentLogoff">
 		<managerEventInstance class="EVENT_FLAG_AGENT">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when an Agent has logged off.</synopsis>
 			<syntax>
 				<xi:include xpointer="xpointer(/docs/managerEvent[@name='AgentLogin']/managerEventInstance/syntax/parameter)" />
@@ -87,6 +90,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="ChannelTalkingStart">
 		<managerEventInstance class="EVENT_FLAG_CLASS">
+			<since><version>12.4.0</version></since>
 			<synopsis>Raised when talking is detected on a channel.</synopsis>
 			<syntax>
 				<channel_snapshot/>
@@ -99,6 +103,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="ChannelTalkingStop">
 		<managerEventInstance class="EVENT_FLAG_CLASS">
+			<since><version>12.4.0</version></since>
 			<synopsis>Raised when talking is no longer detected on a channel.</synopsis>
 			<syntax>
 				<channel_snapshot/>

--- a/main/stasis_endpoints.c
+++ b/main/stasis_endpoints.c
@@ -36,6 +36,7 @@
 /*** DOCUMENTATION
 	<managerEvent language="en_US" name="PeerStatus">
 		<managerEventInstance class="EVENT_FLAG_SYSTEM">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when the state of a peer changes.</synopsis>
 			<syntax>
 				<parameter name="ChannelType">
@@ -71,6 +72,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="ContactStatus">
 		<managerEventInstance class="EVENT_FLAG_SYSTEM">
+			<since><version>13.5.0</version></since>
 			<synopsis>Raised when the state of a contact changes.</synopsis>
 			<syntax>
 				<parameter name="URI">

--- a/main/stasis_system.c
+++ b/main/stasis_system.c
@@ -36,6 +36,7 @@
 /*** DOCUMENTATION
 	<managerEvent language="en_US" name="Registry">
 		<managerEventInstance class="EVENT_FLAG_SYSTEM">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when an outbound registration completes.</synopsis>
 			<syntax>
 				<parameter name="ChannelType">

--- a/res/parking/parking_manager.c
+++ b/res/parking/parking_manager.c
@@ -116,6 +116,7 @@
 	</manager>
 	<managerEvent language="en_US" name="ParkedCall">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a channel is parked.</synopsis>
 			<syntax>
 				<channel_snapshot prefix="Parkee"/>
@@ -139,6 +140,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="ParkedCallTimeOut">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a channel leaves a parking lot due to reaching the time limit of being parked.</synopsis>
 			<syntax>
 				<channel_snapshot prefix="Parkee"/>
@@ -149,6 +151,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="ParkedCallGiveUp">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a channel leaves a parking lot because it hung up without being answered.</synopsis>
 			<syntax>
 				<channel_snapshot prefix="Parkee"/>
@@ -159,6 +162,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="UnParkedCall">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a channel leaves a parking lot because it was retrieved from the parking lot and reconnected.</synopsis>
 			<syntax>
 				<channel_snapshot prefix="Parkee"/>
@@ -170,6 +174,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="ParkedCallSwap">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>13.5.0</version></since>
 			<synopsis>Raised when a channel takes the place of a previously parked channel</synopsis>
 			<syntax>
 				<channel_snapshot prefix="Parkee"/>

--- a/res/res_agi.c
+++ b/res/res_agi.c
@@ -1295,6 +1295,7 @@
 	</manager>
 	<managerEvent language="en_US" name="AsyncAGIStart">
 		<managerEventInstance class="EVENT_FLAG_AGI">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a channel starts AsyncAGI command processing.</synopsis>
 			<syntax>
 				<channel_snapshot/>
@@ -1312,6 +1313,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="AsyncAGIEnd">
 		<managerEventInstance class="EVENT_FLAG_AGI">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a channel stops AsyncAGI command processing.</synopsis>
 			<syntax>
 				<channel_snapshot/>
@@ -1326,6 +1328,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="AsyncAGIExec">
 		<managerEventInstance class="EVENT_FLAG_AGI">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when AsyncAGI completes an AGI command.</synopsis>
 			<syntax>
 				<channel_snapshot/>
@@ -1346,6 +1349,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="AGIExecStart">
 		<managerEventInstance class="EVENT_FLAG_AGI">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a received AGI command starts processing.</synopsis>
 			<syntax>
 				<channel_snapshot/>
@@ -1364,6 +1368,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="AGIExecEnd">
 		<managerEventInstance class="EVENT_FLAG_AGI">
+			<since><version>12.0.0</version></since>
 			<synopsis>Raised when a received AGI command completes processing.</synopsis>
 			<syntax>
 				<channel_snapshot/>

--- a/res/res_fax.c
+++ b/res/res_fax.c
@@ -258,6 +258,7 @@
 	</manager>
 	<managerEvent language="en_US" name="FAXSessionsEntry">
 		<managerEventInstance class="EVENT_FLAG_REPORTING">
+			<since><version>13.0.0</version></since>
 			<synopsis>A single list item for the FAXSessions AMI command</synopsis>
 			<syntax>
 				<parameter name="ActionID" required="false"/>
@@ -308,6 +309,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="FAXSessionsComplete">
 		<managerEventInstance class="EVENT_FLAG_CALL">
+			<since><version>13.0.0</version></since>
 			<synopsis>Raised when all FAXSession events are completed for a FAXSessions command</synopsis>
 			<syntax>
 				<parameter name="ActionID" required="false"/>
@@ -339,6 +341,7 @@
 	</manager>
 	<managerEvent language="en_US" name="FAXSession">
 		<managerEventInstance class="EVENT_FLAG_REPORTING">
+			<since><version>13.0.0</version></since>
 			<synopsis>Raised in response to FAXSession manager command</synopsis>
 			<syntax>
 				<parameter name="ActionID" required="false"/>
@@ -407,6 +410,7 @@
 	</manager>
 	<managerEvent language="en_US" name="FAXStats">
 		<managerEventInstance class="EVENT_FLAG_REPORTING">
+			<since><version>13.0.0</version></since>
 			<synopsis>Raised in response to FAXStats manager command</synopsis>
 			<syntax>
 				<parameter name="ActionID" required="false"/>

--- a/res/res_manager_devicestate.c
+++ b/res/res_manager_devicestate.c
@@ -47,6 +47,7 @@
 			</list-elements>
 			<managerEvent name="DeviceStateListComplete" language="en_US">
 				<managerEventInstance class="EVENT_FLAG_COMMAND">
+					<since><version>13.0.0</version></since>
 					<synopsis>
 						Indicates the end of the list the current known extension states.
 					</synopsis>

--- a/res/res_manager_presencestate.c
+++ b/res/res_manager_presencestate.c
@@ -48,6 +48,7 @@
 			</list-elements>
 			<managerEvent name="PresenceStateListComplete" language="en_US">
 				<managerEventInstance class="EVENT_FLAG_COMMAND">
+					<since><version>13.0.0</version></since>
 					<synopsis>
 						Indicates the end of the list the current known extension states.
 					</synopsis>

--- a/res/res_mwi_external_ami.c
+++ b/res/res_mwi_external_ami.c
@@ -54,6 +54,7 @@
 	</manager>
 	<managerEvent language="en_US" name="MWIGet">
 		<managerEventInstance class="EVENT_FLAG_REPORTING">
+			<since><version>12.1.0</version></since>
 			<synopsis>
 				Raised in response to a MWIGet command.
 			</synopsis>
@@ -76,6 +77,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="MWIGetComplete">
 		<managerEventInstance class="EVENT_FLAG_REPORTING">
+			<since><version>12.1.0</version></since>
 			<synopsis>
 				Raised in response to a MWIGet command.
 			</synopsis>

--- a/res/res_pjsip/pjsip_manager.xml
+++ b/res/res_pjsip/pjsip_manager.xml
@@ -21,6 +21,7 @@
 	</manager>
 	<managerEvent language="en_US" name="IdentifyDetail">
 		<managerEventInstance class="EVENT_FLAG_COMMAND">
+			<since><version>13.20.0</version><version>15.3.0</version></since>
 			<synopsis>Provide details about an identify section.</synopsis>
 			<syntax>
 				<parameter name="ObjectType">
@@ -49,6 +50,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="AorDetail">
 		<managerEventInstance class="EVENT_FLAG_COMMAND">
+			<since><version>13.12.0</version><version>14.1.0</version></since>
 			<synopsis>Provide details about an Address of Record (AoR) section.</synopsis>
 			<syntax>
 				<parameter name="ObjectType">
@@ -104,6 +106,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="AuthDetail">
 		<managerEventInstance class="EVENT_FLAG_COMMAND">
+			<since><version>12.0.0</version></since>
 			<synopsis>Provide details about an authentication section.</synopsis>
 			<syntax>
 				<parameter name="ObjectType">
@@ -138,6 +141,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="TransportDetail">
 		<managerEventInstance class="EVENT_FLAG_COMMAND">
+			<since><version>12.6.0</version></since>
 			<synopsis>Provide details about an authentication section.</synopsis>
 			<syntax>
 				<parameter name="ObjectType">
@@ -217,6 +221,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="EndpointDetail">
 		<managerEventInstance class="EVENT_FLAG_COMMAND">
+			<since><version>12.0.0</version></since>
 			<synopsis>Provide details about an endpoint section.</synopsis>
 			<syntax>
 				<parameter name="ObjectType">
@@ -518,6 +523,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="AorList">
 		<managerEventInstance class="EVENT_FLAG_COMMAND">
+			<since><version>16.0.0</version></since>
 			<synopsis>Provide details about an Address of Record (AoR) section.</synopsis>
 			<syntax>
 				<parameter name="ObjectType">
@@ -564,6 +570,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="AuthList">
 		<managerEventInstance class="EVENT_FLAG_COMMAND">
+			<since><version>16.0.0</version></since>
 			<synopsis>Provide details about an Address of Record (Auth) section.</synopsis>
 			<syntax>
 				<parameter name="ObjectType">
@@ -595,6 +602,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="ContactList">
 		<managerEventInstance class="EVENT_FLAG_COMMAND">
+			<since><version>16.0.0</version></since>
 			<synopsis>Provide details about a contact section.</synopsis>
 			<syntax>
 				<parameter name="ObjectType">
@@ -666,6 +674,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="ContactStatusDetail">
 		<managerEventInstance class="EVENT_FLAG_COMMAND">
+			<since><version>13.0.0</version></since>
 			<synopsis>Provide details about a contact's status.</synopsis>
 			<syntax>
 				<parameter name="AOR">
@@ -727,6 +736,7 @@
 	</managerEvent>
 	<managerEvent language="en_US" name="EndpointList">
 		<managerEventInstance class="EVENT_FLAG_COMMAND">
+			<since><version>12.0.0</version></since>
 			<synopsis>Provide details about a contact's status.</synopsis>
 			<syntax>
 				<parameter name="ObjectType">
@@ -777,6 +787,7 @@
 			</list-elements>
 			<managerEvent language="en_US" name="EndpointListComplete">
 				<managerEventInstance class="EVENT_FLAG_COMMAND">
+					<since><version>12.0.0</version></since>
 					<synopsis>Provide final information about an endpoint list.</synopsis>
 					<syntax>
 						<parameter name="EventList"/>
@@ -821,6 +832,7 @@
 			</list-elements>
 			<managerEvent language="en_US" name="EndpointDetailComplete">
 				<managerEventInstance class="EVENT_FLAG_COMMAND">
+					<since><version>12.0.0</version></since>
 					<synopsis>Provide final information about endpoint details.</synopsis>
 					<syntax>
 						<parameter name="EventList"/>
@@ -851,6 +863,7 @@
 			</list-elements>
 			<managerEvent language="en_US" name="AorListComplete">
 				<managerEventInstance class="EVENT_FLAG_COMMAND">
+					<since><version>16.0.0</version></since>
 					<synopsis>Provide final information about an aor list.</synopsis>
 					<syntax>
 						<parameter name="EventList"/>
@@ -880,6 +893,7 @@
 			</list-elements>
 			<managerEvent language="en_US" name="AuthListComplete">
 				<managerEventInstance class="EVENT_FLAG_COMMAND">
+					<since><version>16.0.0</version></since>
 					<synopsis>Provide final information about an auth list.</synopsis>
 					<syntax>
 						<parameter name="EventList"/>
@@ -910,6 +924,7 @@
 			</list-elements>
 			<managerEvent language="en_US" name="ContactListComplete">
 				<managerEventInstance class="EVENT_FLAG_COMMAND">
+					<since><version>16.0.0</version></since>
 					<synopsis>Provide final information about a contact list.</synopsis>
 					<syntax>
 						<parameter name="EventList"/>


### PR DESCRIPTION
* Do a git blame on the embedded XML managerEvent elements.

* From the commit hash, grab the summary line.

* Do a git log --grep <summary> to find the cherry-pick commits in all
  branches that match.

* Do a git patch-id to ensure the commits are all related and didn't get
  a false match on the summary.

* Do a git tag --contains <commit> to find the tags that contain each
  commit.

* Weed out all tags not ..0.

* Sort and discard any .0.0 and following tags where the commit
  appeared in an earlier branch.

* The result is a single tag for each branch where the application or function
  was defined.

The events defined in res/res_pjsip/pjsip_manager.xml were done by hand
because the XML was extracted from the C source file relatively recently.

Two bugs were fixed along the way...

* The get_documentation awk script was exiting after it processed the first
  DOCUMENTATION block it found in a file.  We have at least 1 source file
  with multiple DOCUMENTATION blocks so only the first one in them was being
  processed.  The awk script was changed to continue searching rather
  than exiting after the first block.

* Fixing the awk script revealed an issue in logger.c where the third
  DOCUMENTATION block contained a XML fragment that consisted only of
  a managerEventInstance element that wasn't wrapped in a managerEvent
  element.  Since logger_doc.xml already existed, the remaining fragments
  in logger.c were moved to it and properly organized.
