### PR TITLE
res_pjsip: Fix startup/reload memory leak in config_auth.

### DIFF
--- a/include/asterisk/res_pjsip.h
+++ b/include/asterisk/res_pjsip.h
@@ -1333,7 +1333,7 @@ enum ast_sip_check_auth_result {
  * \brief Populate a vector of algorithm types from a string.
  *
  * \param id           The object id to use in error messages
- * \param algorithms   The vector to populate
+ * \param algorithms   The initialized but empty vector to populate
  * \param agent_type   The type of agent to use in error messages ("UAC" or "UAS")
  * \param value        The comma-separated string to parse for algorithms
  *

--- a/res/res_pjsip/config_auth.c
+++ b/res/res_pjsip/config_auth.c
@@ -139,6 +139,9 @@ static void *auth_alloc(const char *name)
 		return NULL;
 	}
 
+	AST_VECTOR_INIT(&auth->supported_algorithms_uac, 0);
+	AST_VECTOR_INIT(&auth->supported_algorithms_uas, 0);
+
 	return auth;
 }
 
@@ -195,13 +198,6 @@ int ast_sip_auth_digest_algorithms_vector_init(const char *id,
 	int res = 0;
 
 	ast_assert(algorithms != NULL);
-
-	if (AST_VECTOR_SIZE(algorithms)) {
-		AST_VECTOR_FREE(algorithms);
-	}
-	if (AST_VECTOR_INIT(algorithms, 4)) {
-		return -1;
-	}
 
 	while ((val.ptr = ast_strip(strsep(&iana_names, ",")))) {
 		const pjsip_auth_algorithm *algo;
@@ -719,7 +715,6 @@ static struct ast_cli_entry cli_commands[] = {
 
 static struct ast_sip_cli_formatter_entry *cli_formatter;
 
-#if 1
 static void global_loaded(const char *object_type)
 {
 	ast_sorcery_force_reload_object(ast_sip_get_sorcery(), "auth");
@@ -729,7 +724,6 @@ static void global_loaded(const char *object_type)
 static struct ast_sorcery_observer global_observer = {
 	.loaded = global_loaded,
 };
-#endif
 
 /*! \brief Initialize sorcery with auth support */
 int ast_sip_initialize_sorcery_auth(void)

--- a/res/res_pjsip/config_global.c
+++ b/res/res_pjsip/config_global.c
@@ -219,7 +219,7 @@ static int global_apply(const struct ast_sorcery *sorcery, void *obj)
 		return -1;
 	}
 
-	AST_VECTOR_INIT(&algorithms, 4);
+	AST_VECTOR_INIT(&algorithms, 0);
 	res = ast_sip_auth_digest_algorithms_vector_init("global",
 		&algorithms, "UAS", cfg->default_auth_algorithms_uas);
 	AST_VECTOR_FREE(&algorithms);
@@ -228,7 +228,7 @@ static int global_apply(const struct ast_sorcery *sorcery, void *obj)
 			"Defaulting to %s\n", DEFAULT_AUTH_ALGORITHMS_UAS);
 		ast_string_field_set(cfg, default_auth_algorithms_uas, DEFAULT_AUTH_ALGORITHMS_UAS);
 	}
-	AST_VECTOR_INIT(&algorithms, 4);
+	AST_VECTOR_INIT(&algorithms, 0);
 	res = ast_sip_auth_digest_algorithms_vector_init("global",
 		&algorithms, "UAC", cfg->default_auth_algorithms_uac);
 	AST_VECTOR_FREE(&algorithms);


### PR DESCRIPTION
An issue in config_auth.c:ast_sip_auth_digest_algorithms_vector_init() was
causing double allocations for the two supported_algorithms vectors to the
tune of 915 bytes.  The leak only happens on startup and when a reload is done
and doesn't get bigger with the number of auth objects defined.

* Pre-initialized the two vectors in config_auth:auth_alloc().
* Removed the allocations in ast_sip_auth_digest_algorithms_vector_init().
* Added a note to the doc for ast_sip_auth_digest_algorithms_vector_init()
  noting that the vector passed in should be initialized and empty.
* Simplified the create_artificial_auth() function in pjsip_distributor.
* Set the vector initialization count to 0 in config_global:global_apply().
