### PR TITLE
docs: Add version information to ARI resources and methods.

### DIFF
--- a/rest-api/api-docs/applications.json
+++ b/rest-api/api-docs/applications.json
@@ -6,6 +6,9 @@
 	"swaggerVersion": "1.1",
 	"basePath": "http://localhost:8088/ari",
 	"resourcePath": "/api-docs/applications.{format}",
+	"since": [
+		"13.0.0"
+	],
 	"apis": [
 		{
 			"path": "/applications",
@@ -13,6 +16,9 @@
 			"operations": [
 				{
 					"httpMethod": "GET",
+					"since": [
+						"13.0.0"
+					],
 					"summary": "List all applications.",
 					"nickname": "list",
 					"responseClass": "List[Application]"
@@ -25,6 +31,9 @@
 			"operations": [
 				{
 					"httpMethod": "GET",
+					"since": [
+						"13.0.0"
+					],
 					"summary": "Get details of an application.",
 					"nickname": "get",
 					"responseClass": "Application",
@@ -53,6 +62,9 @@
 			"operations": [
 				{
 					"httpMethod": "POST",
+					"since": [
+						"13.0.0"
+					],
 					"summary": "Subscribe an application to a event source.",
 					"notes": "Returns the state of the application after the subscriptions have changed",
 					"nickname": "subscribe",
@@ -92,6 +104,9 @@
 				},
 				{
 					"httpMethod": "DELETE",
+					"since": [
+						"13.0.0"
+					],
 					"summary": "Unsubscribe an application from an event source.",
 					"notes": "Returns the state of the application after the subscriptions have changed",
 					"nickname": "unsubscribe",
@@ -141,6 +156,10 @@
 			"operations": [
 				{
 					"httpMethod": "PUT",
+					"since": [
+						"13.26.0",
+						"16.3.0"
+					],
 					"summary": "Filter application events types.",
 					"notes": "Allowed and/or disallowed event type filtering can be done. The body (parameter) should specify a JSON key/value object that describes the type of event filtering needed. One, or both of the following keys can be designated:<br /><br />\"allowed\" - Specifies an allowed list of event types<br />\"disallowed\" - Specifies a disallowed list of event types<br /><br />Further, each of those key's value should be a JSON array that holds zero, or more JSON key/value objects. Each of these objects must contain the following key with an associated value:<br /><br />\"type\" - The type name of the event to filter<br /><br />The value must be the string name (case sensitive) of the event type that needs filtering. For example:<br /><br />{ \"allowed\": [ { \"type\": \"StasisStart\" }, { \"type\": \"StasisEnd\" } ] }<br /><br />As this specifies only an allowed list, then only those two event type messages are sent to the application. No other event messages are sent.<br /><br />The following rules apply:<br /><br />* If the body is empty, both the allowed and disallowed filters are set empty.<br />* If both list types are given then both are set to their respective values (note, specifying an empty array for a given type sets that type to empty).<br />* If only one list type is given then only that type is set. The other type is not updated.<br />* An empty \"allowed\" list means all events are allowed.<br />* An empty \"disallowed\" list means no events are disallowed.<br />* Disallowed events take precedence over allowed events if the event type is specified in both lists.",
 					"nickname": "filter",

--- a/rest-api/api-docs/asterisk.json
+++ b/rest-api/api-docs/asterisk.json
@@ -6,6 +6,9 @@
 	"swaggerVersion": "1.1",
 	"basePath": "http://localhost:8088/ari",
 	"resourcePath": "/api-docs/asterisk.{format}",
+	"since": [
+		"12.0.0"
+	],
 	"apis": [
 		{
 			"path": "/asterisk/config/dynamic/{configClass}/{objectType}/{id}",
@@ -13,6 +16,9 @@
 			"operations": [
 				{
 					"httpMethod": "GET",
+					"since": [
+						"13.5.0"
+					],
 					"summary": "Retrieve a dynamic configuration object.",
 					"nickname": "getObject",
 					"responseClass": "List[ConfigTuple]",
@@ -51,6 +57,9 @@
 				},
 				{
 					"httpMethod": "PUT",
+					"since": [
+						"13.5.0"
+					],
 					"summary": "Create or update a dynamic configuration object.",
 					"nickname": "updateObject",
 					"responseClass": "List[ConfigTuple]",
@@ -105,6 +114,9 @@
 				},
 				{
 					"httpMethod": "DELETE",
+					"since": [
+						"13.5.0"
+					],
 					"summary": "Delete a dynamic configuration object.",
 					"nickname": "deleteObject",
 					"responseClass": "void",
@@ -153,6 +165,9 @@
 			"operations": [
 				{
 					"httpMethod": "GET",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Gets Asterisk system information.",
 					"nickname": "getInfo",
 					"responseClass": "AsteriskInfo",
@@ -184,6 +199,10 @@
 			"operations": [
 				{
 					"httpMethod": "GET",
+					"since": [
+						"13.25.0",
+						"16.2.0"
+					],
 					"summary": "Response pong message.",
 					"nickname": "ping",
 					"responseClass": "AsteriskPing"
@@ -196,6 +215,9 @@
 			"operations": [
 				{
 					"httpMethod": "GET",
+					"since": [
+						"13.5.0"
+					],
 					"summary": "List Asterisk modules.",
 					"nickname": "listModules",
 					"responseClass": "List[Module]"
@@ -208,6 +230,9 @@
 			"operations": [
 				{
 					"httpMethod": "GET",
+					"since": [
+						"13.5.0"
+					],
 					"summary": "Get Asterisk module information.",
 					"nickname": "getModule",
 					"responseClass": "Module",
@@ -234,6 +259,9 @@
 				},
 				{
 					"httpMethod": "POST",
+					"since": [
+						"13.5.0"
+					],
 					"summary": "Load an Asterisk module.",
 					"nickname": "loadModule",
 					"responseClass": "void",
@@ -256,6 +284,9 @@
 				},
 				{
 					"httpMethod": "DELETE",
+					"since": [
+						"13.5.0"
+					],
 					"summary": "Unload an Asterisk module.",
 					"nickname": "unloadModule",
 					"responseClass": "void",
@@ -282,6 +313,9 @@
 				},
 				{
 					"httpMethod": "PUT",
+					"since": [
+						"13.5.0"
+					],
 					"summary": "Reload an Asterisk module.",
 					"nickname": "reloadModule",
 					"responseClass": "void",
@@ -314,6 +348,9 @@
 			"operations": [
 				{
 					"httpMethod": "GET",
+					"since": [
+						"13.6.0"
+					],
 					"summary": "Gets Asterisk log channel information.",
 					"nickname": "listLogChannels",
 					"responseClass": "List[LogChannel]"
@@ -326,6 +363,9 @@
 			"operations": [
 				{
 					"httpMethod": "POST",
+					"since": [
+						"13.6.0"
+					],
 					"summary": "Adds a log channel.",
 					"nickname": "addLog",
 					"responseClass": "void",
@@ -360,6 +400,9 @@
 				},
 				{
 					"httpMethod": "DELETE",
+					"since": [
+						"13.6.0"
+					],
 					"summary": "Deletes a log channel.",
 					"nickname": "deleteLog",
 					"responseClass": "void",
@@ -388,6 +431,9 @@
 			"operations": [
 				{
 					"httpMethod": "PUT",
+					"since": [
+						"13.6.0"
+					],
 					"summary": "Rotates a log channel.",
 					"nickname": "rotateLog",
 					"responseClass": "void",
@@ -416,6 +462,9 @@
 			"operations": [
 				{
 					"httpMethod": "GET",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Get the value of a global variable.",
 					"nickname": "getGlobalVar",
 					"responseClass": "Variable",
@@ -438,6 +487,9 @@
 				},
 				{
 					"httpMethod": "POST",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Set the value of a global variable.",
 					"nickname": "setGlobalVar",
 					"responseClass": "void",

--- a/rest-api/api-docs/bridges.json
+++ b/rest-api/api-docs/bridges.json
@@ -6,6 +6,9 @@
 	"swaggerVersion": "1.1",
 	"basePath": "http://localhost:8088/ari",
 	"resourcePath": "/api-docs/bridges.{format}",
+	"since": [
+		"12.0.0"
+	],
 	"requiresModules": [
 		"res_stasis_recording",
 		"res_stasis_playback"
@@ -17,12 +20,18 @@
 			"operations": [
 				{
 					"httpMethod": "GET",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "List all active bridges in Asterisk.",
 					"nickname": "list",
 					"responseClass": "List[Bridge]"
 				},
 				{
 					"httpMethod": "POST",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Create a new bridge.",
 					"notes": "This bridge persists until it has been shut down, or Asterisk has been shut down.",
 					"nickname": "create",
@@ -62,6 +71,9 @@
 			"operations": [
 				{
 					"httpMethod": "POST",
+					"since": [
+						"12.2.0"
+					],
 					"summary": "Create a new bridge or updates an existing one.",
 					"notes": "This bridge persists until it has been shut down, or Asterisk has been shut down.",
 					"nickname": "createWithId",
@@ -95,6 +107,9 @@
 				},
 				{
 					"httpMethod": "GET",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Get bridge details.",
 					"nickname": "get",
 					"responseClass": "Bridge",
@@ -117,6 +132,9 @@
 				},
 				{
 					"httpMethod": "DELETE",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Shut down a bridge.",
 					"notes": "If any channels are in this bridge, they will be removed and resume whatever they were doing beforehand.",
 					"nickname": "destroy",
@@ -146,6 +164,9 @@
 			"operations": [
 				{
 					"httpMethod": "POST",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Add a channel to a bridge.",
 					"nickname": "addChannel",
 					"responseClass": "void",
@@ -229,6 +250,9 @@
 			"operations": [
 				{
 					"httpMethod": "POST",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Remove a channel from a bridge.",
 					"nickname": "removeChannel",
 					"responseClass": "void",
@@ -277,6 +301,10 @@
 			"operations": [
 				{
 					"httpMethod": "POST",
+					"since": [
+						"13.13.0",
+						"14.2.0"
+					],
 					"summary": "Set a channel as the video source in a multi-party mixing bridge. This operation has no effect on bridges with two or fewer participants.",
 					"nickname": "setVideoSource",
 					"responseClass": "void",
@@ -321,6 +349,10 @@
 			"operations": [
 				{
 					"httpMethod": "DELETE",
+					"since": [
+						"13.13.0",
+						"14.2.0"
+					],
 					"summary": "Removes any explicit video source in a multi-party mixing bridge. This operation has no effect on bridges with two or fewer participants. When no explicit video source is set, talk detection will be used to determine the active video stream.",
 					"nickname": "clearVideoSource",
 					"responseClass": "void",
@@ -349,6 +381,9 @@
 			"operations": [
 				{
 					"httpMethod": "POST",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Play music on hold to a bridge or change the MOH class that is playing.",
 					"nickname": "startMoh",
 					"responseClass": "void",
@@ -383,6 +418,9 @@
 				},
 				{
 					"httpMethod": "DELETE",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Stop playing music on hold to a bridge.",
 					"notes": "This will only stop music on hold being played via POST bridges/{bridgeId}/moh.",
 					"nickname": "stopMoh",
@@ -416,6 +454,9 @@
 			"operations": [
 				{
 					"httpMethod": "POST",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Start playback of media on a bridge.",
 					"notes": "The media URI may be any of a number of URI's. Currently sound:, recording:, number:, digits:, characters:, and tone: URI's are supported. This operation creates a playback resource that can be used to control the playback of media (pause, rewind, fast forward, etc.)",
 					"nickname": "play",
@@ -500,6 +541,9 @@
 			"operations": [
 				{
 					"httpMethod": "POST",
+					"since": [
+						"12.3.0"
+					],
 					"summary": "Start playback of media on a bridge.",
 					"notes": "The media URI may be any of a number of URI's. Currently sound:, recording:, number:, digits:, characters:, and tone: URI's are supported. This operation creates a playback resource that can be used to control the playback of media (pause, rewind, fast forward, etc.)",
 					"nickname": "playWithId",
@@ -584,6 +628,9 @@
 			"operations": [
 				{
 					"httpMethod": "POST",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Start a recording.",
 					"notes": "This records the mixed audio from all channels participating in this bridge.",
 					"nickname": "record",

--- a/rest-api/api-docs/channels.json
+++ b/rest-api/api-docs/channels.json
@@ -6,6 +6,9 @@
 	"swaggerVersion": "1.1",
 	"basePath": "http://localhost:8088/ari",
 	"resourcePath": "/api-docs/channels.{format}",
+	"since": [
+		"12.0.0"
+	],
 	"requiresModules": [
 		"res_stasis_answer",
 		"res_stasis_playback",
@@ -19,12 +22,18 @@
 			"operations": [
 				{
 					"httpMethod": "GET",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "List all active channels in Asterisk.",
 					"nickname": "list",
 					"responseClass": "List[Channel]"
 				},
 				{
 					"httpMethod": "POST",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Create a new channel (originate).",
 					"notes": "The new channel is created immediately and a snapshot of it returned. If a Stasis application is provided it will be automatically subscribed to the originated channel for further events and updates.",
 					"nickname": "originate",
@@ -163,6 +172,9 @@
 			"operations": [
 				{
 					"httpMethod": "POST",
+					"since": [
+						"14.0.0"
+					],
 					"summary": "Create channel.",
 					"nickname": "create",
 					"responseClass": "Channel",
@@ -247,6 +259,9 @@
 			"operations": [
 				{
 					"httpMethod": "GET",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Channel details.",
 					"nickname": "get",
 					"responseClass": "Channel",
@@ -269,6 +284,9 @@
 				},
 				{
 					"httpMethod": "POST",
+					"since": [
+						"12.2.0"
+					],
 					"summary": "Create a new channel (originate with id).",
 					"notes": "The new channel is created immediately and a snapshot of it returned. If a Stasis application is provided it will be automatically subscribed to the originated channel for further events and updates.",
 					"nickname": "originateWithId",
@@ -402,6 +420,9 @@
 				},
 				{
 					"httpMethod": "DELETE",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Delete (i.e. hangup) a channel.",
 					"nickname": "hangup",
 					"responseClass": "void",
@@ -468,6 +489,9 @@
 			"operations": [
 				{
 					"httpMethod": "POST",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Exit application; continue execution in the dialplan.",
 					"nickname": "continueInDialplan",
 					"responseClass": "void",
@@ -536,6 +560,10 @@
 			"operations": [
 				{
 					"httpMethod": "POST",
+					"since": [
+						"13.26.0",
+						"16.3.0"
+					],
 					"summary": "Move the channel from one Stasis application to another.",
 					"nickname": "move",
 					"responseClass": "void",
@@ -584,6 +612,9 @@
 			"operations": [
 				{
 					"httpMethod": "POST",
+					"since": [
+						"13.3.0"
+					],
 					"summary": "Redirect the channel to a different location.",
 					"nickname": "redirect",
 					"responseClass": "void",
@@ -636,6 +667,9 @@
 			"operations": [
 				{
 					"httpMethod": "POST",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Answer a channel.",
 					"nickname": "answer",
 					"responseClass": "void",
@@ -672,6 +706,9 @@
 			"operations": [
 				{
 					"httpMethod": "POST",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Indicate ringing to a channel.",
 					"nickname": "ring",
 					"responseClass": "void",
@@ -702,6 +739,9 @@
 				},
 				{
 					"httpMethod": "DELETE",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Stop ringing indication on a channel if locally generated.",
 					"nickname": "ringStop",
 					"responseClass": "void",
@@ -738,6 +778,9 @@
 			"operations": [
 				{
 					"httpMethod": "POST",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Send provided DTMF to a given channel.",
 					"nickname": "sendDTMF",
 					"responseClass": "void",
@@ -822,6 +865,9 @@
 			"operations": [
 				{
 					"httpMethod": "POST",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Mute a channel.",
 					"nickname": "mute",
 					"responseClass": "void",
@@ -869,6 +915,9 @@
 				},
 				{
 					"httpMethod": "DELETE",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Unmute a channel.",
 					"nickname": "unmute",
 					"responseClass": "void",
@@ -922,6 +971,9 @@
 			"operations": [
 				{
 					"httpMethod": "POST",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Hold a channel.",
 					"nickname": "hold",
 					"responseClass": "void",
@@ -952,6 +1004,9 @@
 				},
 				{
 					"httpMethod": "DELETE",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Remove a channel from hold.",
 					"nickname": "unhold",
 					"responseClass": "void",
@@ -988,6 +1043,9 @@
 			"operations": [
 				{
 					"httpMethod": "POST",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Play music on hold to a channel.",
 					"notes": "Using media operations such as /play on a channel playing MOH in this manner will suspend MOH without resuming automatically. If continuing music on hold is desired, the stasis application must reinitiate music on hold.",
 					"nickname": "startMoh",
@@ -1027,6 +1085,9 @@
 				},
 				{
 					"httpMethod": "DELETE",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Stop playing music on hold to a channel.",
 					"nickname": "stopMoh",
 					"responseClass": "void",
@@ -1063,6 +1124,9 @@
 			"operations": [
 				{
 					"httpMethod": "POST",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Play silence to a channel.",
 					"notes": "Using media operations such as /play on a channel playing silence in this manner will suspend silence without resuming automatically.",
 					"nickname": "startSilence",
@@ -1094,6 +1158,9 @@
 				},
 				{
 					"httpMethod": "DELETE",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Stop playing silence to a channel.",
 					"nickname": "stopSilence",
 					"responseClass": "void",
@@ -1130,6 +1197,9 @@
 			"operations": [
 				{
 					"httpMethod": "POST",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Start playback of media.",
 					"notes": "The media URI may be any of a number of URI's. Currently sound:, recording:, number:, digits:, characters:, and tone: URI's are supported. This operation creates a playback resource that can be used to control the playback of media (pause, rewind, fast forward, etc.)",
 					"nickname": "play",
@@ -1208,6 +1278,9 @@
 			"operations": [
 				{
 					"httpMethod": "POST",
+					"since": [
+						"12.2.0"
+					],
 					"summary": "Start playback of media and specify the playbackId.",
 					"notes": "The media URI may be any of a number of URI's. Currently sound:, recording:, number:, digits:, characters:, and tone: URI's are supported. This operation creates a playback resource that can be used to control the playback of media (pause, rewind, fast forward, etc.)",
 					"nickname": "playWithId",
@@ -1286,6 +1359,9 @@
 			"operations": [
 				{
 					"httpMethod": "POST",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Start a recording.",
 					"notes": "Record audio from a channel. Note that this will not capture audio sent to the channel. The bridge itself has a record feature if that's what you want.",
 					"nickname": "record",
@@ -1413,6 +1489,9 @@
 			"operations": [
 				{
 					"httpMethod": "GET",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Get the value of a channel variable or function.",
 					"nickname": "getChannelVar",
 					"responseClass": "Variable",
@@ -1451,6 +1530,9 @@
 				},
 				{
 					"httpMethod": "POST",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Set the value of a channel variable or function.",
 					"nickname": "setChannelVar",
 					"responseClass": "void",
@@ -1503,6 +1585,9 @@
 			"operations": [
 				{
 					"httpMethod": "POST",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Start snooping.",
 					"notes": "Snoop (spy/whisper) on a specific channel.",
 					"nickname": "snoopChannel",
@@ -1596,6 +1681,9 @@
 			"operations": [
 				{
 					"httpMethod": "POST",
+					"since": [
+						"12.2.0"
+					],
 					"summary": "Start snooping.",
 					"notes": "Snoop (spy/whisper) on a specific channel.",
 					"nickname": "snoopChannelWithId",
@@ -1689,6 +1777,9 @@
 			"operations": [
 				{
 					"httpMethod": "POST",
+					"since": [
+						"14.0.0"
+					],
 					"summary": "Dial a created channel.",
 					"nickname": "dial",
 					"responseClass": "void",
@@ -1742,6 +1833,10 @@
 			"operations": [
 				{
 					"httpMethod": "GET",
+					"since": [
+						"13.27.0",
+						"16.4.0"
+					],
 					"summary": "RTP stats on a channel.",
 					"nickname": "rtpstatistics",
 					"responseClass": "RTPstat",
@@ -1770,6 +1865,10 @@
 			"operations": [
 				{
 					"httpMethod": "POST",
+					"since": [
+						"16.6.0",
+						"17.1.0"
+					],
 					"summary": "Start an External Media session.",
 					"notes": "Create a channel to an External Media source/sink.",
 					"nickname": "externalMedia",

--- a/rest-api/api-docs/deviceStates.json
+++ b/rest-api/api-docs/deviceStates.json
@@ -6,6 +6,9 @@
 	"swaggerVersion": "1.1",
 	"basePath": "http://localhost:8088/ari",
 	"resourcePath": "/api-docs/deviceStates.{format}",
+	"since": [
+		"12.0.0"
+	],
 	"requiresModules": [
 		"res_stasis_device_state"
 	],
@@ -16,6 +19,9 @@
 			"operations": [
 				{
 					"httpMethod": "GET",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "List all ARI controlled device states.",
 					"nickname": "list",
 					"responseClass": "List[DeviceState]"
@@ -28,6 +34,9 @@
 			"operations": [
 				{
 					"httpMethod": "GET",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Retrieve the current state of a device.",
 					"nickname": "get",
 					"responseClass": "DeviceState",
@@ -44,6 +53,9 @@
 				},
 				{
 					"httpMethod": "PUT",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Change the state of a device controlled by ARI. (Note - implicitly creates the device state).",
 					"nickname": "update",
 					"responseClass": "void",
@@ -92,6 +104,9 @@
 				},
 				{
 					"httpMethod": "DELETE",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Destroy a device-state controlled by ARI.",
 					"nickname": "delete",
 					"responseClass": "void",

--- a/rest-api/api-docs/endpoints.json
+++ b/rest-api/api-docs/endpoints.json
@@ -6,6 +6,9 @@
 	"swaggerVersion": "1.1",
 	"basePath": "http://localhost:8088/ari",
 	"resourcePath": "/api-docs/endpoints.{format}",
+	"since": [
+		"12.0.0"
+	],
 	"apis": [
 		{
 			"path": "/endpoints",
@@ -13,6 +16,9 @@
 			"operations": [
 				{
 					"httpMethod": "GET",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "List all endpoints.",
 					"nickname": "list",
 					"responseClass": "List[Endpoint]"
@@ -25,6 +31,9 @@
 			"operations": [
 				{
 					"httpMethod": "PUT",
+					"since": [
+						"13.0.0"
+					],
 					"summary": "Send a message to some technology URI or endpoint.",
 					"nickname": "sendMessage",
 					"responseClass": "void",
@@ -81,6 +90,10 @@
 			"operations": [
 				{
 					"httpMethod": "POST",
+					"since": [
+						"18.20.0",
+						"20.5.0"
+					],
 					"summary": "Refer an endpoint or technology URI to some technology URI or endpoint.",
 					"nickname": "refer",
 					"responseClass": "void",
@@ -146,6 +159,9 @@
 			"operations": [
 				{
 					"httpMethod": "GET",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "List available endoints for a given endpoint technology.",
 					"nickname": "listByTech",
 					"responseClass": "List[Endpoint]",
@@ -172,6 +188,9 @@
 			"operations": [
 				{
 					"httpMethod": "GET",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Details for an endpoint.",
 					"nickname": "get",
 					"responseClass": "Endpoint",
@@ -208,6 +227,9 @@
 			"operations": [
 				{
 					"httpMethod": "PUT",
+					"since": [
+						"13.0.0"
+					],
 					"summary": "Send a message to some endpoint in a technology.",
 					"nickname": "sendMessageToEndpoint",
 					"responseClass": "void",
@@ -268,6 +290,10 @@
 			"operations": [
 				{
 					"httpMethod": "POST",
+					"since": [
+						"18.20.0",
+						"20.5.0"
+					],
 					"summary": "Refer an endpoint or technology URI to some technology URI or endpoint.",
 					"nickname": "referToEndpoint",
 					"responseClass": "void",

--- a/rest-api/api-docs/events.json
+++ b/rest-api/api-docs/events.json
@@ -6,6 +6,9 @@
 	"swaggerVersion": "1.2",
 	"basePath": "http://localhost:8088/ari",
 	"resourcePath": "/api-docs/events.{format}",
+	"since": [
+		"12.0.0"
+	],
 	"requiresModules": [
 		"res_http_websocket"
 	],
@@ -16,6 +19,9 @@
 			"operations": [
 				{
 					"httpMethod": "GET",
+					"since": [
+						"12.0.0"
+					],
 					"upgrade": "websocket",
 					"websocketProtocol": "ari",
 					"summary": "WebSocket connection for events.",
@@ -48,6 +54,9 @@
 			"operations": [
 				{
 					"httpMethod": "POST",
+					"since": [
+						"12.3.0"
+					],
 					"summary": "Generate a user event.",
 					"nickname": "userEvent",
 					"responseClass": "void",

--- a/rest-api/api-docs/mailboxes.json
+++ b/rest-api/api-docs/mailboxes.json
@@ -6,6 +6,9 @@
 	"swaggerVersion": "1.1",
 	"basePath": "http://localhost:8088/ari",
 	"resourcePath": "/api-docs/mailboxes.{format}",
+	"since": [
+		"12.1.0"
+	],
 	"requiresModules": [
 		"res_stasis_mailbox"
 	],
@@ -16,6 +19,9 @@
 			"operations": [
 				{
 					"httpMethod": "GET",
+					"since": [
+						"12.1.0"
+					],
 					"summary": "List all mailboxes.",
 					"nickname": "list",
 					"responseClass": "List[Mailbox]"
@@ -28,6 +34,9 @@
 			"operations": [
 				{
 					"httpMethod": "GET",
+					"since": [
+						"12.1.0"
+					],
 					"summary": "Retrieve the current state of a mailbox.",
 					"nickname": "get",
 					"responseClass": "Mailbox",
@@ -50,6 +59,9 @@
 				},
 				{
 					"httpMethod": "PUT",
+					"since": [
+						"12.1.0"
+					],
 					"summary": "Change the state of a mailbox. (Note - implicitly creates the mailbox).",
 					"nickname": "update",
 					"responseClass": "void",
@@ -88,6 +100,9 @@
 				},
 				{
 					"httpMethod": "DELETE",
+					"since": [
+						"12.1.0"
+					],
 					"summary": "Destroy a mailbox.",
 					"nickname": "delete",
 					"responseClass": "void",

--- a/rest-api/api-docs/playbacks.json
+++ b/rest-api/api-docs/playbacks.json
@@ -6,6 +6,9 @@
 	"swaggerVersion": "1.1",
 	"basePath": "http://localhost:8088/ari",
 	"resourcePath": "/api-docs/playbacks.{format}",
+	"since": [
+		"12.0.0"
+	],
 	"requiresModules": [
 		"res_stasis_playback"
 	],
@@ -16,6 +19,9 @@
 			"operations": [
 				{
 					"httpMethod": "GET",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Get a playback's details.",
 					"nickname": "get",
 					"responseClass": "Playback",
@@ -38,6 +44,9 @@
 				},
 				{
 					"httpMethod": "DELETE",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Stop a playback.",
 					"nickname": "stop",
 					"responseClass": "void",
@@ -66,6 +75,9 @@
 			"operations": [
 				{
 					"httpMethod": "POST",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Control a playback.",
 					"nickname": "control",
 					"responseClass": "void",

--- a/rest-api/api-docs/recordings.json
+++ b/rest-api/api-docs/recordings.json
@@ -6,6 +6,9 @@
 	"swaggerVersion": "1.1",
 	"basePath": "http://localhost:8088/ari",
 	"resourcePath": "/api-docs/recordings.{format}",
+	"since": [
+		"12.0.0"
+	],
 	"requiresModules": [
 		"res_stasis_recording"
 	],
@@ -16,6 +19,9 @@
 			"operations": [
 				{
 					"httpMethod": "GET",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "List recordings that are complete.",
 					"nickname": "listStored",
 					"responseClass": "List[StoredRecording]"
@@ -28,6 +34,9 @@
 			"operations": [
 				{
 					"httpMethod": "GET",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Get a stored recording's details.",
 					"nickname": "getStored",
 					"responseClass": "StoredRecording",
@@ -50,6 +59,9 @@
 				},
 				{
 					"httpMethod": "DELETE",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Delete a stored recording.",
 					"nickname": "deleteStored",
 					"responseClass": "void",
@@ -78,6 +90,9 @@
 			"operations": [
 				{
 					"httpMethod": "GET",
+					"since": [
+						"14.0.0"
+					],
 					"summary": "Get the file associated with the stored recording.",
 					"nickname": "getStoredFile",
 					"responseClass": "binary",
@@ -110,6 +125,9 @@
 			"operations": [
 				{
 					"httpMethod": "POST",
+					"since": [
+						"12.5.0"
+					],
 					"summary": "Copy a stored recording.",
 					"nickname": "copyStored",
 					"responseClass": "StoredRecording",
@@ -150,6 +168,9 @@
 			"operations": [
 				{
 					"httpMethod": "GET",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "List live recordings.",
 					"nickname": "getLive",
 					"responseClass": "LiveRecording",
@@ -172,6 +193,9 @@
 				},
 				{
 					"httpMethod": "DELETE",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Stop a live recording and discard it.",
 					"nickname": "cancel",
 					"responseClass": "void",
@@ -199,6 +223,9 @@
 			"operations": [
 				{
 					"httpMethod": "POST",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Stop a live recording and store it.",
 					"nickname": "stop",
 					"responseClass": "void",
@@ -226,6 +253,9 @@
 			"operations": [
 				{
 					"httpMethod": "POST",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Pause a live recording.",
 					"notes": "Pausing a recording suspends silence detection, which will be restarted when the recording is unpaused. Paused time is not included in the accounting for maxDurationSeconds.",
 					"nickname": "pause",
@@ -253,6 +283,9 @@
 				},
 				{
 					"httpMethod": "DELETE",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Unpause a live recording.",
 					"nickname": "unpause",
 					"responseClass": "void",
@@ -284,6 +317,9 @@
 			"operations": [
 				{
 					"httpMethod": "POST",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Mute a live recording.",
 					"notes": "Muting a recording suspends silence detection, which will be restarted when the recording is unmuted.",
 					"nickname": "mute",
@@ -311,6 +347,9 @@
 				},
 				{
 					"httpMethod": "DELETE",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Unmute a live recording.",
 					"nickname": "unmute",
 					"responseClass": "void",

--- a/rest-api/api-docs/sounds.json
+++ b/rest-api/api-docs/sounds.json
@@ -6,6 +6,9 @@
 	"swaggerVersion": "1.1",
 	"basePath": "http://localhost:8088/ari",
 	"resourcePath": "/api-docs/sounds.{format}",
+	"since": [
+		"12.0.0"
+	],
 	"apis": [
 		{
 			"path": "/sounds",
@@ -13,6 +16,9 @@
 			"operations": [
 				{
 					"httpMethod": "GET",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "List all sounds.",
 					"nickname": "list",
 					"responseClass": "List[Sound]",
@@ -42,6 +48,9 @@
 			"operations": [
 				{
 					"httpMethod": "GET",
+					"since": [
+						"12.0.0"
+					],
 					"summary": "Get a sound's details.",
 					"nickname": "get",
 					"responseClass": "Sound",


### PR DESCRIPTION
* Dump a git blame of each file in rest-api/api-docs.

* Get the commit for each "resourcePath" and "httpMethod" entry.

* Find the tags for each commit (same as other processes).

* Insert a "since" array after each "resourcePath" and "httpMethod" entry.
