### PR TITLE
alembic: Database updates required.

### DIFF
--- a/contrib/ast-db-manage/config/versions/44bd6dd914fa_add_qualify_2xx_only_option.py
+++ b/contrib/ast-db-manage/config/versions/44bd6dd914fa_add_qualify_2xx_only_option.py
@@ -3,7 +3,7 @@
 Revision ID: 44bd6dd914fa
 Revises: 4f91fc18c979
 Create Date: 2024-12-02 21:08:41.130023
-
+Update Date: 2025-01-28 09:50:00.000000
 """
 
 # revision identifiers, used by Alembic.

--- a/contrib/ast-db-manage/config/versions/abdc9ede147d_add_fields_to_ps_auths_to_support_new_.py
+++ b/contrib/ast-db-manage/config/versions/abdc9ede147d_add_fields_to_ps_auths_to_support_new_.py
@@ -3,7 +3,7 @@
 Revision ID: abdc9ede147d
 Revises: 44bd6dd914fa
 Create Date: 2024-10-27 15:26:25.165085
-
+Update Date: 2025-01-28 09:50:00.000000
 """
 
 # revision identifiers, used by Alembic.


### PR DESCRIPTION
This commit doesn't actually change anything.  It just adds the following
upgrade notes that were omitted from the original commits.

Resolves: #1097

UpgradeNote: Two commits in this release...
'Add SHA-256 and SHA-512-256 as authentication digest algorithms'
'res_pjsip: Add new AOR option "qualify_2xx_only"'
...have modified alembic scripts for the following database tables: ps_aors,
ps_contacts, ps_auths, ps_globals. If you don't use the scripts to update
your database, reads from those tables will succeeed but inserts into the
ps_contacts table by res_pjsip_registrar will fail.
