### PR TITLE
ARI/pjsip: Make it possible to control transfers through ARI (21,20 only)

### DIFF
--- a/channels/chan_pjsip.c
+++ b/channels/chan_pjsip.c
@@ -1851,6 +1851,8 @@ static int chan_pjsip_indicate(struct ast_channel *ast, int condition, const voi
 		break;
 	case AST_CONTROL_STREAM_TOPOLOGY_SOURCE_CHANGED:
 		break;
+	case AST_CONTROL_TRANSFER:
+		break;
 	case -1:
 		res = -1;
 		break;
@@ -3274,6 +3276,11 @@ static struct ast_custom_function session_refresh_function = {
 	.write = pjsip_acf_session_refresh_write,
 };
 
+static struct ast_custom_function transfer_handling_function = {
+	.name = "PJSIP_TRANSFER_HANDLING",
+	.write = pjsip_transfer_handling_write,
+};
+
 static char *app_pjsip_hangup = "PJSIPHangup";
 
 /*!
@@ -3338,6 +3345,11 @@ static int load_module(void)
 		goto end;
 	}
 
+	if (ast_custom_function_register(&transfer_handling_function)) {
+		ast_log(LOG_WARNING, "Unable to register PJSIP_TRANSFER_HANDLING dialplan function\n");
+		goto end;
+	}
+
 	if (ast_register_application_xml(app_pjsip_hangup, pjsip_app_hangup)) {
 		ast_log(LOG_WARNING, "Unable to register PJSIPHangup dialplan application\n");
 		goto end;
@@ -3393,6 +3405,7 @@ end:
 	ast_custom_function_unregister(&chan_pjsip_parse_uri_function);
 	ast_custom_function_unregister(&chan_pjsip_parse_uri_from_function);
 	ast_custom_function_unregister(&session_refresh_function);
+	ast_custom_function_unregister(&transfer_handling_function);
 	ast_unregister_application(app_pjsip_hangup);
 	ast_manager_unregister(app_pjsip_hangup);
 
@@ -3426,6 +3439,7 @@ static int unload_module(void)
 	ast_custom_function_unregister(&chan_pjsip_parse_uri_function);
 	ast_custom_function_unregister(&chan_pjsip_parse_uri_from_function);
 	ast_custom_function_unregister(&session_refresh_function);
+	ast_custom_function_unregister(&transfer_handling_function);
 	ast_unregister_application(app_pjsip_hangup);
 	ast_manager_unregister(app_pjsip_hangup);
 

--- a/channels/pjsip/dialplan_functions_doc.xml
+++ b/channels/pjsip/dialplan_functions_doc.xml
@@ -405,6 +405,32 @@
 			<para>Parse the contents of the provided variable as a URI and return a specified part of the URI.</para>
 		</description>
 	</function>
+	<function name="PJSIP_TRANSFER_HANDLING" language="en_US">
+		<since>
+			<version>22.3.0</version>
+			<version>21.8.0</version>
+			<version>20.13.0</version>
+		</since>
+		<synopsis>
+			Set how transfers are handled for a PJSIP channel.
+		</synopsis>
+		<syntax>
+			<parameter name="mode" required="false">
+				<para>How transfers are handled for a PJSIP channel. Default is <literal>core</literal>.</para>
+				<enumlist>
+					<enum name="core">
+						<para>Asterisk will handle attended and blind transfers.</para>
+					</enum>
+					<enum name="ari-only">
+						<para>Asterisk will generate ARI events on incoming SIP REFER.</para>
+					</enum>
+				</enumlist>
+			</parameter>
+		</syntax>
+		<description>
+			<para>When written, sets the transferhandling behavior</para>
+		</description>
+	</function>
 
 	<info name="CHANNEL" language="en_US" tech="PJSIP">
 		<enumlist>

--- a/channels/pjsip/include/dialplan_functions.h
+++ b/channels/pjsip/include/dialplan_functions.h
@@ -168,4 +168,16 @@ int pjsip_app_hangup(struct ast_channel *chan, const char *data);
  */
 int pjsip_action_hangup(struct mansession *s, const struct message *m);
 
+/*!
+ * \brief PJSIP_TRANSFER_HANDLING function write callback
+ * \param chan The channel the function is called on
+ * \param cmd the Name of the function
+ * \param data Arguments passed to the function
+ * \param value Value to be set by the function
+ *
+ * \retval 0 on success
+ * \retval -1 on failure
+ */
+int pjsip_transfer_handling_write(struct ast_channel *chan, const char *cmd, char *data, const char *value);
+
 #endif /* _PJSIP_DIALPLAN_FUNCTIONS */

--- a/include/asterisk/frame.h
+++ b/include/asterisk/frame.h
@@ -408,6 +408,9 @@ struct ast_control_t38_parameters {
 enum ast_control_transfer {
 	AST_TRANSFER_SUCCESS = 0, /*!< Transfer request on the channel worked */
 	AST_TRANSFER_FAILED,      /*!< Transfer request on the channel failed */
+	AST_TRANSFER_PROGRESS,    /*!< Transfer request on the channel is in progress */
+	AST_TRANSFER_UNAVAILABLE, /*!< Transfer request on the channel is unavailable */
+	AST_TRANSFER_INVALID,     /*!< Invalid state for none of the above. */
 };
 
 struct ast_control_pvt_cause_code {

--- a/include/asterisk/refer.h
+++ b/include/asterisk/refer.h
@@ -37,6 +37,11 @@
 extern "C" {
 #endif
 
+#include "asterisk/vector.h"
+#include "asterisk/frame.h"
+
+struct ast_channel;
+
 /*!
  * \brief A refer structure.
  *
@@ -72,6 +77,13 @@ struct ast_refer_tech {
 	 */
 	int (* const refer_send)(const struct ast_refer *refer);
 };
+
+struct ast_refer_param {
+	const char *param_name;
+	const char *param_value;
+};
+
+AST_VECTOR(ast_refer_params, struct ast_refer_param);
 
 /*!
  * \brief Register a refer technology
@@ -313,6 +325,20 @@ void ast_refer_var_iterator_destroy(struct ast_refer_var_iterator *iter);
  * \brief Unref a refer var from inside an iterator loop
  */
 void ast_refer_var_unref_current(struct ast_refer_var_iterator *iter);
+
+/*!
+ * \brief Notify a transfer request.
+ * \param originating_chan The channel that received the transfer request
+ * \param referred_by Information about the requesting identity
+ * \param exten The extension for blind transfers
+ * \param protocol_id Technology specific replace indication
+ * \param dest The identified replace target for attended requests.
+ * \param params List of protocol specific params.
+ * \param state The state of the transfer
+ */
+int ast_refer_notify_transfer_request(struct ast_channel *originating_chan, const char *referred_by, const char *exten,
+				      const char *protocol_id, struct ast_channel *dest, struct ast_refer_params *params,
+				      enum ast_control_transfer state);
 
 /*!
  *  @}

--- a/include/asterisk/res_pjsip_session.h
+++ b/include/asterisk/res_pjsip_session.h
@@ -217,6 +217,8 @@ struct ast_sip_session {
 	unsigned int defer_terminate:1;
 	/*! Termination requested while termination deferred */
 	unsigned int terminate_while_deferred:1;
+	/*! Transferhandling ari */
+	unsigned int transferhandling_ari:1;
 	/*! Deferred incoming re-invite */
 	pjsip_rx_data *deferred_reinvite;
 	/*! Current T.38 state */

--- a/include/asterisk/stasis_channels.h
+++ b/include/asterisk/stasis_channels.h
@@ -20,6 +20,7 @@
 #ifndef STASIS_CHANNELS_H_
 #define STASIS_CHANNELS_H_
 
+#include "asterisk/refer.h"
 #include "asterisk/stringfields.h"
 #include "asterisk/stasis.h"
 #include "asterisk/channel.h"
@@ -657,6 +658,14 @@ struct stasis_message_type *ast_channel_talking_start(void);
  */
 struct stasis_message_type *ast_channel_talking_stop(void);
 
+/*
+ * \since 23
+ * \brief Message type for a attended or blind transfer request
+ *
+ * \return A stasis message type
+ */
+struct stasis_message_type *ast_channel_transfer_request_type(void);
+
 /*!
  * \since 12
  * \brief Publish in the \ref ast_channel_topic or \ref ast_channel_topic_all
@@ -749,6 +758,44 @@ int ast_channel_snapshot_caller_id_equal(
 int ast_channel_snapshot_connected_line_equal(
 	const struct ast_channel_snapshot *old_snapshot,
 	const struct ast_channel_snapshot *new_snapshot);
+
+
+/*!
+ * \since 23
+ * \brief Message published during an "ARI" transfer
+ */
+struct ast_ari_transfer_message {
+	/*! The channel receiving the transfer request */
+	struct ast_channel_snapshot *source;
+	/*! The bridge associated with the source channel */
+	struct ast_bridge_snapshot *source_bridge;
+	/*! The peer channel */
+	struct ast_channel_snapshot *source_peer;
+	/*! Referer identity */
+	char *referred_by;
+
+
+	/*! Destination extension */
+	char destination[AST_MAX_EXTENSION];
+	/*! Information for attended transfers */
+	char *protocol_id;
+	/*! The identified destination channel. */
+	struct ast_channel_snapshot *dest;
+	/*! The bridge associated with the channel. */
+	struct ast_bridge_snapshot *dest_bridge;
+	/*! The peer of the destination channel. */
+	struct ast_channel_snapshot *dest_peer;
+	/*! An array of protocol specific params, e.g. from/to information */
+	struct ast_refer_params *refer_params;
+	/*! The current state of the transfer. */
+	enum ast_control_transfer state;
+};
+
+
+struct ast_ari_transfer_message *ast_ari_transfer_message_create(struct ast_channel *originating_chan,
+								 const char *referred_by, const char *exten,
+								 const char *protocol_id, struct ast_channel *dest,
+								 struct ast_refer_params *params, enum ast_control_transfer);
 
 /*!
  * \brief Initialize the stasis channel topic and message types

--- a/main/stasis_channels.c
+++ b/main/stasis_channels.c
@@ -34,12 +34,14 @@
 #include "asterisk/json.h"
 #include "asterisk/pbx.h"
 #include "asterisk/bridge.h"
+#include "asterisk/stasis_bridges.h"
 #include "asterisk/translate.h"
 #include "asterisk/stasis.h"
 #include "asterisk/stasis_channels.h"
 #include "asterisk/dial.h"
 #include "asterisk/linkedlists.h"
 #include "asterisk/utf8.h"
+#include "asterisk/vector.h"
 
 /*** DOCUMENTATION
 	<managerEvent language="en_US" name="VarSet">
@@ -1631,6 +1633,175 @@ static struct ast_json *unhold_to_json(struct stasis_message *message,
 		"channel", json_channel);
 }
 
+static const char *state2str(enum ast_control_transfer state) {
+	switch (state) {
+	case AST_TRANSFER_FAILED:
+		return "channel_declined";
+	case AST_TRANSFER_SUCCESS:
+		return "channel_answered";
+	case AST_TRANSFER_PROGRESS:
+		return "channel_progress";
+	case AST_TRANSFER_UNAVAILABLE:
+		return "channel_declined";
+	default:
+		return "invalid";
+	}
+}
+
+static struct ast_json *ari_transfer_to_json(struct stasis_message *msg,
+	const struct stasis_message_sanitizer *sanitize)
+{
+	struct ast_json *json_channel, *res;
+	struct ast_json *refer_json, *referred_json, *dest_json;
+	const struct timeval *tv = stasis_message_timestamp(msg);
+	struct ast_ari_transfer_message *transfer_msg = stasis_message_data(msg);
+
+	dest_json = ast_json_pack("{s: s, s: s}",
+		"protocol_id", transfer_msg->protocol_id,
+		"destination", transfer_msg->destination);
+	if (!dest_json) {
+		return NULL;
+	}
+
+	if (AST_VECTOR_SIZE(transfer_msg->refer_params) > 0) {
+		struct ast_json *params = ast_json_array_create();
+		if (!params) {
+			return NULL;
+		}
+		for (int i = 0; i < AST_VECTOR_SIZE(transfer_msg->refer_params); ++i) {
+			struct ast_refer_param param = AST_VECTOR_GET(transfer_msg->refer_params, i);
+			ast_json_array_append(params, ast_json_pack("{s: s, s: s}",
+								    "parameter_name", param.param_name,
+								    "parameter_value", param.param_value));
+		}
+		ast_json_object_set(dest_json, "additional_protocol_params", params);
+	}
+
+	refer_json = ast_json_pack("{s: o}",
+		"requested_destination", dest_json);
+	if (!refer_json) {
+		return NULL;
+	}
+	if (transfer_msg->dest) {
+		struct ast_json *dest_chan_json;
+
+		dest_chan_json = ast_channel_snapshot_to_json(transfer_msg->dest, sanitize);
+		ast_json_object_set(refer_json, "destination_channel", dest_chan_json);
+	}
+	if (transfer_msg->dest_peer) {
+		struct ast_json *peer_chan_json;
+
+		peer_chan_json = ast_channel_snapshot_to_json(transfer_msg->dest_peer, sanitize);
+		ast_json_object_set(refer_json, "connected_channel", peer_chan_json);
+	}
+	if (transfer_msg->dest_bridge) {
+		struct ast_json *dest_bridge_json;
+
+		dest_bridge_json = ast_bridge_snapshot_to_json(transfer_msg->dest_bridge, sanitize);
+		ast_json_object_set(refer_json, "bridge", dest_bridge_json);
+	}
+
+	json_channel = ast_channel_snapshot_to_json(transfer_msg->source, sanitize);
+	if (!json_channel) {
+		return NULL;
+	}
+
+	referred_json = ast_json_pack("{s: o}",
+		"source_channel", json_channel);
+	if (!referred_json) {
+		return NULL;
+	}
+	if (transfer_msg->source_peer) {
+		struct ast_json *peer_chan_json;
+
+		peer_chan_json = ast_channel_snapshot_to_json(transfer_msg->source_peer, sanitize);
+		ast_json_object_set(referred_json, "connected_channel", peer_chan_json);
+	}
+	if (transfer_msg->source_bridge) {
+		struct ast_json *source_bridge_json;
+
+		source_bridge_json = ast_bridge_snapshot_to_json(transfer_msg->source_bridge, sanitize);
+		ast_json_object_set(referred_json, "bridge", source_bridge_json);
+	}
+
+	res = ast_json_pack("{s: s, s: o, s: o, s: o}",
+		"type", "ChannelTransfer",
+		"timestamp", ast_json_timeval(*tv, NULL),
+		"refer_to", refer_json,
+		"referred_by", referred_json);
+	if (!res) {
+		return NULL;
+	}
+
+	if (transfer_msg->state != AST_TRANSFER_INVALID) {
+		ast_json_object_set(res, "state", ast_json_string_create(state2str(transfer_msg->state)));
+	}
+	return res;
+}
+
+static void ari_transfer_dtor(void *obj)
+{
+	struct ast_ari_transfer_message *msg = obj;
+
+	ao2_cleanup(msg->source);
+	ao2_cleanup(msg->source_bridge);
+	ao2_cleanup(msg->source_peer);
+	ao2_cleanup(msg->dest);
+	ao2_cleanup(msg->dest_bridge);
+	ao2_cleanup(msg->dest_peer);
+	ao2_cleanup(msg->refer_params);
+	ast_free(msg->referred_by);
+	ast_free(msg->protocol_id);
+}
+
+struct ast_ari_transfer_message *ast_ari_transfer_message_create(struct ast_channel *originating_chan, const char *referred_by,
+								 const char *exten, const char *protocol_id, struct ast_channel *dest,
+								 struct ast_refer_params *params, enum ast_control_transfer state)
+{
+	struct ast_ari_transfer_message *msg;
+	msg = ao2_alloc(sizeof(*msg), ari_transfer_dtor);
+	if (!msg) {
+		return NULL;
+	}
+
+	msg->refer_params = params;
+	ao2_ref(msg->refer_params, +1);
+
+	msg->state = state;
+
+	ast_channel_lock(originating_chan);
+	msg->source = ao2_bump(ast_channel_snapshot(originating_chan));
+	ast_channel_unlock(originating_chan);
+	if (!msg->source) {
+		ao2_cleanup(msg);
+		return NULL;
+	}
+
+	if (dest) {
+		ast_channel_lock(dest);
+		msg->dest = ao2_bump(ast_channel_snapshot(dest));
+		ast_channel_unlock(dest);
+		if (!msg->dest) {
+			ao2_cleanup(msg);
+			return NULL;
+		}
+	}
+
+	msg->referred_by = ast_strdup(referred_by);
+	if (!msg->referred_by) {
+		ao2_cleanup(msg);
+		return NULL;
+	}
+	ast_copy_string(msg->destination, exten, sizeof(msg->destination));
+	msg->protocol_id = ast_strdup(protocol_id);
+	if (!msg->protocol_id) {
+		ao2_cleanup(msg);
+		return NULL;
+	}
+
+	return msg;
+}
+
 /*!
  * @{ \brief Define channel message types.
  */
@@ -1681,6 +1852,9 @@ STASIS_MESSAGE_TYPE_DEFN(ast_channel_talking_stop,
 	.to_ami = talking_stop_to_ami,
 	.to_json = talking_stop_to_json,
 	);
+STASIS_MESSAGE_TYPE_DEFN(ast_channel_transfer_request_type,
+	.to_json = ari_transfer_to_json,
+	);
 
 /*! @} */
 
@@ -1717,6 +1891,7 @@ static void stasis_channels_cleanup(void)
 	STASIS_MESSAGE_TYPE_CLEANUP(ast_channel_agent_logoff_type);
 	STASIS_MESSAGE_TYPE_CLEANUP(ast_channel_talking_start);
 	STASIS_MESSAGE_TYPE_CLEANUP(ast_channel_talking_stop);
+	STASIS_MESSAGE_TYPE_CLEANUP(ast_channel_transfer_request_type);
 }
 
 int ast_stasis_channels_init(void)
@@ -1768,6 +1943,7 @@ int ast_stasis_channels_init(void)
 	res |= STASIS_MESSAGE_TYPE_INIT(ast_channel_mixmonitor_mute_type);
 	res |= STASIS_MESSAGE_TYPE_INIT(ast_channel_talking_start);
 	res |= STASIS_MESSAGE_TYPE_INIT(ast_channel_talking_stop);
+	res |= STASIS_MESSAGE_TYPE_INIT(ast_channel_transfer_request_type);
 
 	return res;
 }

--- a/res/ari/ari_model_validators.c
+++ b/res/ari/ari_model_validators.c
@@ -2428,6 +2428,60 @@ ari_validator ast_ari_validate_mailbox_fn(void)
 	return ast_ari_validate_mailbox;
 }
 
+int ast_ari_validate_additional_param(struct ast_json *json)
+{
+	int res = 1;
+	struct ast_json_iter *iter;
+	int has_parameter_name = 0;
+	int has_parameter_value = 0;
+
+	for (iter = ast_json_object_iter(json); iter; iter = ast_json_object_iter_next(json, iter)) {
+		if (strcmp("parameter_name", ast_json_object_iter_key(iter)) == 0) {
+			int prop_is_valid;
+			has_parameter_name = 1;
+			prop_is_valid = ast_ari_validate_string(
+				ast_json_object_iter_value(iter));
+			if (!prop_is_valid) {
+				ast_log(LOG_ERROR, "ARI AdditionalParam field parameter_name failed validation\n");
+				res = 0;
+			}
+		} else
+		if (strcmp("parameter_value", ast_json_object_iter_key(iter)) == 0) {
+			int prop_is_valid;
+			has_parameter_value = 1;
+			prop_is_valid = ast_ari_validate_string(
+				ast_json_object_iter_value(iter));
+			if (!prop_is_valid) {
+				ast_log(LOG_ERROR, "ARI AdditionalParam field parameter_value failed validation\n");
+				res = 0;
+			}
+		} else
+		{
+			ast_log(LOG_ERROR,
+				"ARI AdditionalParam has undocumented field %s\n",
+				ast_json_object_iter_key(iter));
+			res = 0;
+		}
+	}
+
+	if (!has_parameter_name) {
+		ast_log(LOG_ERROR, "ARI AdditionalParam missing required field parameter_name\n");
+		res = 0;
+	}
+
+	if (!has_parameter_value) {
+		ast_log(LOG_ERROR, "ARI AdditionalParam missing required field parameter_value\n");
+		res = 0;
+	}
+
+	return res;
+}
+
+ari_validator ast_ari_validate_additional_param_fn(void)
+{
+	return ast_ari_validate_additional_param;
+}
+
 int ast_ari_validate_application_move_failed(struct ast_json *json)
 {
 	int res = 1;
@@ -4915,6 +4969,126 @@ ari_validator ast_ari_validate_channel_talking_started_fn(void)
 	return ast_ari_validate_channel_talking_started;
 }
 
+int ast_ari_validate_channel_transfer(struct ast_json *json)
+{
+	int res = 1;
+	struct ast_json_iter *iter;
+	int has_type = 0;
+	int has_application = 0;
+	int has_timestamp = 0;
+	int has_refer_to = 0;
+	int has_referred_by = 0;
+
+	for (iter = ast_json_object_iter(json); iter; iter = ast_json_object_iter_next(json, iter)) {
+		if (strcmp("asterisk_id", ast_json_object_iter_key(iter)) == 0) {
+			int prop_is_valid;
+			prop_is_valid = ast_ari_validate_string(
+				ast_json_object_iter_value(iter));
+			if (!prop_is_valid) {
+				ast_log(LOG_ERROR, "ARI ChannelTransfer field asterisk_id failed validation\n");
+				res = 0;
+			}
+		} else
+		if (strcmp("type", ast_json_object_iter_key(iter)) == 0) {
+			int prop_is_valid;
+			has_type = 1;
+			prop_is_valid = ast_ari_validate_string(
+				ast_json_object_iter_value(iter));
+			if (!prop_is_valid) {
+				ast_log(LOG_ERROR, "ARI ChannelTransfer field type failed validation\n");
+				res = 0;
+			}
+		} else
+		if (strcmp("application", ast_json_object_iter_key(iter)) == 0) {
+			int prop_is_valid;
+			has_application = 1;
+			prop_is_valid = ast_ari_validate_string(
+				ast_json_object_iter_value(iter));
+			if (!prop_is_valid) {
+				ast_log(LOG_ERROR, "ARI ChannelTransfer field application failed validation\n");
+				res = 0;
+			}
+		} else
+		if (strcmp("timestamp", ast_json_object_iter_key(iter)) == 0) {
+			int prop_is_valid;
+			has_timestamp = 1;
+			prop_is_valid = ast_ari_validate_date(
+				ast_json_object_iter_value(iter));
+			if (!prop_is_valid) {
+				ast_log(LOG_ERROR, "ARI ChannelTransfer field timestamp failed validation\n");
+				res = 0;
+			}
+		} else
+		if (strcmp("refer_to", ast_json_object_iter_key(iter)) == 0) {
+			int prop_is_valid;
+			has_refer_to = 1;
+			prop_is_valid = ast_ari_validate_refer_to(
+				ast_json_object_iter_value(iter));
+			if (!prop_is_valid) {
+				ast_log(LOG_ERROR, "ARI ChannelTransfer field refer_to failed validation\n");
+				res = 0;
+			}
+		} else
+		if (strcmp("referred_by", ast_json_object_iter_key(iter)) == 0) {
+			int prop_is_valid;
+			has_referred_by = 1;
+			prop_is_valid = ast_ari_validate_referred_by(
+				ast_json_object_iter_value(iter));
+			if (!prop_is_valid) {
+				ast_log(LOG_ERROR, "ARI ChannelTransfer field referred_by failed validation\n");
+				res = 0;
+			}
+		} else
+		if (strcmp("state", ast_json_object_iter_key(iter)) == 0) {
+			int prop_is_valid;
+			prop_is_valid = ast_ari_validate_string(
+				ast_json_object_iter_value(iter));
+			if (!prop_is_valid) {
+				ast_log(LOG_ERROR, "ARI ChannelTransfer field state failed validation\n");
+				res = 0;
+			}
+		} else
+		{
+			ast_log(LOG_ERROR,
+				"ARI ChannelTransfer has undocumented field %s\n",
+				ast_json_object_iter_key(iter));
+			res = 0;
+		}
+	}
+
+	if (!has_type) {
+		ast_log(LOG_ERROR, "ARI ChannelTransfer missing required field type\n");
+		res = 0;
+	}
+
+	if (!has_application) {
+		ast_log(LOG_ERROR, "ARI ChannelTransfer missing required field application\n");
+		res = 0;
+	}
+
+	if (!has_timestamp) {
+		ast_log(LOG_ERROR, "ARI ChannelTransfer missing required field timestamp\n");
+		res = 0;
+	}
+
+	if (!has_refer_to) {
+		ast_log(LOG_ERROR, "ARI ChannelTransfer missing required field refer_to\n");
+		res = 0;
+	}
+
+	if (!has_referred_by) {
+		ast_log(LOG_ERROR, "ARI ChannelTransfer missing required field referred_by\n");
+		res = 0;
+	}
+
+	return res;
+}
+
+ari_validator ast_ari_validate_channel_transfer_fn(void)
+{
+	return ast_ari_validate_channel_transfer;
+}
+
 int ast_ari_validate_channel_unhold(struct ast_json *json)
 {
 	int res = 1;
@@ -5876,6 +6050,9 @@ int ast_ari_validate_event(struct ast_json *json)
 	if (strcmp("ChannelTalkingStarted", discriminator) == 0) {
 		return ast_ari_validate_channel_talking_started(json);
 	} else
+	if (strcmp("ChannelTransfer", discriminator) == 0) {
+		return ast_ari_validate_channel_transfer(json);
+	} else
 	if (strcmp("ChannelUnhold", discriminator) == 0) {
 		return ast_ari_validate_channel_unhold(json);
 	} else
@@ -6082,6 +6259,9 @@ int ast_ari_validate_message(struct ast_json *json)
 	} else
 	if (strcmp("ChannelTalkingStarted", discriminator) == 0) {
 		return ast_ari_validate_channel_talking_started(json);
+	} else
+	if (strcmp("ChannelTransfer", discriminator) == 0) {
+		return ast_ari_validate_channel_transfer(json);
 	} else
 	if (strcmp("ChannelUnhold", discriminator) == 0) {
 		return ast_ari_validate_channel_unhold(json);
@@ -7004,6 +7184,177 @@ int ast_ari_validate_recording_started(struct ast_json *json)
 ari_validator ast_ari_validate_recording_started_fn(void)
 {
 	return ast_ari_validate_recording_started;
+}
+
+int ast_ari_validate_refer_to(struct ast_json *json)
+{
+	int res = 1;
+	struct ast_json_iter *iter;
+	int has_requested_destination = 0;
+
+	for (iter = ast_json_object_iter(json); iter; iter = ast_json_object_iter_next(json, iter)) {
+		if (strcmp("bridge", ast_json_object_iter_key(iter)) == 0) {
+			int prop_is_valid;
+			prop_is_valid = ast_ari_validate_bridge(
+				ast_json_object_iter_value(iter));
+			if (!prop_is_valid) {
+				ast_log(LOG_ERROR, "ARI ReferTo field bridge failed validation\n");
+				res = 0;
+			}
+		} else
+		if (strcmp("connected_channel", ast_json_object_iter_key(iter)) == 0) {
+			int prop_is_valid;
+			prop_is_valid = ast_ari_validate_channel(
+				ast_json_object_iter_value(iter));
+			if (!prop_is_valid) {
+				ast_log(LOG_ERROR, "ARI ReferTo field connected_channel failed validation\n");
+				res = 0;
+			}
+		} else
+		if (strcmp("destination_channel", ast_json_object_iter_key(iter)) == 0) {
+			int prop_is_valid;
+			prop_is_valid = ast_ari_validate_channel(
+				ast_json_object_iter_value(iter));
+			if (!prop_is_valid) {
+				ast_log(LOG_ERROR, "ARI ReferTo field destination_channel failed validation\n");
+				res = 0;
+			}
+		} else
+		if (strcmp("requested_destination", ast_json_object_iter_key(iter)) == 0) {
+			int prop_is_valid;
+			has_requested_destination = 1;
+			prop_is_valid = ast_ari_validate_required_destination(
+				ast_json_object_iter_value(iter));
+			if (!prop_is_valid) {
+				ast_log(LOG_ERROR, "ARI ReferTo field requested_destination failed validation\n");
+				res = 0;
+			}
+		} else
+		{
+			ast_log(LOG_ERROR,
+				"ARI ReferTo has undocumented field %s\n",
+				ast_json_object_iter_key(iter));
+			res = 0;
+		}
+	}
+
+	if (!has_requested_destination) {
+		ast_log(LOG_ERROR, "ARI ReferTo missing required field requested_destination\n");
+		res = 0;
+	}
+
+	return res;
+}
+
+ari_validator ast_ari_validate_refer_to_fn(void)
+{
+	return ast_ari_validate_refer_to;
+}
+
+int ast_ari_validate_referred_by(struct ast_json *json)
+{
+	int res = 1;
+	struct ast_json_iter *iter;
+	int has_source_channel = 0;
+
+	for (iter = ast_json_object_iter(json); iter; iter = ast_json_object_iter_next(json, iter)) {
+		if (strcmp("bridge", ast_json_object_iter_key(iter)) == 0) {
+			int prop_is_valid;
+			prop_is_valid = ast_ari_validate_bridge(
+				ast_json_object_iter_value(iter));
+			if (!prop_is_valid) {
+				ast_log(LOG_ERROR, "ARI ReferredBy field bridge failed validation\n");
+				res = 0;
+			}
+		} else
+		if (strcmp("connected_channel", ast_json_object_iter_key(iter)) == 0) {
+			int prop_is_valid;
+			prop_is_valid = ast_ari_validate_channel(
+				ast_json_object_iter_value(iter));
+			if (!prop_is_valid) {
+				ast_log(LOG_ERROR, "ARI ReferredBy field connected_channel failed validation\n");
+				res = 0;
+			}
+		} else
+		if (strcmp("source_channel", ast_json_object_iter_key(iter)) == 0) {
+			int prop_is_valid;
+			has_source_channel = 1;
+			prop_is_valid = ast_ari_validate_channel(
+				ast_json_object_iter_value(iter));
+			if (!prop_is_valid) {
+				ast_log(LOG_ERROR, "ARI ReferredBy field source_channel failed validation\n");
+				res = 0;
+			}
+		} else
+		{
+			ast_log(LOG_ERROR,
+				"ARI ReferredBy has undocumented field %s\n",
+				ast_json_object_iter_key(iter));
+			res = 0;
+		}
+	}
+
+	if (!has_source_channel) {
+		ast_log(LOG_ERROR, "ARI ReferredBy missing required field source_channel\n");
+		res = 0;
+	}
+
+	return res;
+}
+
+ari_validator ast_ari_validate_referred_by_fn(void)
+{
+	return ast_ari_validate_referred_by;
+}
+
+int ast_ari_validate_required_destination(struct ast_json *json)
+{
+	int res = 1;
+	struct ast_json_iter *iter;
+
+	for (iter = ast_json_object_iter(json); iter; iter = ast_json_object_iter_next(json, iter)) {
+		if (strcmp("additional_protocol_params", ast_json_object_iter_key(iter)) == 0) {
+			int prop_is_valid;
+			prop_is_valid = ast_ari_validate_list(
+				ast_json_object_iter_value(iter),
+				ast_ari_validate_additional_param);
+			if (!prop_is_valid) {
+				ast_log(LOG_ERROR, "ARI RequiredDestination field additional_protocol_params failed validation\n");
+				res = 0;
+			}
+		} else
+		if (strcmp("destination", ast_json_object_iter_key(iter)) == 0) {
+			int prop_is_valid;
+			prop_is_valid = ast_ari_validate_string(
+				ast_json_object_iter_value(iter));
+			if (!prop_is_valid) {
+				ast_log(LOG_ERROR, "ARI RequiredDestination field destination failed validation\n");
+				res = 0;
+			}
+		} else
+		if (strcmp("protocol_id", ast_json_object_iter_key(iter)) == 0) {
+			int prop_is_valid;
+			prop_is_valid = ast_ari_validate_string(
+				ast_json_object_iter_value(iter));
+			if (!prop_is_valid) {
+				ast_log(LOG_ERROR, "ARI RequiredDestination field protocol_id failed validation\n");
+				res = 0;
+			}
+		} else
+		{
+			ast_log(LOG_ERROR,
+				"ARI RequiredDestination has undocumented field %s\n",
+				ast_json_object_iter_key(iter));
+			res = 0;
+		}
+	}
+
+	return res;
+}
+
+ari_validator ast_ari_validate_required_destination_fn(void)
+{
+	return ast_ari_validate_required_destination;
 }
 
 int ast_ari_validate_stasis_end(struct ast_json *json)

--- a/res/ari/ari_model_validators.h
+++ b/res/ari/ari_model_validators.h
@@ -572,6 +572,22 @@ int ast_ari_validate_mailbox(struct ast_json *json);
 ari_validator ast_ari_validate_mailbox_fn(void);
 
 /*!
+ * \brief Validator for AdditionalParam.
+ *
+ * Protocol specific additional parameter
+ *
+ * \param json JSON object to validate.
+ * \retval True (non-zero) if valid.
+ * \retval False (zero) if invalid.
+ */
+int ast_ari_validate_additional_param(struct ast_json *json);
+
+/*!
+ * \brief Function pointer to ast_ari_validate_additional_param().
+ */
+ari_validator ast_ari_validate_additional_param_fn(void);
+
+/*!
  * \brief Validator for ApplicationMoveFailed.
  *
  * Notification that trying to move a channel to another Stasis application failed.
@@ -912,6 +928,22 @@ int ast_ari_validate_channel_talking_started(struct ast_json *json);
 ari_validator ast_ari_validate_channel_talking_started_fn(void);
 
 /*!
+ * \brief Validator for ChannelTransfer.
+ *
+ * transfer on a channel.
+ *
+ * \param json JSON object to validate.
+ * \retval True (non-zero) if valid.
+ * \retval False (zero) if invalid.
+ */
+int ast_ari_validate_channel_transfer(struct ast_json *json);
+
+/*!
+ * \brief Function pointer to ast_ari_validate_channel_transfer().
+ */
+ari_validator ast_ari_validate_channel_transfer_fn(void);
+
+/*!
  * \brief Validator for ChannelUnhold.
  *
  * A channel initiated a media unhold.
@@ -1216,6 +1248,54 @@ int ast_ari_validate_recording_started(struct ast_json *json);
 ari_validator ast_ari_validate_recording_started_fn(void);
 
 /*!
+ * \brief Validator for ReferTo.
+ *
+ * transfer destination requested by transferee
+ *
+ * \param json JSON object to validate.
+ * \retval True (non-zero) if valid.
+ * \retval False (zero) if invalid.
+ */
+int ast_ari_validate_refer_to(struct ast_json *json);
+
+/*!
+ * \brief Function pointer to ast_ari_validate_refer_to().
+ */
+ari_validator ast_ari_validate_refer_to_fn(void);
+
+/*!
+ * \brief Validator for ReferredBy.
+ *
+ * transfer destination requested by transferee
+ *
+ * \param json JSON object to validate.
+ * \retval True (non-zero) if valid.
+ * \retval False (zero) if invalid.
+ */
+int ast_ari_validate_referred_by(struct ast_json *json);
+
+/*!
+ * \brief Function pointer to ast_ari_validate_referred_by().
+ */
+ari_validator ast_ari_validate_referred_by_fn(void);
+
+/*!
+ * \brief Validator for RequiredDestination.
+ *
+ * Information about the requested destination
+ *
+ * \param json JSON object to validate.
+ * \retval True (non-zero) if valid.
+ * \retval False (zero) if invalid.
+ */
+int ast_ari_validate_required_destination(struct ast_json *json);
+
+/*!
+ * \brief Function pointer to ast_ari_validate_required_destination().
+ */
+ari_validator ast_ari_validate_required_destination_fn(void);
+
+/*!
  * \brief Validator for StasisEnd.
  *
  * Notification that a channel has left a Stasis application.
@@ -1441,6 +1521,9 @@ ari_validator ast_ari_validate_application_fn(void);
  * - name: string (required)
  * - new_messages: int (required)
  * - old_messages: int (required)
+ * AdditionalParam
+ * - parameter_name: string (required)
+ * - parameter_value: string (required)
  * ApplicationMoveFailed
  * - asterisk_id: string
  * - type: string (required)
@@ -1606,6 +1689,14 @@ ari_validator ast_ari_validate_application_fn(void);
  * - application: string (required)
  * - timestamp: Date (required)
  * - channel: Channel (required)
+ * ChannelTransfer
+ * - asterisk_id: string
+ * - type: string (required)
+ * - application: string (required)
+ * - timestamp: Date (required)
+ * - refer_to: ReferTo (required)
+ * - referred_by: ReferredBy (required)
+ * - state: string
  * ChannelUnhold
  * - asterisk_id: string
  * - type: string (required)
@@ -1726,6 +1817,19 @@ ari_validator ast_ari_validate_application_fn(void);
  * - application: string (required)
  * - timestamp: Date (required)
  * - recording: LiveRecording (required)
+ * ReferTo
+ * - bridge: Bridge
+ * - connected_channel: Channel
+ * - destination_channel: Channel
+ * - requested_destination: RequiredDestination (required)
+ * ReferredBy
+ * - bridge: Bridge
+ * - connected_channel: Channel
+ * - source_channel: Channel (required)
+ * RequiredDestination
+ * - additional_protocol_params: List[AdditionalParam]
+ * - destination: string
+ * - protocol_id: string
  * StasisEnd
  * - asterisk_id: string
  * - type: string (required)

--- a/res/ari/resource_channels.h
+++ b/res/ari/resource_channels.h
@@ -870,5 +870,31 @@ int ast_ari_channels_external_media_parse_body(
  * \param[out] response HTTP response
  */
 void ast_ari_channels_external_media(struct ast_variable *headers, struct ast_ari_channels_external_media_args *args, struct ast_ari_response *response);
+/*! Argument struct for ast_ari_channels_transfer_progress() */
+struct ast_ari_channels_transfer_progress_args {
+	/*! Channel's id */
+	const char *channel_id;
+	/*! The state of the progress */
+	const char *states;
+};
+/*!
+ * \brief Body parsing function for /channels/{channelId}/transfer_progress.
+ * \param body The JSON body from which to parse parameters.
+ * \param[out] args The args structure to parse into.
+ * \retval zero on success
+ * \retval non-zero on failure
+ */
+int ast_ari_channels_transfer_progress_parse_body(
+	struct ast_json *body,
+	struct ast_ari_channels_transfer_progress_args *args);
+
+/*!
+ * \brief Inform the channel about the progress of the attended/blind transfer.
+ *
+ * \param headers HTTP headers
+ * \param args Swagger parameters
+ * \param[out] response HTTP response
+ */
+void ast_ari_channels_transfer_progress(struct ast_variable *headers, struct ast_ari_channels_transfer_progress_args *args, struct ast_ari_response *response);
 
 #endif /* _ASTERISK_RESOURCE_CHANNELS_H */

--- a/res/res_ari_channels.c
+++ b/res/res_ari_channels.c
@@ -3002,6 +3002,92 @@ static void ast_ari_channels_external_media_cb(
 fin: __attribute__((unused))
 	return;
 }
+int ast_ari_channels_transfer_progress_parse_body(
+	struct ast_json *body,
+	struct ast_ari_channels_transfer_progress_args *args)
+{
+	struct ast_json *field;
+	/* Parse query parameters out of it */
+	field = ast_json_object_get(body, "states");
+	if (field) {
+		args->states = ast_json_string_get(field);
+	}
+	return 0;
+}
+
+/*!
+ * \brief Parameter parsing callback for /channels/{channelId}/transfer_progress.
+ * \param ser TCP/TLS session object
+ * \param get_params GET parameters in the HTTP request.
+ * \param path_vars Path variables extracted from the request.
+ * \param headers HTTP headers.
+ * \param body
+ * \param[out] response Response to the HTTP request.
+ */
+static void ast_ari_channels_transfer_progress_cb(
+	struct ast_tcptls_session_instance *ser,
+	struct ast_variable *get_params, struct ast_variable *path_vars,
+	struct ast_variable *headers, struct ast_json *body, struct ast_ari_response *response)
+{
+	struct ast_ari_channels_transfer_progress_args args = {};
+	struct ast_variable *i;
+#if defined(AST_DEVMODE)
+	int is_valid;
+	int code;
+#endif /* AST_DEVMODE */
+
+	for (i = get_params; i; i = i->next) {
+		if (strcmp(i->name, "states") == 0) {
+			args.states = (i->value);
+		} else
+		{}
+	}
+	for (i = path_vars; i; i = i->next) {
+		if (strcmp(i->name, "channelId") == 0) {
+			args.channel_id = (i->value);
+		} else
+		{}
+	}
+	if (ast_ari_channels_transfer_progress_parse_body(body, &args)) {
+		ast_ari_response_alloc_failed(response);
+		goto fin;
+	}
+	ast_ari_channels_transfer_progress(headers, &args, response);
+#if defined(AST_DEVMODE)
+	code = response->response_code;
+
+	switch (code) {
+	case 0: /* Implementation is still a stub, or the code wasn't set */
+		is_valid = response->message == NULL;
+		break;
+	case 500: /* Internal Server Error */
+	case 501: /* Not Implemented */
+	case 400: /* Endpoint parameter not provided */
+	case 404: /* Channel or endpoint not found */
+	case 409: /* Channel not in a Stasis application */
+	case 412: /* Channel in invalid state */
+		is_valid = 1;
+		break;
+	default:
+		if (200 <= code && code <= 299) {
+			is_valid = ast_ari_validate_void(
+				response->message);
+		} else {
+			ast_log(LOG_ERROR, "Invalid error response %d for /channels/{channelId}/transfer_progress\n", code);
+			is_valid = 0;
+		}
+	}
+
+	if (!is_valid) {
+		ast_log(LOG_ERROR, "Response validation failed for /channels/{channelId}/transfer_progress\n");
+		ast_ari_response_error(response, 500,
+			"Internal Server Error", "Response validation failed");
+	}
+#endif /* AST_DEVMODE */
+
+fin: __attribute__((unused))
+	return;
+}
 
 /*! \brief REST handler for /api-docs/channels.json */
 static struct stasis_rest_handlers channels_create = {
@@ -3183,6 +3269,15 @@ static struct stasis_rest_handlers channels_channelId_rtp_statistics = {
 	.children = {  }
 };
 /*! \brief REST handler for /api-docs/channels.json */
+static struct stasis_rest_handlers channels_channelId_transfer_progress = {
+	.path_segment = "transfer_progress",
+	.callbacks = {
+		[AST_HTTP_POST] = ast_ari_channels_transfer_progress_cb,
+	},
+	.num_children = 0,
+	.children = {  }
+};
+/*! \brief REST handler for /api-docs/channels.json */
 static struct stasis_rest_handlers channels_channelId = {
 	.path_segment = "channelId",
 	.is_wildcard = 1,
@@ -3191,8 +3286,8 @@ static struct stasis_rest_handlers channels_channelId = {
 		[AST_HTTP_POST] = ast_ari_channels_originate_with_id_cb,
 		[AST_HTTP_DELETE] = ast_ari_channels_hangup_cb,
 	},
-	.num_children = 16,
-	.children = { &channels_channelId_continue,&channels_channelId_move,&channels_channelId_redirect,&channels_channelId_answer,&channels_channelId_ring,&channels_channelId_dtmf,&channels_channelId_mute,&channels_channelId_hold,&channels_channelId_moh,&channels_channelId_silence,&channels_channelId_play,&channels_channelId_record,&channels_channelId_variable,&channels_channelId_snoop,&channels_channelId_dial,&channels_channelId_rtp_statistics, }
+	.num_children = 17,
+	.children = { &channels_channelId_continue,&channels_channelId_move,&channels_channelId_redirect,&channels_channelId_answer,&channels_channelId_ring,&channels_channelId_dtmf,&channels_channelId_mute,&channels_channelId_hold,&channels_channelId_moh,&channels_channelId_silence,&channels_channelId_play,&channels_channelId_record,&channels_channelId_variable,&channels_channelId_snoop,&channels_channelId_dial,&channels_channelId_rtp_statistics,&channels_channelId_transfer_progress, }
 };
 /*! \brief REST handler for /api-docs/channels.json */
 static struct stasis_rest_handlers channels_externalMedia = {

--- a/rest-api/api-docs/channels.json
+++ b/rest-api/api-docs/channels.json
@@ -1997,6 +1997,59 @@
 					]
 				}
 			]
+		},
+		{
+			"path": "/channels/{channelId}/transfer_progress",
+			"description": "Inform the channel that the transfer is in progress.",
+			"operations": [
+				{
+					"httpMethod": "POST",
+					"since": [
+						"22.3.0",
+						"21.8.0",
+						"20.13.0"
+					],
+					"summary": "Inform the channel about the progress of the attended/blind transfer.",
+					"nickname": "transfer_progress",
+					"responseClass": "void",
+					"parameters": [
+						{
+							"name": "channelId",
+							"description": "Channel's id",
+							"paramType": "path",
+							"required": true,
+							"allowMultiple": false,
+							"dataType": "string"
+						},
+						{
+							"name": "states",
+							"description": "The state of the progress",
+							"paramType": "query",
+							"required": true,
+							"allowMultiple": false,
+							"dataType": "string"
+						}
+					],
+					"errorResponses": [
+						{
+							"code": 400,
+							"reason": "Endpoint parameter not provided"
+						},
+						{
+							"code": 404,
+							"reason": "Channel or endpoint not found"
+						},
+						{
+							"code": 409,
+							"reason": "Channel not in a Stasis application"
+						},
+						{
+							"code": 412,
+							"reason": "Channel in invalid state"
+						}
+					]
+				}
+			]
 		}
 	],
 	"models": {

--- a/rest-api/api-docs/events.json
+++ b/rest-api/api-docs/events.json
@@ -198,7 +198,8 @@
 				"StasisStart",
 				"TextMessageReceived",
 				"ChannelConnectedLine",
-				"PeerStatusChange"
+				"PeerStatusChange",
+				"ChannelTransfer"
 			]
 		},
 		"ContactInfo": {
@@ -920,6 +921,110 @@
 					"required": true,
 					"type": "Channel",
 					"description": "The channel whose connected line has changed."
+				}
+			}
+		},
+		"ChannelTransfer": {
+			"id": "ChannelTransfer",
+			"description": "transfer on a channel.",
+			"properties": {
+				"state": {
+					"required": false,
+					"type": "string",
+					"description": "Transfer State"
+				},
+				"refer_to": {
+					"required": true,
+					"type": "ReferTo",
+					"description": "Refer-To information with optionally both affected channels"
+				},
+				"referred_by": {
+					"required": true,
+					"type": "ReferredBy",
+					"description": "Referred-By SIP Header according rfc3892"
+				}
+			}
+		},
+		"ReferTo": {
+			"id": "ReferTo",
+			"description": "transfer destination requested by transferee",
+			"properties": {
+				"requested_destination": {
+					"required": true,
+					"type": "RequiredDestination"
+				},
+				"destination_channel": {
+					"required": false,
+					"type": "Channel",
+					"description": "The Channel Object, that is to be replaced"
+				},
+				"connected_channel": {
+					"required": false,
+					"type": "Channel",
+					"description": "Channel, connected to the to be replaced channel"
+				},
+				"bridge": {
+					"required": false,
+					"type": "Bridge",
+					"description": "Bridge connecting both destination channels"
+				}
+			}
+		},
+		"ReferredBy": {
+			"id": "ReferredBy",
+			"description": "transfer destination requested by transferee",
+			"properties": {
+				"source_channel": {
+					"required": true,
+					"type": "Channel",
+					"description": "The channel on which the refer was received"
+				},
+				"connected_channel": {
+					"required": false,
+					"type": "Channel",
+					"description": "Channel, Connected to the channel, receiving the transfer request on."
+				},
+				"bridge": {
+					"required": false,
+					"type": "Bridge",
+					"description": "Bridge connecting both Channels"
+				}
+			}
+		},
+		"RequiredDestination": {
+			"id": "RequiredDestination",
+			"description": "Information about the requested destination",
+			"properties": {
+				"protocol_id": {
+					"required": false,
+					"type": "string",
+					"description": "the requested protocol-id by the referee in case of SIP channel, this is a SIP Call ID, Mutually exclusive to destination"
+				},
+				"destination": {
+					"required": false,
+					"type": "string",
+					"description": "Destination User Part. Only for Blind transfer. Mutually exclusive to protocol_id"
+				},
+				"additional_protocol_params": {
+					"required": false,
+					"type": "List[AdditionalParam]",
+					"description": "List of additional protocol specific information"
+				}
+			}
+		},
+		"AdditionalParam": {
+			"id": "AdditionalParam",
+			"description": "Protocol specific additional parameter",
+			"properties": {
+				"parameter_name": {
+					"required": true,
+					"type": "string",
+					"description": "Name of the parameter"
+				},
+				"parameter_value": {
+					"required": true,
+					"type": "string",
+					"description": "Value of the parameter"
 				}
 			}
 		}


### PR DESCRIPTION
Introduce a ChannelTransfer event and the ability to notify progress to ARI. Implement emitting this event from the PJSIP channel instead of handling the transfer in Asterisk when configured.

Introduce a dialplan function to the PJSIP channel to switch between the "core" and "ari-only" behavior.

UserNote: Call transfers on the PJSIP channel can now be controlled by ARI. This can be enabled by using the PJSIP_TRANSFER_HANDLING(ari-only) dialplan function.