### PR TITLE
docs: Fix various typos in main/

### DIFF
--- a/main/acl.c
+++ b/main/acl.c
@@ -104,7 +104,7 @@ static void score_address(const struct sockaddr_in *sin, struct in_addr *best_ad
 	/* RFC 3330 Test network */
 	} else if (strncmp(address, "192.0.2.", 8) == 0) {
 		score = -15;
-	/* Every other address should be publically routable */
+	/* Every other address should be publicly routable */
 	} else {
 		score = 0;
 	}

--- a/main/aoc.c
+++ b/main/aoc.c
@@ -80,7 +80,7 @@
 				<parameter name="Scale" />
 				<parameter name="Unit">
 					<enumlist>
-						<enum name="Octect" />
+						<enum name="Octet" />
 						<enum name="Segment" />
 						<enum name="Message" />
 					</enumlist>

--- a/main/ast_expr2.c
+++ b/main/ast_expr2.c
@@ -3449,7 +3449,7 @@ chk_times (FP___TYPE a, FP___TYPE b, FP___TYPE r)
 	/* special case: first operand is 0, no overflow possible */
 	if (a == 0)
 		return 0;
-	/* cerify that result of division matches second operand */
+	/* verify that result of division matches second operand */
 	if (r / a != b)
 		return 1;
 	return 0;

--- a/main/ast_expr2.y
+++ b/main/ast_expr2.y
@@ -1442,7 +1442,7 @@ chk_times (FP___TYPE a, FP___TYPE b, FP___TYPE r)
 	/* special case: first operand is 0, no overflow possible */
 	if (a == 0)
 		return 0;
-	/* cerify that result of division matches second operand */
+	/* verify that result of division matches second operand */
 	if (r / a != b)
 		return 1;
 	return 0;

--- a/main/astmm.c
+++ b/main/astmm.c
@@ -129,7 +129,7 @@ struct ast_region {
 	 * \brief Location of the requested malloc block to return.
 	 *
 	 * \note Must have the same alignment that malloc returns.
-	 * i.e., It is suitably aligned for any kind of varible.
+	 * i.e., It is suitably aligned for any kind of variable.
 	 */
 	unsigned char data[0] __attribute__((aligned));
 };
@@ -1132,7 +1132,7 @@ static void mm_atexit_hash_restore(struct region_list *list)
 
 /*!
  * \internal
- * \brief Sort regions comparision.
+ * \brief Sort regions comparison.
  *
  * \param left Region to compare.
  * \param right Region to compare.

--- a/main/astobj2_container.c
+++ b/main/astobj2_container.c
@@ -271,7 +271,7 @@ static void *internal_ao2_traverse(struct ao2_container *self, enum search_flags
 			return NULL;
 		}
 		if (!(multi_iterator = ast_calloc(1, sizeof(*multi_iterator)))) {
-			ao2_t_ref(multi_container, -1, "OBJ_MULTIPLE interator creation failed.");
+			ao2_t_ref(multi_container, -1, "OBJ_MULTIPLE iterator creation failed.");
 			return NULL;
 		}
 	}

--- a/main/audiohook.c
+++ b/main/audiohook.c
@@ -496,7 +496,7 @@ static void audiohook_list_set_samplerate_compatibility(struct ast_audiohook_lis
 	 * at that level when it should be lower, and with no way to lower it since any
 	 * rate compared against it would be lower.
 	 *
-	 * By setting it back to the lowest rate it can recalulate the new highest rate.
+	 * By setting it back to the lowest rate it can recalculate the new highest rate.
 	 */
 	audiohook_list->list_internal_samp_rate = DEFAULT_INTERNAL_SAMPLE_RATE;
 
@@ -1255,7 +1255,7 @@ static int audiohook_volume_callback(struct ast_audiohook *audiohook, struct ast
 		return 0;
 	}
 
-	/* Try to find the datastore containg adjustment information, if we can't just bail out */
+	/* Try to find the datastore containing adjustment information, if we can't just bail out */
 	if (!(datastore = ast_channel_datastore_find(chan, &audiohook_volume_datastore, NULL))) {
 		return 0;
 	}

--- a/main/bridge.c
+++ b/main/bridge.c
@@ -4185,7 +4185,7 @@ static enum ast_transfer_result blind_transfer_bridge(int is_external,
  * the transferee channel.
  *
  * \param channels A two-channel container containing the transferer and transferee
- * \param transferer The party that is transfering the call
+ * \param transferer The party that is transferring the call
  * \return The party that is being transferred
  */
 static struct ast_channel *get_transferee(struct ao2_container *channels, struct ast_channel *transferer)
@@ -4225,7 +4225,7 @@ static struct ast_channel *get_transferee(struct ao2_container *channels, struct
  * \param bridge2 Bridge that chan2 is in. If NULL, then chan2 is not bridged.
  * \param transfer_msg Data to publish for a stasis attended transfer message.
  * \retval AST_BRIDGE_TRANSFER_FAIL Internal error occurred
- * \retval AST_BRIDGE_TRANSFER_SUCCESS Succesfully transferred the bridge
+ * \retval AST_BRIDGE_TRANSFER_SUCCESS Successfully transferred the bridge
  */
 static enum ast_transfer_result attended_transfer_bridge(struct ast_channel *chan1,
 		struct ast_channel *chan2, struct ast_bridge *bridge1, struct ast_bridge *bridge2,

--- a/main/bridge_basic.c
+++ b/main/bridge_basic.c
@@ -89,7 +89,7 @@ static const struct ast_datastore_info dtmf_features_info = {
  * \since 12.0.0
  * \brief read a feature code character and set it on for the give feature_flags struct
  *
- * \param feature_flags flags being modifed
+ * \param feature_flags flags being modified
  * \param feature feature code provided - should be an uppercase letter
  *
  * \retval 0 if the feature was set successfully
@@ -341,7 +341,7 @@ struct bridge_basic_personality {
  * \param len Length of the given extension buffer.
  *
  * \retval 0 success
- * \retval non-zero failiure
+ * \retval non-zero failure
  */
 static int builtin_feature_get_exten(struct ast_channel *chan, const char *feature_name, char *buf, size_t len)
 {
@@ -1474,7 +1474,7 @@ static struct attended_transfer_properties *attended_transfer_properties_alloc(
 	/*
 	 * Save the transferee's party information for any recall calls.
 	 * This is the only piece of information needed that gets overwritten
-	 * on the transferer channel by the inital call to the transfer target.
+	 * on the transferer channel by the initial call to the transfer target.
 	 */
 	ast_party_connected_line_copy(&props->original_transferer_colp,
 		ast_channel_connected(props->transferer));
@@ -3196,7 +3196,7 @@ static int grab_transfer(struct ast_channel *chan, char *exten, size_t exten_len
 		if (extenres) {
 			ast_copy_string(exten, extenoverride, exten_len);
 			ast_channel_unlock(chan);
-			ast_verb(3, "Transfering call to '%s@%s'", exten, context);
+			ast_verb(3, "Transferring call to '%s@%s'", exten, context);
 			return 0;
 		}
 		ast_log(LOG_WARNING, "Override extension '%s' does not exist in context '%s'\n", extenoverride, context);

--- a/main/bridge_channel.c
+++ b/main/bridge_channel.c
@@ -1275,7 +1275,7 @@ void ast_bridge_channel_playfile(struct ast_bridge_channel *bridge_channel, ast_
 
 	/*
 	 * It may be necessary to resume music on hold after we finish
-	 * playing the announcment.
+	 * playing the announcement.
 	 */
 	if (ast_test_flag(ast_channel_flags(bridge_channel->chan), AST_FLAG_MOH)) {
 		const char *latest_musicclass;

--- a/main/callerid.c
+++ b/main/callerid.c
@@ -671,7 +671,7 @@ int callerid_feed(struct callerid_state *cid, unsigned char *ubuf, int len, stru
 							 * but it would be silly for a telephone switch to do that. */
 							break;
 						/* For MDMF spills, we would expect to get an "O" or a "P"
-						 * for paramter 4 (or 8) as opposed to 2 (or 7) to indicate
+						 * for parameter 4 (or 8) as opposed to 2 (or 7) to indicate
 						 * a blocked or out of area presentation.
 						 * However, for SDMF, which doesn't have parameters,
 						 * there is no differentiation, which is why the logic below

--- a/main/ccss.c
+++ b/main/ccss.c
@@ -584,7 +584,7 @@ static enum ast_device_state cc_state_to_devstate_map[] = {
  *
  * \param state
  *
- * \return the correponding DEVICE STATE from the cc_state_to_devstate_map
+ * \return the corresponding DEVICE STATE from the cc_state_to_devstate_map
  * when passed an internal state.
  */
 static enum ast_device_state cc_state_to_devstate(enum cc_state state)
@@ -612,7 +612,7 @@ static enum ast_device_state ccss_device_state(const char *device_name)
 	match_flags = MATCH_NO_REQUEST;
 	core_instance = ao2_t_callback_data(cc_core_instances, 0, match_agent,
 		(char *) device_name, &match_flags,
-		"Find Core Instance for ccss_device_state reqeust.");
+		"Find Core Instance for ccss_device_state request.");
 	if (!core_instance) {
 		ast_log_dynamic_level(cc_logger_level,
 			"Couldn't find a core instance for caller %s\n", device_name);
@@ -2208,7 +2208,7 @@ static void call_destructor_with_no_monitor(const char * const monitor_type, voi
 
 /*!
  * \internal
- * \brief Allocate and intitialize a device cc_monitor
+ * \brief Allocate and initialize a device cc_monitor
  *
  * For all intents and purposes, this is the same as
  * cc_extension_monitor_init, except that there is only
@@ -4294,7 +4294,7 @@ static int cccancel_exec(struct ast_channel *chan, const char *data)
 	}
 
 	if (strcmp(core_instance->agent->callbacks->type, "generic")) {
-		ast_log(LOG_WARNING, "CallCompletionCancel may only be used for calles with a generic agent\n");
+		ast_log(LOG_WARNING, "CallCompletionCancel may only be used for calls with a generic agent\n");
 		cc_unref(core_instance, "Unref core instance found during CallCompletionCancel");
 		pbx_builtin_setvar_helper(chan, "CC_CANCEL_RESULT", "FAIL");
 		pbx_builtin_setvar_helper(chan, "CC_CANCEL_REASON", "NOT_GENERIC");

--- a/main/cdr.c
+++ b/main/cdr.c
@@ -1629,7 +1629,7 @@ static void cdr_object_swap_snapshot(struct cdr_object_snapshot *old_snapshot,
 		struct ast_channel_snapshot *new_snapshot)
 {
 	cdr_object_update_cid(old_snapshot, new_snapshot);
-	ao2_t_replace(old_snapshot->snapshot, new_snapshot, "Swap CDR shapshot");
+	ao2_t_replace(old_snapshot->snapshot, new_snapshot, "Swap CDR snapshot");
 }
 
 /* BASE METHOD IMPLEMENTATIONS */
@@ -2914,7 +2914,7 @@ static void handle_parked_call_message(void *data, struct stasis_subscription *s
 	}
 
 	if (unhandled) {
-		/* Nothing handled the messgae - we need a new one! */
+		/* Nothing handled the message - we need a new one! */
 		struct cdr_object *new_cdr;
 
 		new_cdr = cdr_object_create_and_append(cdr, stasis_message_timestamp(message));
@@ -4445,7 +4445,7 @@ static void destroy_subscriptions(void)
 }
 
 /*!
- * \brief Create the Stasis subcriptions for CDRs
+ * \brief Create the Stasis subscriptions for CDRs
  */
 static int create_subscriptions(void)
 {

--- a/main/channel.c
+++ b/main/channel.c
@@ -942,7 +942,7 @@ __ast_channel_alloc_ap(int needqueue, int state, const char *cid_num, const char
 
 	/*
 	 * And now, since the channel structure is built, and has its name, let
-	 * the world know of its existance
+	 * the world know of its existence
 	 */
 	ast_channel_stage_snapshot_done(tmp);
 
@@ -3712,7 +3712,7 @@ static struct ast_frame *__ast_read(struct ast_channel *chan, int dropaudio, int
 				ast_channel_alert_write(chan);
 			} else {
 				/*
-				 * Safely disable continous timer events if only buffered dtmf begin or end
+				 * Safely disable continuous timer events if only buffered dtmf begin or end
 				 * frames are left in the readq.
 				 */
 				ast_timer_disable_continuous(ast_channel_timer(chan));
@@ -5097,7 +5097,7 @@ static void adjust_frame_for_plc(struct ast_channel *chan, struct ast_frame *fra
 		return;
 	}
 
-	/* First, we need to be sure that our buffer is large enough to accomodate
+	/* First, we need to be sure that our buffer is large enough to accommodate
 	 * the samples we need to fill in. This will likely only occur on the first
 	 * frame we write.
 	 */
@@ -6931,7 +6931,7 @@ static void channel_do_masquerade(struct ast_channel *original, struct ast_chann
 	 */
 	ao2_lock(channels);
 
-	/* Bump the refs to ensure that they won't dissapear on us. */
+	/* Bump the refs to ensure that they won't disappear on us. */
 	ast_channel_ref(original);
 	ast_channel_ref(clonechan);
 
@@ -7144,7 +7144,7 @@ static void channel_do_masquerade(struct ast_channel *original, struct ast_chann
 	ast_autochan_new_channel(clonechan, original);
 
 	clone_variables(original, clonechan);
-	/* Presense of ADSI capable CPE follows clone */
+	/* Presence of ADSI capable CPE follows clone */
 	ast_channel_adsicpe_set(original, ast_channel_adsicpe(clonechan));
 	/* Bridge remains the same */
 	/* CDR fields remain the same */

--- a/main/cli.c
+++ b/main/cli.c
@@ -1754,7 +1754,7 @@ static char *handle_showchan(struct ast_cli_entry *e, int cmd, struct ast_cli_ar
 		"   Pickup Group: %llu\n"
 		"    Application: %s\n"
 		"           Data: %s\n"
-		" Call Identifer: %s\n",
+		" Call Identifier: %s\n",
 		ast_channel_name(chan),
 		ast_channel_tech(chan)->type,
 		ast_channel_uniqueid(chan),

--- a/main/config_options.c
+++ b/main/config_options.c
@@ -391,7 +391,7 @@ static struct aco_option *aco_option_find(struct aco_type *type, const char *nam
 	struct aco_option *opt;
 
 	if (!type || !type->internal || !type->internal->opts) {
-		ast_log(LOG_NOTICE, "Attempting to use NULL or unitialized config type\n");
+		ast_log(LOG_NOTICE, "Attempting to use NULL or uninitialized config type\n");
 		return NULL;
 	}
 

--- a/main/core_local.c
+++ b/main/core_local.c
@@ -297,7 +297,7 @@ struct ast_channel *ast_local_get_peer(struct ast_channel *ast)
 
 	found = p ? ao2_find(locals, p, 0) : NULL;
 	if (!found) {
-		/* ast is either not a local channel or it has alredy been hungup */
+		/* ast is either not a local channel or it has already been hungup */
 		return NULL;
 	}
 	ao2_lock(found);
@@ -895,7 +895,7 @@ static struct local_pvt *local_alloc(const char *data, struct ast_stream_topolog
 	 *
 	 * This is a silly default because it represents state held by
 	 * the local channels.  Unless local channel optimization is
-	 * disabled, the state will dissapear when the local channels
+	 * disabled, the state will disappear when the local channels
 	 * optimize out.
 	 */
 	ast_set_flag(&pvt->base, AST_UNREAL_MOH_INTERCEPT);

--- a/main/db.c
+++ b/main/db.c
@@ -220,7 +220,7 @@ static void clean_statements(void)
 static int init_statements(void)
 {
 	/* Don't initialize create_astdb_statement here as the astdb table needs to exist
-	 * brefore these statements can be initialized */
+	 * before these statements can be initialized */
 	return init_stmt(&get_stmt, get_stmt_sql, sizeof(get_stmt_sql))
 	|| init_stmt(&exists_stmt, exists_stmt_sql, sizeof(exists_stmt_sql))
 	|| init_stmt(&del_stmt, del_stmt_sql, sizeof(del_stmt_sql))

--- a/main/devicestate.c
+++ b/main/devicestate.c
@@ -783,7 +783,7 @@ static const char *device_state_get_id(struct stasis_message *message)
  * \since 12.2.0
  *
  * \param cache_topic Caching topic the aggregate message may be published over.
- * \param aggregate The aggregate shapshot message to publish.
+ * \param aggregate The aggregate snapshot message to publish.
  */
 static void device_state_aggregate_publish(struct stasis_topic *cache_topic, struct stasis_message *aggregate)
 {
@@ -808,7 +808,7 @@ static void device_state_aggregate_publish(struct stasis_topic *cache_topic, str
  * \since 12.2.0
  *
  * \param entry Cache entry to calculate a new aggregate snapshot.
- * \param new_snapshot The shapshot that is being updated.
+ * \param new_snapshot The snapshot that is being updated.
  *
  * \note Return a ref bumped pointer from stasis_cache_entry_get_aggregate()
  * if a new aggregate could not be calculated because of error.

--- a/main/dns.c
+++ b/main/dns.c
@@ -485,7 +485,7 @@ static int dns_parse_answer_ex(void *context, int rr_class, int rr_type, unsigne
 /*!
  * \brief Lookup record in DNS
  *
- * \note Asterisk DNS is synchronus at this time. This means that if your DNS does not
+ * \note Asterisk DNS is synchronous at this time. This means that if your DNS does not
  *       work properly, Asterisk might not start properly or a channel may lock.
 */
 int ast_search_dns(void *context,

--- a/main/enum.c
+++ b/main/enum.c
@@ -40,7 +40,7 @@
  *   http://tools.ietf.org/wg/enum/draft-ietf-enum-branch-location-record/
  *
  * \par Possible improvement
- * \todo Implement a caching mechanism for multile enum lookups
+ * \todo Implement a caching mechanism for multiple enum lookups
  * - See https://issues.asterisk.org/view.php?id=6739
  * \todo The service type selection needs to be redone.
  */
@@ -513,7 +513,7 @@ static int parse_naptr(unsigned char *dst, int dstsize, char *tech, int techsize
 		re_flags |= REG_ICASE;
 	}
 
-	pattern = regexp + 1;   /* pattern is the regex without the begining and ending delimiter */
+	pattern = regexp + 1;   /* pattern is the regex without the beginning and ending delimiter */
 	*delim2 = 0;    /* zero out the middle delimiter */
 	subst   = delim2 + 1; /* dst substring is everything after the second delimiter. */
 	regexp[regexp_len - 1] = 0; /* zero out the last delimiter */
@@ -603,7 +603,7 @@ static int parse_naptr(unsigned char *dst, int dstsize, char *tech, int techsize
 	return 0;
 }
 
-/* do not return requested value, just count RRs and return thei number in dst */
+/* do not return requested value, just count RRs and return their number in dst */
 #define ENUMLOOKUP_OPTIONS_COUNT       1
 /* do an ISN style lookup */
 #define ENUMLOOKUP_OPTIONS_ISN		2
@@ -675,7 +675,7 @@ int ast_get_enum(struct ast_channel *chan, const char *number, char *dst, int ds
 
 /*
   We don't need that any more, that "n" preceding the number has been replaced by a flag
-  in the options paramter.
+  in the options parameter.
 	ast_copy_string(naptrinput, number, sizeof(naptrinput));
 */
 /*
@@ -740,7 +740,7 @@ int ast_get_enum(struct ast_channel *chan, const char *number, char *dst, int ds
 	 * This code does more than simple RFC3261 ENUM. All these rewriting
 	 * schemes have in common that they build the FQDN for the NAPTR lookup
 	 * by concatenating
-	 *    - a number which needs be flipped and "."-seperated 	(left)
+	 *    - a number which needs be flipped and "."-separated 	(left)
 	 *    - some fixed string					(middle)
 	 *    - an Apex.						(apex)
 	 *

--- a/main/features_config.c
+++ b/main/features_config.c
@@ -281,7 +281,7 @@
 				<description>
 					<para>The applicationmap is an area where new custom features can be created. Items
 					defined in the applicationmap are not automatically accessible to bridged parties. Access
-					to the individual items is controled using the <replaceable>DYNAMIC_FEATURES</replaceable> channel variable.
+					to the individual items is controlled using the <replaceable>DYNAMIC_FEATURES</replaceable> channel variable.
 					The <replaceable>DYNAMIC_FEATURES</replaceable> is a <literal>#</literal> separated list of
 					either applicationmap item names or featuregroup names.</para>
 				</description>

--- a/main/file.c
+++ b/main/file.c
@@ -729,7 +729,7 @@ static int fileexists_test(const char *filename, const char *fmt, const char *la
  *
  * \param filename Name of the file.
  * \param fmt Format to look for the file in. OPTIONAL
- * \param preflang The perfered language
+ * \param preflang The preferred language
  * \param buf Returns the matching filename
  * \param buflen Size of the buf
  * \param result_cap OPTIONAL format capabilities result structure

--- a/main/fixedjitterbuf.c
+++ b/main/fixedjitterbuf.c
@@ -268,7 +268,7 @@ int fixed_jb_put(struct fixed_jb *jb, void *data, long ms, long ts, long now)
 
 		return FIXED_JB_OK;
 	} else if (!jb->frames) {
-		/* the frame list is empty or thats just the first frame ever */
+		/* the frame list is empty or that's just the first frame ever */
 		/* tail should also be NULL is that case */
 		ASSERT(jb->tail == NULL);
 		jb->frames = jb->tail = newframe;

--- a/main/json.c
+++ b/main/json.c
@@ -88,7 +88,7 @@ enum ast_json_type ast_json_typeof(const struct ast_json *json)
 	case JSON_FALSE: return AST_JSON_FALSE;
 	case JSON_NULL: return AST_JSON_NULL;
 	}
-	ast_assert(0); /* Unexpect return from json_typeof */
+	ast_assert(0); /* Unexpected return from json_typeof */
 	return r;
 }
 

--- a/main/loader.c
+++ b/main/loader.c
@@ -2376,7 +2376,7 @@ static int loader_builtin_init(struct load_order *load_order)
 			continue;
 		}
 
-		/* Parse dependendencies from mod->info. */
+		/* Parse dependencies from mod->info. */
 		if (module_post_register(mod)) {
 			return -1;
 		}

--- a/main/manager.c
+++ b/main/manager.c
@@ -2586,7 +2586,7 @@ static int action_listcategories(struct mansession *s, const struct message *m)
 
 	ret = is_restricted_file(fn);
 	if (ret == 1) {
-		astman_send_error(s, m, "File requires escalated priveleges");
+		astman_send_error(s, m, "File requires escalated privileges");
 		return 0;
 	} else if (ret == -1) {
 		astman_send_error(s, m, "Config file not found");
@@ -5319,7 +5319,7 @@ static int action_originate(struct mansession *s, const struct message *m)
 			ast_string_field_set(fast, otherchannelid, assignedids.uniqueid2);
 			fast->vars = vars;
 			fast->cap = cap;
-			cap = NULL; /* transfered originate helper the capabilities structure.  It is now responsible for freeing it. */
+			cap = NULL; /* transferred originate helper the capabilities structure.  It is now responsible for freeing it. */
 			fast->timeout = to;
 			fast->early_media = bridge_early;
 			fast->priority = pi;

--- a/main/manager_channels.c
+++ b/main/manager_channels.c
@@ -131,7 +131,7 @@
 				<channel_snapshot/>
 				<parameter name="Extension">
 					<para>Deprecated in 12, but kept for
-					backward compatability. Please use
+					backward compatibility. Please use
 					'Exten' instead.</para>
 				</parameter>
 				<parameter name="Application">

--- a/main/manager_doc.xml
+++ b/main/manager_doc.xml
@@ -1060,7 +1060,7 @@
 			<syntax>
 				<xi:include xpointer="xpointer(/docs/manager[@name='Login']/syntax/parameter[@name='ActionID'])" />
 				<parameter name="EventList">
-					<para>Conveys the status of the command reponse list</para>
+					<para>Conveys the status of the command response list</para>
 				</parameter>
 				<parameter name="ListItems">
 					<para>The total number of list items produced</para>
@@ -1262,8 +1262,8 @@
 				<para>This represents the amount of units charged. The ETSI AOC standard specifies that
 				this value along with the optional UnitType value are entries in a list.  To accommodate this
 				these values take an index value starting at 0 which can be used to generate this list of
-				unit entries.  For Example, If two unit entires were required this could be achieved by setting the
-				paramter UnitAmount(0)=1234 and UnitAmount(1)=5678.  Note that UnitAmount at index 0 is
+				unit entries.  For example, If two unit entries were required this could be achieved by setting the
+				parameter UnitAmount(0)=1234 and UnitAmount(1)=5678.  Note that UnitAmount at index 0 is
 				required when ChargeType=Unit, all other entries in the list are optional.
 				</para>
 			</parameter>
@@ -1583,7 +1583,7 @@
 			</note>
 			<note>
 			<para>
-			This comand requires the system permission because
+			This command requires the system permission because
 			this command can be used to create filters that may bypass
 			filters defined in manager.conf
 			</para>

--- a/main/message.c
+++ b/main/message.c
@@ -187,7 +187,7 @@
 						Successfully passed on to the protocol handler, but delivery has not necessarily been guaranteed.
 					</value>
 					<value name="FAILURE">
-						The protocol handler reported that it was unabled to deliver the message for some reason.
+						The protocol handler reported that it was unable to deliver the message for some reason.
 					</value>
 				</variable>
 			</variablelist>
@@ -1447,7 +1447,7 @@ struct ast_msg_data {
 	/*! The length of this structure plus the actual length of the allocated buffer */
 	size_t length;
 	enum ast_msg_data_source_type source;
-	/*! These are indices into the buffer where teh attribute starts */
+	/*! These are indices into the buffer where the attribute starts */
 	int attribute_value_offsets[__AST_MSG_DATA_ATTR_LAST];
 	/*! The buffer containing the NULL separated attributes */
 	char buf[0];

--- a/main/pbx.c
+++ b/main/pbx.c
@@ -1022,7 +1022,7 @@ static void pbx_destroy(struct ast_pbx *p)
  * in a similar collating sequence as sorting alphabetic strings, from left to
  * right. Thus, "1XXXXX" comes before "X11111", and would be the "better" match,
  * because "1" is more specific than "X".
- * So, to accomodate this philosophy, I sort the tree branches along the alt_char
+ * So, to accommodate this philosophy, I sort the tree branches along the alt_char
  * line so they are lowest to highest in specificity numbers. This way, as soon
  * as we encounter our first complete match, we automatically have the "best"
  * match and can stop the traversal immediately. Same for CANMATCH/MATCHMORE.
@@ -4341,7 +4341,7 @@ static enum ast_pbx_result __ast_pbx_run(struct ast_channel *c,
 	callid = ast_read_threadstorage_callid();
 	/* If the thread isn't already associated with a callid, we should create that association. */
 	if (!callid) {
-		/* Associate new PBX thread with the channel call id if it is availble.
+		/* Associate new PBX thread with the channel call id if it is available.
 		 * If not, create a new one instead.
 		 */
 		callid = ast_channel_callid(c);

--- a/main/pbx_app.c
+++ b/main/pbx_app.c
@@ -271,9 +271,9 @@ static char *handle_show_application(struct ast_cli_entry *e, int cmd, struct as
 		return NULL;
 	case CLI_GENERATE:
 		/*
-		 * There is a possibility to show informations about more than one
+		 * There is a possibility to show information about more than one
 		 * application at one time. You can type 'show application Dial Echo' and
-		 * you will see informations about these two applications ...
+		 * you will see information about these two applications ...
 		 */
 		return ast_complete_applications(a->line, a->word, -1);
 	}

--- a/main/pbx_functions.c
+++ b/main/pbx_functions.c
@@ -312,7 +312,7 @@ static int write_escalates(const struct ast_custom_function *acf)
  *  \param acf ast_custom_function structure with empty 'desc' and 'synopsis'
  *             but with a function 'name'.
  *  \retval -1 On error.
- *  \retval 0 On succes.
+ *  \retval 0 On success.
  */
 static int acf_retrieve_docs(struct ast_custom_function *acf)
 {

--- a/main/pickup.c
+++ b/main/pickup.c
@@ -69,7 +69,7 @@ STASIS_MESSAGE_TYPE_DEFN(
 
 /*!
  * The presence of this datastore on the channel indicates that
- * someone is attemting to pickup or has picked up the channel.
+ * someone is attempting to pickup or has picked up the channel.
  * The purpose is to prevent a race between two channels
  * attempting to pickup the same channel.
  */

--- a/main/rtp_engine.c
+++ b/main/rtp_engine.c
@@ -1973,7 +1973,7 @@ static int rtp_codecs_assign_payload_code_rx(struct ast_rtp_codecs *codecs, int 
 				/* We can either call this with the full list or the current rx list. The former
 				 * (static_RTP_PT) results in payload types skipping statically 'used' slots so you
 				 * get 101, 113...
-				 * With the latter (the built ingore list) you get what's expected 101, 102, 103 under
+				 * With the latter (the built ignore list) you get what's expected 101, 102, 103 under
 				 * most circumstances, but this results in static types being replaced.  Probably fine
 				 * because we preclude the current list.
 				 */

--- a/main/say.c
+++ b/main/say.c
@@ -5168,7 +5168,7 @@ int ast_say_date_with_format_is(struct ast_channel *chan, time_t t, const char *
 				}
 				break;
 			case 'H':
-				/* 24-Hour, single digit hours preceeded by "oh" (0) */
+				/* 24-Hour, single digit hours preceded by "oh" (0) */
 				if (tm.tm_hour < 10 && tm.tm_hour > 0) {
 					res = wait_file(chan, ints, "digits/0", lang);
 				}

--- a/main/stasis.c
+++ b/main/stasis.c
@@ -268,7 +268,7 @@
  * subscriptions need the topics to unsubscribe and check subscription status.
  *
  * The cycle is broken by stasis_unsubscribe(). The unsubscribe will remove the
- * topic's reference to a subscription. When the subcription is destroyed, it
+ * topic's reference to a subscription. When the subscription is destroyed, it
  * will remove its reference to the topic.
  *
  * This means that until a subscription has be explicitly unsubscribed, it will
@@ -2656,7 +2656,7 @@ static char *statistics_show_subscription(struct ast_cli_entry *e, int cmd, stru
 
 	subscription_stats = ao2_global_obj_ref(subscription_statistics);
 	if (!subscription_stats) {
-		ast_cli(a->fd, "Could not fetch subcription_statistics container\n");
+		ast_cli(a->fd, "Could not fetch subscription_statistics container\n");
 		return CLI_FAILURE;
 	}
 

--- a/main/stasis_bridges.c
+++ b/main/stasis_bridges.c
@@ -59,8 +59,8 @@
 						<enum name="Not Permitted"><para>Bridge does not permit transfers</para></enum>
 						<enum name="Success"><para>Transfer completed successfully</para></enum>
 					</enumlist>
-					<note><para>A result of <literal>Success</literal> does not necessarily mean that a target was succesfully
-					contacted. It means that a party was succesfully placed into the dialplan at the expected location.</para></note>
+					<note><para>A result of <literal>Success</literal> does not necessarily mean that a target was successfully
+					contacted. It means that a party was successfully placed into the dialplan at the expected location.</para></note>
 				</parameter>
 				<channel_snapshot prefix="Transferer"/>
 				<channel_snapshot prefix="Transferee"/>

--- a/main/stdtime/localtime.c
+++ b/main/stdtime/localtime.c
@@ -1744,7 +1744,7 @@ struct ast_tm *ast_localtime(const struct timeval *timep, struct ast_tm *tmp, co
 }
 
 /*
-** This function provides informaton about daylight savings time
+** This function provides information about daylight savings time
 ** for the given timezone.  This includes whether it can determine
 ** if daylight savings is used for this timezone, the UTC times for
 ** when daylight savings transitions, and the offset in seconds from

--- a/main/stun.c
+++ b/main/stun.c
@@ -508,7 +508,7 @@ try_again:
 			/* Bad STUN packet, not right type, or transaction ID did not match. */
 			memset(answer, 0, sizeof(struct sockaddr_in));
 
-			/* Was not a resonse to our request. */
+			/* Was not a response to our request. */
 			goto try_again;
 		}
 		/* Success.  answer contains the external address if available. */

--- a/main/taskprocessor.c
+++ b/main/taskprocessor.c
@@ -336,7 +336,7 @@ static void tps_shutdown(void)
  	 * a taskprocessor was not cleaned up somewhere */
 	if (objcount > 0) {
   		ast_log(LOG_ERROR,
-    		"Asertion may occur, the following taskprocessors are still runing:\n");
+    		"Assertion may occur, the following taskprocessors are still running:\n");
 
 		sorted_tps = ao2_container_alloc_rbtree(AO2_ALLOC_OPT_LOCK_NOLOCK, 0, tps_sort_cb,
 			NULL);

--- a/main/udptl.c
+++ b/main/udptl.c
@@ -913,7 +913,7 @@ static void calculate_far_max_ifp(struct ast_udptl *udptl)
 	 * datagram buffer. this is complicated by the fact that some
 	 * far endpoints send us bogus (small) max datagram values,
 	 * which would result in either buffer overrun or no error
-	 * correction. we try to accomodate those, but if the supplied
+	 * correction. we try to accommodate those, but if the supplied
 	 * value is too small to do so, we'll emit warning messages and
 	 * the user will have to use configuration options to override
 	 * the max datagram value supplied by the far endpoint.

--- a/main/utils.c
+++ b/main/utils.c
@@ -2631,7 +2631,7 @@ int ast_utils_init(void)
 /*!
  *\brief Parse digest authorization header.
  *\return Returns -1 if we have no auth or something wrong with digest.
- *\note	This function may be used for Digest request and responce header.
+ *\note	This function may be used for Digest request and response header.
  * request arg is set to nonzero, if we parse Digest Request.
  * pedantic arg can be set to nonzero if we need to do addition Digest check.
  */

--- a/main/xml.c
+++ b/main/xml.c
@@ -304,7 +304,7 @@ struct ast_xml_node *ast_xml_find_element(struct ast_xml_node *root_node, const 
 	}
 
 	for (cur = root_node; cur; cur = ast_xml_node_get_next(cur)) {
-		/* Check if the name matchs */
+		/* Check if the name matches */
 		if (strcmp(ast_xml_node_get_name(cur), name)) {
 			continue;
 		}

--- a/main/xmldoc.c
+++ b/main/xmldoc.c
@@ -629,7 +629,7 @@ static int xmldoc_has_specialtags(struct ast_xml_node *fixnode)
  * \param rootname Name of the application, function, option, etc. to build the syntax.
  * \param childname The name of each parameter node.
  * \param printparenthesis Boolean if we must print parenthesis if not parameters are found in the rootnode.
- * \param printrootname Boolean if we must print the rootname before the syntax and parenthesis at the begining/end.
+ * \param printrootname Boolean if we must print the rootname before the syntax and parenthesis at the beginning/end.
  *
  * \retval NULL on error.
  * \retval An ast_malloc'ed string with the syntax generated.
@@ -757,7 +757,7 @@ static char *xmldoc_get_syntax_fun(struct ast_xml_node *rootnode, const char *ro
 				paramname = xmldoc_get_syntax_fun(node, argname, "argument", prnparenthesis, prnparenthesis);
 				ast_xml_free_attr(argname);
 			} else {
-				/* Malformed XML, print **UNKOWN** */
+				/* Malformed XML, print **UNKNOWN** */
 				paramname = ast_strdup("**unknown**");
 			}
 		} else {
@@ -923,7 +923,7 @@ static char *xmldoc_parse_cmd_enumlist(struct ast_xml_node *fixnode)
  *
  * \param fixnode The \<syntax\> node pointer.
  * \param name The name of the 'command'.
- * \param printname Print the name of the command before the paramters?
+ * \param printname Print the name of the command before the parameters?
  *
  * \return On error, return just 'name'.
  * \return On success return the generated syntax.
@@ -1441,7 +1441,7 @@ static int xmldoc_parse_specialtags(struct ast_xml_node *fixnode, const char *ta
 
 		/* parse <para> elements inside special tags. */
 		for (node = ast_xml_node_get_children(node); node; node = ast_xml_node_get_next(node)) {
-			/* first <para> just print it without tabs at the begining. */
+			/* first <para> just print it without tabs at the beginning. */
 			if ((xmldoc_parse_para(node, "", posttabs, buffer) == 2)
 				|| (xmldoc_parse_info(node, "", posttabs, buffer) == 2)) {
 				ret = 2;
@@ -1509,7 +1509,7 @@ static int xmldoc_parse_argument(struct ast_xml_node *fixnode, int insideparamet
  * \brief Parse a \<variable\> node inside a \<variablelist\> node.
  *
  * \param node The variable node to parse.
- * \param tabs A string to be appended at the begining of the output that will be stored
+ * \param tabs A string to be appended at the beginning of the output that will be stored
  *        in buffer.
  * \param buffer This must be an already created ast_str. It will be used
  *        to store the result (if already has something it will be appended to the current
@@ -1541,7 +1541,7 @@ static int xmldoc_parse_variable(struct ast_xml_node *node, const char *tabs, st
 			ast_str_append(buffer, 0, "\n");
 			printedpara = 1;
 		}
-		/* Parse each <value name='valuename'>desciption</value> */
+		/* Parse each <value name='valuename'>description</value> */
 		valname = ast_xml_get_attribute(tmp, "name");
 		if (valname) {
 			ret = 1;
@@ -1570,7 +1570,7 @@ static int xmldoc_parse_variable(struct ast_xml_node *node, const char *tabs, st
  * \brief Parse a \<variablelist\> node and put all the output inside 'buffer'.
  *
  * \param node The variablelist node pointer.
- * \param tabs A string to be appended at the begining of the output that will be stored
+ * \param tabs A string to be appended at the beginning of the output that will be stored
  *        in buffer.
  * \param buffer This must be an already created ast_str. It will be used
  *        to store the result (if already has something it will be appended to the current
@@ -1653,7 +1653,7 @@ static char *_ast_xmldoc_build_seealso(struct ast_xml_node *node)
 	}
 
 	if (!node || !ast_xml_node_get_children(node)) {
-		/* we couldnt find a <see-also> node. */
+		/* we couldn't find a <see-also> node. */
 		return NULL;
 	}
 
@@ -1751,7 +1751,7 @@ static char *_ast_xmldoc_build_since(struct ast_xml_node *node)
 	}
 
 	if (!node || !ast_xml_node_get_children(node)) {
-		/* we couldnt find a <since> node. */
+		/* we couldn't find a <since> node. */
 		return NULL;
 	}
 
@@ -1885,7 +1885,7 @@ static int xmldoc_parse_enumlist(struct ast_xml_node *fixnode, const char *tabs,
  * \brief Parse an \<option\> node.
  *
  * \param fixnode An ast_xml pointer to the \<option\> node.
- * \param tabs A string to be appended at the begining of each line being added to the
+ * \param tabs A string to be appended at the beginning of each line being added to the
  *             buffer string.
  * \param buffer The output buffer.
  *
@@ -1932,7 +1932,7 @@ static int xmldoc_parse_option(struct ast_xml_node *fixnode, const char *tabs, s
  * \brief Parse an \<optionlist\> element from the xml documentation.
  *
  * \param fixnode Pointer to the optionlist xml node.
- * \param tabs A string to be appended at the begining of each line being added to the
+ * \param tabs A string to be appended at the beginning of each line being added to the
  *             buffer string.
  * \param buffer Output buffer to put what is inside the optionlist tag.
  */
@@ -2337,7 +2337,7 @@ char *ast_xmldoc_build_synopsis(const char *type, const char *name, const char *
 
 /*!
  * \internal
- * \brief Build the descripton for an item
+ * \brief Build the description for an item
  *
  * \param node	The description node to parse
  *


### PR DESCRIPTION
Found via `codespell -q 3 -S "./CREDITS" -L abd,asent,atleast,childrens,contentn,crypted,dne,durationm,exten,inout,leapyear,nd,oclock,offsetp,ot,parm,parms,requestor,ser,slanguage,slin,thirdparty,varn,varns,ues`