### PR TITLE
docs: Fix various typos in channels/

### DIFF
--- a/channels/chan_dahdi.c
+++ b/channels/chan_dahdi.c
@@ -1347,7 +1347,7 @@ static int analogsub_to_dahdisub(enum analog_sub analogsub)
  * \brief release all members on the doomed pris list
  * \since 13.0
  *
- * Called priodically by the monitor threads to release spans marked for
+ * Called periodically by the monitor threads to release spans marked for
  * removal.
  */
 static void release_doomed_pris(void)
@@ -3255,7 +3255,7 @@ static void my_pri_make_cc_dialstring(void *priv, char *buf, size_t buf_size)
 		AST_APP_ARG(group);	/* channel/group token */
 		//AST_APP_ARG(ext);	/* extension token */
 		//AST_APP_ARG(opts);	/* options token */
-		//AST_APP_ARG(other);	/* Any remining unused arguments */
+		//AST_APP_ARG(other);	/* Any remaining unused arguments */
 	);
 
 	pvt = priv;
@@ -5469,7 +5469,7 @@ static int dahdi_call(struct ast_channel *ast, const char *rdest, int timeout)
 		AST_APP_ARG(group);	/* channel/group token */
 		AST_APP_ARG(ext);	/* extension token */
 		//AST_APP_ARG(opts);	/* options token */
-		AST_APP_ARG(other);	/* Any remining unused arguments */
+		AST_APP_ARG(other);	/* Any remaining unused arguments */
 	);
 
 	ast_mutex_lock(&p->lock);
@@ -6560,7 +6560,7 @@ static int dahdi_hangup(struct ast_channel *ast)
 				p->subs[SUB_REAL].inthreeway = 0;
 			}
 		} else if (idx == SUB_CALLWAIT) {
-			/* Ditch the holding callwait call, and immediately make it availabe */
+			/* Ditch the holding callwait call, and immediately make it available */
 			if (p->subs[SUB_CALLWAIT].inthreeway) {
 				/* This is actually part of a three way, placed on hold.  Place the third part
 				   on music on hold now */
@@ -6979,7 +6979,7 @@ static int dahdi_setoption(struct ast_channel *chan, int option, void *data, int
 			(*cp == 2) ? "MATE" : "ON", (int) *cp, ast_channel_name(chan));
 		dahdi_ec_disable(p);
 		/* otherwise, turn it on */
-		if (!p->didtdd) { /* if havent done it yet */
+		if (!p->didtdd) { /* if haven't done it yet */
 			unsigned char mybuf[41000];/*! \todo XXX This is an abuse of the stack!! */
 			unsigned char *buf;
 			int size, res, fd, len;
@@ -8696,7 +8696,7 @@ winkflashdone:
 			(p->polarity == POLARITY_REV) &&
 			((ast_channel_state(ast) == AST_STATE_UP) || (ast_channel_state(ast) == AST_STATE_RING)) ) {
 			/* Added log_debug information below to provide a better indication of what is going on */
-			ast_debug(1, "Polarity Reversal event occured - DEBUG 1: channel %d, state %u, pol= %d, aonp= %d, honp= %d, pdelay= %d, tv= %" PRIi64 "\n", p->channel, ast_channel_state(ast), p->polarity, p->answeronpolarityswitch, p->hanguponpolarityswitch, p->polarityonanswerdelay, ast_tvdiff_ms(ast_tvnow(), p->polaritydelaytv) );
+			ast_debug(1, "Polarity Reversal event occurred - DEBUG 1: channel %d, state %u, pol= %d, aonp= %d, honp= %d, pdelay= %d, tv= %" PRIi64 "\n", p->channel, ast_channel_state(ast), p->polarity, p->answeronpolarityswitch, p->hanguponpolarityswitch, p->polarityonanswerdelay, ast_tvdiff_ms(ast_tvnow(), p->polaritydelaytv) );
 
 			if (ast_tvdiff_ms(ast_tvnow(), p->polaritydelaytv) > p->polarityonanswerdelay) {
 				ast_debug(1, "Polarity Reversal detected and now Hanging up on channel %d\n", p->channel);
@@ -8710,7 +8710,7 @@ winkflashdone:
 			ast_debug(1, "Ignoring Polarity switch to IDLE on channel %d, state %u\n", p->channel, ast_channel_state(ast));
 		}
 		/* Added more log_debug information below to provide a better indication of what is going on */
-		ast_debug(1, "Polarity Reversal event occured - DEBUG 2: channel %d, state %u, pol= %d, aonp= %d, honp= %d, pdelay= %d, tv= %" PRIi64 "\n", p->channel, ast_channel_state(ast), p->polarity, p->answeronpolarityswitch, p->hanguponpolarityswitch, p->polarityonanswerdelay, ast_tvdiff_ms(ast_tvnow(), p->polaritydelaytv) );
+		ast_debug(1, "Polarity Reversal event occurred - DEBUG 2: channel %d, state %u, pol= %d, aonp= %d, honp= %d, pdelay= %d, tv= %" PRIi64 "\n", p->channel, ast_channel_state(ast), p->polarity, p->answeronpolarityswitch, p->hanguponpolarityswitch, p->polarityonanswerdelay, ast_tvdiff_ms(ast_tvnow(), p->polaritydelaytv) );
 		break;
 	default:
 		ast_debug(1, "Dunno what to do with event %d on channel %d\n", res, p->channel);
@@ -8875,7 +8875,7 @@ static struct ast_frame *dahdi_read(struct ast_channel *ast)
 		/*
 		 * Check to see if the channel is still associated with the same
 		 * private structure.  While the Asterisk channel was unlocked
-		 * the following events may have occured:
+		 * the following events may have occurred:
 		 *
 		 * 1) A masquerade may have associated the channel with another
 		 * technology or private structure.
@@ -12141,7 +12141,7 @@ static void *do_monitor(void *data)
 							int energy;
 							struct timeval now;
 							/* State machine dtmfcid_holdoff_state allows for the line to settle
-							 * before checking agin for dtmf energy.  Presently waits for 500 mS before checking again
+							 * before checking again for dtmf energy.  Presently waits for 500 mS before checking again
 							*/
 							if (1 == i->dtmfcid_holdoff_state) {
 								gettimeofday(&i->dtmfcid_delay, NULL);
@@ -13190,7 +13190,7 @@ static struct dahdi_pvt *mkintf(int channel, const struct dahdi_chan_conf *conf,
 		if (tmp->use_smdi) {
 			tmp->smdi_iface = ast_smdi_interface_find(conf->smdi_port);
 			if (!(tmp->smdi_iface)) {
-				ast_log(LOG_ERROR, "Invalid SMDI port specfied, disabling SMDI support\n");
+				ast_log(LOG_ERROR, "Invalid SMDI port specified, disabling SMDI support\n");
 				tmp->use_smdi = 0;
 			}
 		}
@@ -13831,7 +13831,7 @@ static struct dahdi_pvt *determine_starting_point(const char *data, struct dahdi
 		AST_APP_ARG(group);	/* channel/group token */
 		//AST_APP_ARG(ext);	/* extension token */
 		//AST_APP_ARG(opts);	/* options token */
-		AST_APP_ARG(other);	/* Any remining unused arguments */
+		AST_APP_ARG(other);	/* Any remaining unused arguments */
 	);
 
 	/*
@@ -15171,7 +15171,7 @@ static char *handle_pri_destroy_span(struct ast_cli_entry *e, int cmd,
 		e->command = "pri destroy span";
 		e->usage =
 			"Usage: pri destroy span <span>\n"
-			"       Destorys D-channel of span and its B-channels.\n"
+			"       Destroys D-channel of span and its B-channels.\n"
 			"	DON'T USE THIS UNLESS YOU KNOW WHAT YOU ARE DOING.\n";
 		return NULL;
 	case CLI_GENERATE:
@@ -15750,7 +15750,7 @@ static char *handle_mfcr2_destroy_link(struct ast_cli_entry *e, int cmd, struct 
 		e->command = "mfcr2 destroy link";
 		e->usage =
 			"Usage: mfcr2 destroy link <index-number>\n"
-			"       Destorys D-channel of link and its B-channels.\n"
+			"       Destroys D-channel of link and its B-channels.\n"
 			"	DON'T USE THIS UNLESS YOU KNOW WHAT YOU ARE DOING.\n";
 		return NULL;
 	case CLI_GENERATE:
@@ -18510,7 +18510,7 @@ static int dahdi_datetime_send_option(const char *value)
 
 /*! process_dahdi() - ignore keyword 'channel' and similar */
 #define PROC_DAHDI_OPT_NOCHAN  (1 << 0)
-/*! process_dahdi() - No warnings on non-existing cofiguration keywords */
+/*! process_dahdi() - No warnings on non-existing configuration keywords */
 #define PROC_DAHDI_OPT_NOWARN  (1 << 1)
 
 static void parse_busy_pattern(struct ast_variable *v, struct ast_dsp_busy_pattern *busy_cadence)
@@ -20137,7 +20137,7 @@ static int setup_dahdi_int(int reload, struct dahdi_chan_conf *default_conf, str
 						while (c && (i < SIG_PRI_NUM_DCHANS)) {
 							dchannels[i] = atoi(c + 1);
 							if (dchannels[i] < 0) {
-								ast_log(LOG_WARNING, "D-channel for trunk group %d must be a postiive number at line %d of chan_dahdi.conf\n", trunkgroup, v->lineno);
+								ast_log(LOG_WARNING, "D-channel for trunk group %d must be a positive number at line %d of chan_dahdi.conf\n", trunkgroup, v->lineno);
 							} else
 								i++;
 							c = strchr(c + 1, ',');
@@ -20169,13 +20169,13 @@ static int setup_dahdi_int(int reload, struct dahdi_chan_conf *default_conf, str
 							} else
 									ast_verb(2, "Mapped span %d to trunk group %d (logical span %d)\n", spanno, trunkgroup, logicalspan);
 							} else
-								ast_log(LOG_WARNING, "Logical span must be a postive number, or '0' (for unspecified) at line %d of chan_dahdi.conf\n", v->lineno);
+								ast_log(LOG_WARNING, "Logical span must be a positive number, or '0' (for unspecified) at line %d of chan_dahdi.conf\n", v->lineno);
 						} else
-							ast_log(LOG_WARNING, "Trunk group must be a postive number at line %d of chan_dahdi.conf\n", v->lineno);
+							ast_log(LOG_WARNING, "Trunk group must be a positive number at line %d of chan_dahdi.conf\n", v->lineno);
 					} else
 						ast_log(LOG_WARNING, "Missing trunk group for span map at line %d of chan_dahdi.conf\n", v->lineno);
 				} else
-					ast_log(LOG_WARNING, "Span number must be a postive integer at line %d of chan_dahdi.conf\n", v->lineno);
+					ast_log(LOG_WARNING, "Span number must be a positive integer at line %d of chan_dahdi.conf\n", v->lineno);
 			} else {
 				ast_log(LOG_NOTICE, "Ignoring unknown keyword '%s' in trunkgroups\n", v->name);
 			}

--- a/channels/chan_iax2.c
+++ b/channels/chan_iax2.c
@@ -1013,7 +1013,7 @@ static time_t max_calltoken_delay = 10;
  * However, to maintain old behavior for Asterisk 1.4, these are set to
  * 1 by default.  When using multiple buckets, search order through these
  * containers is considered random, so you will not be able to depend on
- * the order the entires are specified in iax.conf for matching order. */
+ * the order the entries are specified in iax.conf for matching order. */
 #ifdef LOW_MEMORY
 #define MAX_PEER_BUCKETS 17
 #else
@@ -1235,7 +1235,7 @@ static ast_mutex_t iaxsl[ARRAY_LEN(iaxs)];
 /*!
  * \brief Another container of iax2_pvt structures
  *
- * Active IAX2 pvt structs used during transfering a call are stored here.
+ * Active IAX2 pvt structs used during transferring a call are stored here.
  */
 static struct ao2_container *iax_transfercallno_pvts;
 
@@ -2072,7 +2072,7 @@ static int user_cmp_cb(void *obj, void *arg, int flags)
 }
 
 /*!
- * \note This funtion calls realtime_peer -> reg_source_db -> iax2_poke_peer -> find_callno,
+ * \note This function calls realtime_peer -> reg_source_db -> iax2_poke_peer -> find_callno,
  *       so do not call it with a pvt lock held.
  */
 static struct iax2_peer *find_peer(const char *name, int realtime)
@@ -3195,7 +3195,7 @@ static int __find_callno(unsigned short callno, unsigned short dcallno, struct a
 			};
 
 			ast_sockaddr_copy(&tmp_pvt.addr, addr);
-			/* this works for finding normal call numbers not involving transfering */
+			/* this works for finding normal call numbers not involving transferring */
 			if ((pvt = ao2_find(iax_peercallno_pvts, &tmp_pvt, OBJ_POINTER))) {
 				if (return_locked) {
 					ast_mutex_lock(&iaxsl[pvt->callno]);
@@ -6297,7 +6297,7 @@ static unsigned int calc_timestamp(struct chan_iax2_pvt *p, unsigned int ts, str
 			if ( (unsigned int)ms < p->lastsent )
 				ms = p->lastsent;
 		} else {
-			/* On a dataframe, use last value + 3 (to accomodate jitter buffer shrinking) if appropriate unless
+			/* On a dataframe, use last value + 3 (to accommodate jitter buffer shrinking) if appropriate unless
 			   it's a genuine frame */
 			adjust = (ms - p->lastsent);
 			if (genuine) {
@@ -8857,7 +8857,7 @@ static int complete_transfer(int callno, struct iax_ies *ies)
 		remove_by_peercallno(pvt);
 	}
 	pvt->peercallno = peercallno;
-	/*this is where the transfering call switches hash tables */
+	/*this is where the transferring call switches hash tables */
 	store_by_peercallno(pvt);
 	pvt->transferring = TRANSFER_NONE;
 	pvt->svoiceformat = -1;
@@ -10409,7 +10409,7 @@ static int socket_process_helper(struct iax2_thread *thread)
 			if (ies.calltoken && ies.calltokendata) {
 				/* if we've gotten this far, and the calltoken ie data exists,
 				 * then calltoken validation _MUST_ have taken place.  If calltoken
-				 * data is provided, it is always validated reguardless of any
+				 * data is provided, it is always validated regardless of any
 				 * calltokenoptional or requirecalltoken options */
 				new = NEW_ALLOW_CALLTOKEN_VALIDATED;
 			} else {

--- a/channels/chan_motif.c
+++ b/channels/chan_motif.c
@@ -193,7 +193,7 @@
 					<since>
 						<version>11.0.0</version>
 					</since>
-					<synopsis>Accout code for CDR purposes</synopsis>
+					<synopsis>Account code for CDR purposes</synopsis>
 				</configOption>
 				<configOption name="allow">
 					<since>
@@ -706,7 +706,7 @@ static void jingle_set_owner(struct jingle_session *session, struct ast_channel 
 	}
 }
 
-/*! \brief Internal helper function which enables video support on a sesson if possible */
+/*! \brief Internal helper function which enables video support on a session if possible */
 static void jingle_enable_video(struct jingle_session *session)
 {
 	struct ast_sockaddr tmp;
@@ -1222,7 +1222,7 @@ static struct ast_channel *jingle_session_lock_full(struct jingle_session *pvt)
 		}
 
 		/* If the owner changed while everything was unlocked, no problem,
-		 * just start over and everthing will work.  This is rare, do not be
+		 * just start over and everything will work.  This is rare, do not be
 		 * confused by this loop and think this it is an expensive operation.
 		 * The majority of the calls to this function will never involve multiple
 		 * executions of this loop. */
@@ -1550,7 +1550,7 @@ static void jingle_send_session_action(struct jingle_session *session, const cha
 	iks_delete(iq);
 }
 
-/*! \brief Internal function which sends a session-inititate message */
+/*! \brief Internal function which sends a session-initiate message */
 static void jingle_send_session_initiate(struct jingle_session *session)
 {
 	jingle_send_session_action(session, session->transport == JINGLE_TRANSPORT_GOOGLE_V1 ? "initiate" : "session-initiate");
@@ -2773,7 +2773,7 @@ static int load_module(void)
 	}
 
 	if (aco_info_init(&cfg_info)) {
-		ast_log(LOG_ERROR, "Unable to intialize configuration for chan_motif.\n");
+		ast_log(LOG_ERROR, "Unable to initialize configuration for chan_motif.\n");
 		goto end;
 	}
 

--- a/channels/chan_unistim.c
+++ b/channels/chan_unistim.c
@@ -434,7 +434,7 @@ static struct unistim_device {
 	int callhistory;			/*!< Allowed to record call history */
         int sharp_dial;				/*!< Execute Dial on '#' or not */
 	char lst_cid[TEXT_LENGTH_MAX];  /*!< Last callerID received */
-	char lst_cnm[TEXT_LENGTH_MAX];  /*!< Last callername recevied */
+	char lst_cnm[TEXT_LENGTH_MAX];  /*!< Last callername received */
 	char call_forward[AST_MAX_EXTENSION];   /*!< Forward number */
 	int output;				     /*!< Handset, headphone or speaker */
 	int previous_output;	    /*!< Previous output */
@@ -459,7 +459,7 @@ static struct unistimsession {
 	ast_mutex_t lock;
 	struct sockaddr_in sin;	 /*!< IP address of the phone */
 	struct sockaddr_in sout;	/*!< IP address of server */
-	int timeout;			    /*!< time-out in ticks : resend packet if no ack was received before the timeout occured */
+	int timeout;			    /*!< time-out in ticks : resend packet if no ack was received before the timeout occurred */
 	unsigned short seq_phone;       /*!< sequence number for the next packet (when we receive a request) */
 	unsigned short seq_server;      /*!< sequence number for the next packet (when we send a request) */
 	unsigned short last_seq_ack;    /*!< sequence number of the last ACK received */
@@ -467,12 +467,12 @@ static struct unistimsession {
 	int last_buf_available;	 /*!< number of a free slot */
 	int nb_retransmit;		      /*!< number of retransmission */
 	int state;				      /*!< state of the phone (see phone_state) */
-	int size_buff_entry;	    /*!< size of the buffer used to enter datas */
-	char buff_entry[16];	    /*!< Buffer for temporary datas */
+	int size_buff_entry;	    /*!< size of the buffer used to enter data */
+	char buff_entry[16];	    /*!< Buffer for temporary data */
 	char macaddr[18];		       /*!< mac address of the phone (not always available) */
 	char firmware[8];		       /*!< firmware of the phone (not always available) */
 	struct wsabuf wsabufsend[MAX_BUF_NUMBER];      /*!< Size of each paquet stored in the buffer array & pointer to this buffer */
-	unsigned char buf[MAX_BUF_NUMBER][MAX_BUF_SIZE];	/*!< Buffer array used to keep the lastest non-acked paquets */
+	unsigned char buf[MAX_BUF_NUMBER][MAX_BUF_SIZE];	/*!< Buffer array used to keep the latest non-acked paquets */
 	struct unistim_device *device;
 	struct unistimsession *next;
 } *sessions = NULL;
@@ -947,12 +947,12 @@ static void send_raw_client(int size, const unsigned char *data, struct sockaddr
 #endif
 
 	if (sendmsg(unistimsock, &msg, 0) == -1) {
-		display_last_error("Error sending datas");
+		display_last_error("Error sending data");
 	}
 #else
 	if (sendto(unistimsock, data, size, 0, (struct sockaddr *) addr_to, sizeof(*addr_to))
 		== -1)
-		display_last_error("Error sending datas");
+		display_last_error("Error sending data");
 #endif
 }
 
@@ -979,7 +979,7 @@ static void send_client(int size, const unsigned char *data, struct unistimsessi
 
 /*#ifdef DUMP_PACKET */
 	if (unistimdebug) {
-		ast_verb(0, "Sending datas with seq #0x%04x Using slot #%d :\n", (unsigned)pte->seq_server, buf_pos);
+		ast_verb(0, "Sending data with seq #0x%04x Using slot #%d :\n", (unsigned)pte->seq_server, buf_pos);
 	}
 /*#endif */
 	send_raw_client(pte->wsabufsend[buf_pos].len, pte->wsabufsend[buf_pos].buf, &(pte->sin),
@@ -2176,12 +2176,12 @@ static void rcv_mac_addr(struct unistimsession *pte, const unsigned char *buf)
 		struct unistim_line *line;
 		struct unistim_subchannel *sub;
 
-		ast_verb(3, "Device '%s' successfuly registered\n", pte->device->name);
+		ast_verb(3, "Device '%s' successfully registered\n", pte->device->name);
 
 		AST_LIST_LOCK(&pte->device->subs);
 		AST_LIST_TRAVERSE_SAFE_BEGIN(&pte->device->subs, sub, list) {
 			if (sub) {
-				ast_log(LOG_ERROR, "Subchannel lost sice reboot. Hanged channel may apear!\n");
+				ast_log(LOG_ERROR, "Subchannel lost sice reboot. Hanged channel may appear!\n");
 				AST_LIST_REMOVE_CURRENT(list);
 				ast_free(sub);
 			}
@@ -4225,7 +4225,7 @@ static void key_main_page(struct unistimsession *pte, char keycode)
 					sizeof(pte->device->call_forward) - 1);
 			pte->device->call_forward[0] = '\0';
 			send_icon(TEXT_LINE0, FAV_ICON_NONE, pte);
-			pte->device->output = OUTPUT_HANDSET;   /* Seems to be reseted somewhere */
+			pte->device->output = OUTPUT_HANDSET;   /* Seems to be reset somewhere */
 			show_main_page(pte);
 			break;
 		}
@@ -4889,7 +4889,7 @@ static int unistim_call(struct ast_channel *ast, const char *dest, int timeout)
 	}
 	session->state = STATE_RINGING;
 	send_callerid_screen(session, sub);
-	if (ast_strlen_zero(ast_channel_call_forward(ast))) { /* Send ring only if no call forward, otherwise short ring will apear */
+	if (ast_strlen_zero(ast_channel_call_forward(ast))) { /* Send ring only if no call forward, otherwise short ring will appear */
 		send_text(TEXT_LINE2, TEXT_NORMAL, session, ustmtext("is calling you.", session));
 		send_text_status(session, ustmtext("Accept        Ignore Hangup", session));
 
@@ -5567,7 +5567,7 @@ static int unistim_sendtext(struct ast_channel *ast, const char *text)
 			case 0:
 				if ((cur < '0') && (cur > '5')) {
 					ast_log(LOG_WARNING,
-							"sendtext failed : position must be a number beetween 0 and 5\n");
+							"sendtext failed : position must be a number between 0 and 5\n");
 					return 1;
 				}
 				pos = cur - '0';
@@ -5583,7 +5583,7 @@ static int unistim_sendtext(struct ast_channel *ast, const char *text)
 			case 2:
 				if ((cur < '3') && (cur > '6')) {
 					ast_log(LOG_WARNING,
-							"sendtext failed : icon must be a number beetween 32 and 63 (first digit invalid)\n");
+							"sendtext failed : icon must be a number between 32 and 63 (first digit invalid)\n");
 					return 1;
 				}
 				icon = (cur - '0') * 10;
@@ -5592,7 +5592,7 @@ static int unistim_sendtext(struct ast_channel *ast, const char *text)
 			case 3:
 				if ((cur < '0') && (cur > '9')) {
 					ast_log(LOG_WARNING,
-							"sendtext failed : icon must be a number beetween 32 and 63 (second digit invalid)\n");
+							"sendtext failed : icon must be a number between 32 and 63 (second digit invalid)\n");
 					return 1;
 				}
 				icon += (cur - '0');
@@ -5601,7 +5601,7 @@ static int unistim_sendtext(struct ast_channel *ast, const char *text)
 			case 4:
 				if (cur != '@') {
 					ast_log(LOG_WARNING,
-							"sendtext failed : icon must be a number beetween 32 and 63 (too many digits)\n");
+							"sendtext failed : icon must be a number between 32 and 63 (too many digits)\n");
 					return 1;
 				}
 				tok = 5;
@@ -6513,7 +6513,7 @@ static struct unistim_device *build_device(const char *cat, const struct ast_var
 	d = devices;
 	while (d) {
 		if (!strcmp(d->name, cat)) {
-			/* Yep, we alreay have this one */
+			/* Yep, we already have this one */
 			if (unistimsock < 0) {
 				/* It's a dupe */
 				ast_log(LOG_WARNING, "Duplicate entry found (%s), ignoring.\n", cat);
@@ -6614,7 +6614,7 @@ static struct unistim_device *build_device(const char *cat, const struct ast_var
 		} else if (!strcasecmp(v->name, "contrast")) {
 			d->contrast = atoi(v->value);
 			if ((d->contrast < 0) || (d->contrast > 15)) {
-				ast_log(LOG_WARNING, "contrast must be beetween 0 and 15\n");
+				ast_log(LOG_WARNING, "contrast must be between 0 and 15\n");
 				d->contrast = 8;
 			}
 		} else if (!strcasecmp(v->name, "nat")) {

--- a/channels/console_gui.c
+++ b/channels/console_gui.c
@@ -563,7 +563,7 @@ static int switch_video_out(struct video_desc *env, int index, Uint8 button)
  * \param env = pointer to the video environment descriptor
  *
  * returns:
- * - 0 on falure switching from off to on
+ * - 0 on failure switching from off to on
  * - 1 on success in switching from off to on
  * - 2 on success in switching from on to off
 */
@@ -593,7 +593,7 @@ static int turn_on_off(int index, struct video_desc *env)
 			p->status_index |= IS_ON;
 			/* print the new message in the message board */
 			update_device_info(env, index);
-			return 1; /* open succeded */
+			return 1; /* open succeeded */
 		}
 		return 0; /* failure */
 	} else {
@@ -1226,7 +1226,7 @@ static void sdl_setup(struct video_desc *env)
 
 	/* Some helper variables used for filling the SDL window */
 	int x0; /* the x coordinate of the center of the keypad */
-	int x1; /* userful for calculating of the size of the parent window */
+	int x1; /* useful for calculating of the size of the parent window */
 	int y0; /* y coordinate of the keypad, the remote window and the local window */
 	int src_wins_tot_w; /* total width of the source windows */
 	int i;
@@ -1414,7 +1414,7 @@ static void sdl_setup(struct video_desc *env)
 
 	SDL_WM_SetCaption("Asterisk console Video Output", NULL);
 
-	/* intialize the windows for local and remote video */
+	/* initialize the windows for local and remote video */
 	if (set_win(gui->screen, &gui->win[WIN_REMOTE], dpy_fmt,
 			env->rem_dpy.w, env->rem_dpy.h, x0-kp_w/2-BORDER-env->rem_dpy.w, y0))
 		goto no_sdl;

--- a/channels/console_video.c
+++ b/channels/console_video.c
@@ -240,7 +240,7 @@ struct video_out_desc {
  * The overall descriptor, with room for config info, video source and
  * received data descriptors, SDL info, etc.
  * This should be globally visible to all modules (grabber, vcodecs, gui)
- * and contain all configurtion info.
+ * and contain all configuration info.
  */
 struct video_desc {
 	char codec_name[64];        /* the codec we use */
@@ -319,7 +319,7 @@ used_mem(const char *msg)
 
 /*! \brief Try to open video sources, return 0 on success, 1 on error
  * opens all video sources found in the oss.conf configuration files.
- * Saves the grabber and the datas in the device table (in the devices field
+ * Saves the grabber and the data in the device table (in the devices field
  * of the descriptor referenced by v).
  * Initializes the device_primary and device_secondary
  * fields of v with the first devices that was
@@ -342,7 +342,7 @@ static int grabber_open(struct video_out_desc *v)
 			continue;
 		/* for each type of grabber supported... */
 		for (j = 0; (g = console_grabbers[j]); j++) {
-			/* the grabber is opened and the informations saved in the device table */
+			/* the grabber is opened and the information saved in the device table */
 			g_data = g->open(v->devices[i].name, &v->loc_src_geometry, v->fps);
 			if (!g_data)
 				continue;
@@ -370,7 +370,7 @@ static int grabber_open(struct video_out_desc *v)
  * \param fps = frame per seconds, for every device
  *
  * returns:
- * - NULL on falure
+ * - NULL on failure
  * - reference to the device buffer on success
  */
 static struct fbuf_t *grabber_read(struct video_device *dev, int fps)
@@ -779,13 +779,13 @@ int console_write_video(struct ast_channel *chan, struct ast_frame *f)
  * grabber_read on each device in the device table.
  * it encodes the primary source buffer, if the picture in picture mode is
  * enabled it encodes (in the buffer to split) the secondary source buffer too.
- * The encoded buffer is splitted to build the local and the remote view.
+ * The encoded buffer is split to build the local and the remote view.
  * Return a list of ast_frame representing the video fragments.
  * The head pointer is returned by the function, the tail pointer
  * is returned as an argument.
  *
  * \param env = video environment descriptor
- * \param tail = tail ponter (practically a return value)
+ * \param tail = tail pointer (practically a return value)
  */
 static struct ast_frame *get_video_frames(struct video_desc *env, struct ast_frame **tail)
 {
@@ -902,7 +902,7 @@ static void *video_thread(void *arg)
 	 */
 	video_out_init(env);
 
-	/* Writes intial status of the sources. */
+	/* Writes initial status of the sources. */
 	if (env->gui) {
 		for (i = 0; i < env->out.device_num; i++) {
 			print_message(env->gui->thumb_bd_array[i].board,

--- a/channels/iax2/include/astobj.h
+++ b/channels/iax2/include/astobj.h
@@ -213,7 +213,7 @@ extern "C" {
  * \param object A pointer the object to operate on.
  * \param destructor The destructor to call if the object is no longer referenced.  It will be passed the pointer as an argument.
  *
- * This macro unreferences an object and calls the specfied destructor if the
+ * This macro unreferences an object and calls the specified destructor if the
  * object is no longer referenced.  The destructor should free the object if it
  * was dynamically allocated.
  */
@@ -358,7 +358,7 @@ extern "C" {
  * \param eval A statement to evaluate in the iteration loop.
  *
  * This is macro is a little complicated, but it may help to think of it as a
- * loop.  Basically it iterates through the specfied containter as long as the
+ * loop.  Basically it iterates through the specified container as long as the
  * condition is met.  Two variables, iterator and next, are provided for use in
  * your \p eval statement.  See the sample code for an example.
  *
@@ -393,7 +393,7 @@ extern "C" {
  * \param container A pointer to the container to search.
  * \param namestr The name to search for.
  *
- * Use this function to find an object with the specfied name in a container.
+ * Use this function to find an object with the specified name in a container.
  *
  * \note When the returned object is no longer in use, #ASTOBJ_UNREF() should
  * be used to free the additional reference created by this macro.
@@ -468,7 +468,7 @@ extern "C" {
  * \param container A pointer to the container to operate on.
  * \param obj A pointer to the object to remove.
  *
- * This macro iterates through a container and removes the specfied object if
+ * This macro iterates through a container and removes the specified object if
  * it exists in the container.
  *
  * \note This macro does not destroy any objects, it simply unlinks
@@ -503,7 +503,7 @@ extern "C" {
  * \param namestr The name of the object to remove.
  *
  * This macro iterates through a container and removes the first object with
- * the specfied name from the container.
+ * the specified name from the container.
  *
  * \note This macro does not destroy any objects, it simply unlinks
  * them.  No destructors are called.
@@ -647,8 +647,8 @@ extern "C" {
  * \param container A pointer to the container to prune.
  * \param destructor A destructor function to call on each marked object.
  *
- * This macro iterates through the specfied container and prunes any marked
- * objects executing the specfied destructor if necessary.
+ * This macro iterates through the specified container and prunes any marked
+ * objects executing the specified destructor if necessary.
  */
 #define ASTOBJ_CONTAINER_PRUNE_MARKED(container,destructor) \
 	do { \
@@ -756,7 +756,7 @@ extern "C" {
 
 /*! \brief Destroy a container.
  *
- * \param container A pointer to the container to destory.
+ * \param container A pointer to the container to destroy.
  *
  * This macro frees up resources used by a container.  It does not operate on
  * the objects in the container.  To unlink the objects from the container use
@@ -797,7 +797,7 @@ extern "C" {
  * \param obj A pointer to the object to dump.
  *
  * This macro dumps a text representation of the name, objectflags, and
- * refcount fields of an object to the specfied string buffer.
+ * refcount fields of an object to the specified string buffer.
  */
 #define ASTOBJ_DUMP(s,slen,obj) \
 	snprintf((s),(slen),"name: %s\nobjflags: %u\nrefcount: %u\n\n", (obj)->name, (obj)->objflags, (obj)->refcount);

--- a/channels/iax2/include/firmware.h
+++ b/channels/iax2/include/firmware.h
@@ -86,7 +86,7 @@ int iax_firmware_append(struct iax_ie_data *ie_data,
  *                  \c callback function each time it is invoked.
  *
  * This function visits each of the elements in the IAX firmware list, calling
- * the specfied \c callback for each element. Iteration continues until the end
+ * the specified \c callback for each element. Iteration continues until the end
  * of the list is reached, or the \c callback returns non-zero.
  *
  * The \c callback function receives a pointer to the firmware header and the

--- a/channels/iax2/include/parser.h
+++ b/channels/iax2/include/parser.h
@@ -128,7 +128,7 @@ struct iax_frame {
 	int iseqno;
 	/*! Retransmission ID */
 	int retrans;
-	/*! is this packet encrypted or not. if set this varible holds encryption methods*/
+	/*! is this packet encrypted or not. if set this variable holds encryption methods*/
 	int encmethods;
 	/*! store encrypt key */
 	ast_aes_encrypt_key ecx;

--- a/channels/iax2/include/provision.h
+++ b/channels/iax2/include/provision.h
@@ -18,7 +18,7 @@
 
 #include "parser.h"
 
-#define PROV_IE_USEDHCP 	1	/* Presense only */
+#define PROV_IE_USEDHCP 	1	/* Presence only */
 #define PROV_IE_IPADDR		2	/* 32-bit */
 #define PROV_IE_SUBNET		3	/* 32-bit */
 #define PROV_IE_GATEWAY		4	/* 32-bit */

--- a/channels/pjsip/dialplan_functions_doc.xml
+++ b/channels/pjsip/dialplan_functions_doc.xml
@@ -71,7 +71,7 @@
 		</synopsis>
 		<syntax>
 			<parameter name="to" required="false">
-				<para>Abritrary URI to which to send the NOTIFY.  If none is specified, send inside
+				<para>Arbitrary URI to which to send the NOTIFY.  If none is specified, send inside
 				the SIP dialog for the current channel.</para>
 			</parameter>
 			<parameter name="content" required="true">

--- a/channels/sig_analog.c
+++ b/channels/sig_analog.c
@@ -1341,7 +1341,7 @@ int analog_hangup(struct analog_pvt *p, struct ast_channel *ast)
 				/* Need to hold the lock for real-call, private, and call-waiting call */
 				analog_lock_sub_owner(p, ANALOG_SUB_CALLWAIT);
 				if (!p->subs[ANALOG_SUB_CALLWAIT].owner) {
-					/* The call waiting call dissappeared. */
+					/* The call waiting call disappeared. */
 					analog_set_new_owner(p, NULL);
 					break;
 				}
@@ -3327,7 +3327,7 @@ static struct ast_frame *__analog_handle_event(struct analog_pvt *p, struct ast_
 				analog_lock_sub_owner(p, ANALOG_SUB_CALLWAIT);
 				if (!p->subs[ANALOG_SUB_CALLWAIT].owner) {
 					/*
-					 * The call waiting call dissappeared.
+					 * The call waiting call disappeared.
 					 * Let's just ignore this flash-hook.
 					 */
 					ast_log(LOG_NOTICE, "Whoa, the call-waiting call disappeared.\n");
@@ -3454,7 +3454,7 @@ static struct ast_frame *__analog_handle_event(struct analog_pvt *p, struct ast_
 				analog_lock_sub_owner(p, ANALOG_SUB_THREEWAY);
 				if (!p->subs[ANALOG_SUB_THREEWAY].owner) {
 					/*
-					 * The 3-way call dissappeared.
+					 * The 3-way call disappeared.
 					 * Let's just ignore this flash-hook.
 					 */
 					ast_log(LOG_NOTICE, "Whoa, the 3-way call disappeared.\n");
@@ -3688,7 +3688,7 @@ winkflashdone:
 		}
 
 		/* Added more log_debug information below to provide a better indication of what is going on */
-		ast_debug(1, "Polarity Reversal event occured - DEBUG 2: channel %d, state %u, pol= %d, aonp= %d, honp= %d, pdelay= %d, tv= %" PRIi64 "\n", p->channel, ast_channel_state(ast), p->polarity, p->answeronpolarityswitch, p->hanguponpolarityswitch, p->polarityonanswerdelay, ast_tvdiff_ms(ast_tvnow(), p->polaritydelaytv) );
+		ast_debug(1, "Polarity Reversal event occurred - DEBUG 2: channel %d, state %u, pol= %d, aonp= %d, honp= %d, pdelay= %d, tv= %" PRIi64 "\n", p->channel, ast_channel_state(ast), p->polarity, p->answeronpolarityswitch, p->hanguponpolarityswitch, p->polarityonanswerdelay, ast_tvdiff_ms(ast_tvnow(), p->polaritydelaytv) );
 		break;
 	default:
 		ast_debug(1, "Dunno what to do with event %d on channel %d\n", res, p->channel);

--- a/channels/sig_pri.c
+++ b/channels/sig_pri.c
@@ -6773,7 +6773,7 @@ static void *pri_dchannel(void *vpri)
 					sig_pri_open_media(pri->pvts[chanpos]);
 				} else if (pri->inband_on_proceeding) {
 					/*
-					 * XXX This is to accomodate a broken switch that sends a
+					 * XXX This is to accommodate a broken switch that sends a
 					 * PROCEEDING without any progress indication ie for
 					 * inband audio.  This should be part of the conditional
 					 * test above to bring the voice path up.
@@ -7703,7 +7703,7 @@ void sig_pri_extract_called_num_subaddr(struct sig_pri_chan *p, const char *rdes
 		AST_APP_ARG(group);	/* channel/group token */
 		AST_APP_ARG(ext);	/* extension token */
 		//AST_APP_ARG(opts);	/* options token */
-		AST_APP_ARG(other);	/* Any remining unused arguments */
+		AST_APP_ARG(other);	/* Any remaining unused arguments */
 	);
 
 	/* Get private copy of dial string and break it up. */
@@ -7802,7 +7802,7 @@ int sig_pri_call(struct sig_pri_chan *p, struct ast_channel *ast, const char *rd
 		AST_APP_ARG(group);	/* channel/group token */
 		AST_APP_ARG(ext);	/* extension token */
 		AST_APP_ARG(opts);	/* options token */
-		AST_APP_ARG(other);	/* Any remining unused arguments */
+		AST_APP_ARG(other);	/* Any remaining unused arguments */
 	);
 	struct ast_flags opts;
 	char *opt_args[OPT_ARG_ARRAY_SIZE];
@@ -9510,7 +9510,7 @@ int sig_pri_cc_agent_stop_offer_timer(struct ast_cc_agent *agent)
  * if there is some error when attempting to process
  * the incoming CC request.
  *
- * The duty of this is to issue a propper response to a
+ * The duty of this is to issue a proper response to a
  * CC request from the caller by acknowledging receipt
  * of that request or rejecting it.
  */

--- a/channels/sig_pri.h
+++ b/channels/sig_pri.h
@@ -360,7 +360,7 @@ struct sig_pri_chan {
 	/*! \brief Channel reset/restart state. */
 	enum sig_pri_reset_state resetting;
 #if defined(HAVE_PRI_TRANSFER)
-	/*! If non-NULL, send transfer disconnect successfull response to first call disconnecting. */
+	/*! If non-NULL, send transfer disconnect successful response to first call disconnecting. */
 	struct xfer_rsp_data *xfer_data;
 #endif	/* defined(HAVE_PRI_TRANSFER) */
 	int prioffset;					/*!< channel number in span */

--- a/channels/sig_ss7.h
+++ b/channels/sig_ss7.h
@@ -309,8 +309,8 @@ struct sig_ss7_chan {
 	/*!
 	 * \brief Indication of the call being a CUG call and its permissions.
 	 * \note 0 or 1 - non-CUG call
-	 * \note 2 - CUG call, outgoing access alowed
-	 * \note 3 - CUG call, outgoing access not alowed
+	 * \note 2 - CUG call, outgoing access allowed
+	 * \note 3 - CUG call, outgoing access not allowed
 	 */
 	unsigned char cug_indicator;
 };

--- a/channels/vcodecs.c
+++ b/channels/vcodecs.c
@@ -41,11 +41,11 @@ typedef int (*encoder_init_f)(AVCodecContext *v);
 /*! \brief actually call the encoder */
 typedef int (*encoder_encode_f)(struct video_out_desc *v);
 
-/*! \brief encapsulate the bistream in RTP frames */
+/*! \brief encapsulate the bitstream in RTP frames */
 typedef struct ast_frame *(*encoder_encap_f)(struct fbuf_t *, int mtu,
 		struct ast_frame **tail);
 
-/*! \brief inizialize the decoder */
+/*! \brief initialize the decoder */
 typedef int (*decoder_init_f)(AVCodecContext *enc_ctx);
 
 /*! \brief extract the bitstream from RTP frames and store in the fbuf.
@@ -547,7 +547,7 @@ static int h263_enc_init(AVCodecContext *enc_ctx)
  * FP = 0- mode A, (only one word of header)
  * FP = 10 mode B, and also means this is an I or P frame
  * FP = 11 mode C, and also means this is a PB frame.
- * SBIT, EBIT nuber of bits to ignore at beginning (msbits) and end (lsbits)
+ * SBIT, EBIT number of bits to ignore at beginning (msbits) and end (lsbits)
  * SRC  bits 6,7,8 from the h263 PTYPE field
  * I = 0 intra-coded, 1 = inter-coded (bit 9 from PTYPE)
  * U = 1 for Unrestricted Motion Vector (bit 10 from PTYPE)


### PR DESCRIPTION
Found via `codespell -q 3 -S "./CREDITS,*.po" -L abd,asent,atleast,cachable,childrens,contentn,crypted,dne,durationm,enew,exten,inout,leapyear,mye,nd,oclock,offsetp,ot,parm,parms,preceeding,pris,ptd,requestor,re-use,re-used,re-uses,ser,siz,slanguage,slin,thirdparty,varn,varns,ues`