### PR TITLE
res_stir_shaken: Allow missing or anonymous CID to continue to the dialplan.

### DIFF
--- a/include/asterisk/res_stir_shaken.h
+++ b/include/asterisk/res_stir_shaken.h
@@ -55,6 +55,7 @@ enum ast_stir_shaken_vs_response_code {
 	AST_STIR_SHAKEN_VS_NO_DEST_TN,
 	AST_STIR_SHAKEN_VS_INVALID_HEADER,
 	AST_STIR_SHAKEN_VS_INVALID_GRANT,
+	AST_STIR_SHAKEN_VS_INVALID_OR_NO_CID,
 	AST_STIR_SHAKEN_VS_RESPONSE_CODE_MAX
 };
 
@@ -231,6 +232,16 @@ enum stir_shaken_failure_action_enum
  * \retval 0 if false
  */
 int	ast_stir_shaken_vs_get_use_rfc9410_responses(
+		struct ast_stir_shaken_vs_ctx *ctx);
+
+/*!
+ * \brief Get caller_id from context
+ *
+ * \param ctx VS context
+ *
+ * \retval Caller ID or NULL
+ */
+const char *ast_stir_shaken_vs_get_caller_id(
 		struct ast_stir_shaken_vs_ctx *ctx);
 
 /*!

--- a/res/res_stir_shaken/verification.c
+++ b/res/res_stir_shaken/verification.c
@@ -84,6 +84,7 @@ static const char *vs_rc_map[] = {
 	[AST_STIR_SHAKEN_VS_NO_DEST_TN] = "missing_dest_tn",
 	[AST_STIR_SHAKEN_VS_INVALID_HEADER] = "invalid_header",
 	[AST_STIR_SHAKEN_VS_INVALID_GRANT] = "invalid_grant",
+	[AST_STIR_SHAKEN_VS_INVALID_OR_NO_CID] = "invalid_or_no_callerid",
 };
 
 const char *vs_response_code_to_str(
@@ -629,6 +630,12 @@ int ast_stir_shaken_vs_get_use_rfc9410_responses(
 	return ctx->eprofile->vcfg_common.use_rfc9410_responses;
 }
 
+const char *ast_stir_shaken_vs_get_caller_id(
+		struct ast_stir_shaken_vs_ctx *ctx)
+{
+	return ctx->caller_id;
+}
+
 void ast_stir_shaken_vs_ctx_set_response_code(
 	struct ast_stir_shaken_vs_ctx *ctx,
 	enum ast_stir_shaken_vs_response_code vs_rc)
@@ -685,11 +692,6 @@ enum ast_stir_shaken_vs_response_code
 	if (ast_strlen_zero(tag)) {
 		SCOPE_EXIT_LOG_RTN_VALUE(AST_STIR_SHAKEN_VS_INVALID_ARGUMENTS,
 			LOG_ERROR, "%s: Must provide tag\n", t);
-	}
-
-	if (ast_strlen_zero(canon_caller_id)) {
-		SCOPE_EXIT_LOG_RTN_VALUE(AST_STIR_SHAKEN_VS_INVALID_ARGUMENTS,
-		LOG_ERROR, "%s: Must provide caller_id\n", t);
 	}
 
 	ctx = ao2_alloc_options(sizeof(*ctx), ctx_destructor,


### PR DESCRIPTION
The verification check for missing or anonymous callerid was happening before
the endpoint's profile was retrieved which meant that the failure_action
parameter wasn't available.  Therefore, if verification was enabled and there
was no callerid or it was "anonymous", the call was immediately terminated
instead of giving the dialplan the ability to decide what to do with the call.

* The callerid check now happens after the verification context is created and
  the endpoint's stir_shaken_profile is available.

* The check now processes the callerid failure just as it does for other
  verification failures and respects the failure_action parameter.  If set
  to "continue" or "continue_return_reason", `STIR_SHAKEN(0,verify_result)`
  in the dialplan will return "invalid_or_no_callerid".

* If the endpoint's failure_action is "reject_request", the call will be
  rejected with `433 "Anonymity Disallowed"`.

* If the endpoint's failure_action is "continue_return_reason", the call will
  continue but a `Reason: STIR; cause=433; text="Anonymity Disallowed"`
  header will be added to the next provisional or final response.

Resolves: #1112
