### PR TITLE
channel.c: Remove dead AST_GENERATOR_FD code.

### DIFF
--- a/include/asterisk/channel.h
+++ b/include/asterisk/channel.h
@@ -201,8 +201,8 @@ extern "C" {
  */
 #define AST_ALERT_FD	(AST_MAX_FDS-1)		/*!< used for alertpipe */
 #define AST_TIMING_FD	(AST_MAX_FDS-2)		/*!< used for timingfd */
-#define AST_AGENT_FD	(AST_MAX_FDS-3)		/*!< used by agents for pass through */
-#define AST_GENERATOR_FD	(AST_MAX_FDS-4)	/*!< used by generator */
+#define AST_AGENT_FD	(AST_MAX_FDS-3)		/*!< unused - formerly used by agents for pass through */
+#define AST_GENERATOR_FD	(AST_MAX_FDS-4)	/*!< unused - formerly used by generator */
 #define AST_JITTERBUFFER_FD	(AST_MAX_FDS-5)	/*!< used by generator */
 
 enum ast_bridge_result {

--- a/main/channel.c
+++ b/main/channel.c
@@ -2903,7 +2903,6 @@ static void deactivate_generator_nolock(struct ast_channel *chan)
 		}
 		ast_channel_generatordata_set(chan, NULL);
 		ast_channel_generator_set(chan, NULL);
-		ast_channel_set_fd(chan, AST_GENERATOR_FD, -1);
 		ast_clear_flag(ast_channel_flags(chan), AST_FLAG_WRITE_INT);
 		ast_settimeout(chan, 0, NULL, NULL);
 	}
@@ -3659,17 +3658,6 @@ static struct ast_frame *__ast_read(struct ast_channel *chan, int dropaudio, int
 			break;
 		}
 
-	} else if (ast_channel_fd_isset(chan, AST_GENERATOR_FD) && ast_channel_fdno(chan) == AST_GENERATOR_FD) {
-		/* if the AST_GENERATOR_FD is set, call the generator with args
-		 * set to -1 so it can do whatever it needs to.
-		 */
-		void *tmp = ast_channel_generatordata(chan);
-		ast_channel_generatordata_set(chan, NULL);     /* reset to let ast_write get through */
-		ast_channel_generator(chan)->generate(chan, tmp, -1, -1);
-		ast_channel_generatordata_set(chan, tmp);
-		f = &ast_null_frame;
-		ast_channel_fdno_set(chan, -1);
-		goto done;
 	} else if (ast_channel_fd_isset(chan, AST_JITTERBUFFER_FD) && ast_channel_fdno(chan) == AST_JITTERBUFFER_FD) {
 		ast_clear_flag(ast_channel_flags(chan), AST_FLAG_EXCEPTION);
 	}
@@ -6884,7 +6872,6 @@ static void channel_do_masquerade(struct ast_channel *original, struct ast_chann
 	int origstate;
 	unsigned int orig_disablestatecache;
 	unsigned int clone_disablestatecache;
-	int generator_fd;
 	int visible_indication;
 	int clone_hold_state;
 	int moh_is_playing;
@@ -7084,15 +7071,12 @@ static void channel_do_masquerade(struct ast_channel *original, struct ast_chann
 	/* Keep the same parkinglot. */
 	ast_channel_parkinglot_set(original, ast_channel_parkinglot(clonechan));
 
-	/* Clear all existing file descriptors but retain the generator */
-	generator_fd = ast_channel_fd(original, AST_GENERATOR_FD);
+	/* Clear all existing file descriptors */
 	ast_channel_internal_fd_clear_all(original);
-	ast_channel_set_fd(original, AST_GENERATOR_FD, generator_fd);
 
-	/* Copy all file descriptors present on clonechan to original, skipping generator */
+	/* Copy all file descriptors present on clonechan to original */
 	for (x = 0; x < ast_channel_fd_count(clonechan); x++) {
-		if (x != AST_GENERATOR_FD)
-			ast_channel_set_fd(original, x, ast_channel_fd(clonechan, x));
+		ast_channel_set_fd(original, x, ast_channel_fd(clonechan, x));
 	}
 
 	ast_app_group_update(clonechan, original);


### PR DESCRIPTION
Nothing ever sets the `AST_GENERATOR_FD`, so this block of code will never execute. It also is the only place where the `generate` callback is called with the channel lock held which made it difficult to reason about the thread safety of `ast_generator`s.

In passing, also note that `AST_AGENT_FD` isn't used either.