### PR TITLE
docs: AMI documentation fixes.

### DIFF
--- a/apps/app_agent_pool.c
+++ b/apps/app_agent_pool.c
@@ -218,11 +218,11 @@
 					<para>Present if Status value is <literal>AGENT_ONCALL</literal>.</para>
 				</parameter>
 				<parameter name="CallStarted">
-					<para>Epoche time when the agent started talking with the caller.</para>
+					<para>Epoch time when the agent started talking with the caller.</para>
 					<para>Present if Status value is <literal>AGENT_ONCALL</literal>.</para>
 				</parameter>
 				<parameter name="LoggedInTime">
-					<para>Epoche time when the agent logged in.</para>
+					<para>Epoch time when the agent logged in.</para>
 					<para>Present if Status value is <literal>AGENT_IDLE</literal> or <literal>AGENT_ONCALL</literal>.</para>
 				</parameter>
 				<channel_snapshot/>

--- a/main/stasis_bridges.c
+++ b/main/stasis_bridges.c
@@ -122,6 +122,7 @@
 					<note><para>This header is only present when <replaceable>DestType</replaceable> is <literal>Threeway</literal></para></note>
 				</parameter>
 				<channel_snapshot prefix="Transferee" />
+				<channel_snapshot prefix="TransferTarget" />
 			</syntax>
 			<description>
 				<para>The headers in this event attempt to describe all the major details of the attended transfer. The two transferer channels

--- a/main/stasis_channels.c
+++ b/main/stasis_channels.c
@@ -86,7 +86,10 @@
 			</since>
 			<synopsis>Raised when an Agent has logged off.</synopsis>
 			<syntax>
-				<xi:include xpointer="xpointer(/docs/managerEvent[@name='AgentLogin']/managerEventInstance/syntax/parameter)" />
+				<channel_snapshot/>
+				<parameter name="Agent">
+					<para>Agent ID of the agent.</para>
+				</parameter>
 				<parameter name="Logintime">
 					<para>The number of seconds the agent was logged in.</para>
 				</parameter>

--- a/res/res_pjsip/pjsip_configuration.c
+++ b/res/res_pjsip/pjsip_configuration.c
@@ -567,7 +567,7 @@ static int media_address_to_str(const void *obj, const intptr_t *args, char **bu
 	return 0;
 }
 
-static int redirect_handler(const struct aco_option *opt, struct ast_variable *var, void *obj)
+static int redirect_method_handler(const struct aco_option *opt, struct ast_variable *var, void *obj)
 {
 	struct ast_sip_endpoint *endpoint = obj;
 
@@ -583,6 +583,21 @@ static int redirect_handler(const struct aco_option *opt, struct ast_variable *v
 		return -1;
 	}
 
+	return 0;
+}
+
+static const char *redirect_method_map[] = {
+	[AST_SIP_REDIRECT_USER] = "user",
+	[AST_SIP_REDIRECT_URI_CORE] = "uri_core",
+	[AST_SIP_REDIRECT_URI_PJSIP] = "uri_pjsip",
+};
+
+static int redirect_method_to_str(const void *obj, const intptr_t *args, char **buf)
+{
+	const struct ast_sip_endpoint *endpoint = obj;
+	if (ARRAY_IN_BOUNDS(endpoint->redirect_method, redirect_method_map)) {
+		*buf = ast_strdup(redirect_method_map[endpoint->redirect_method]);
+	}
 	return 0;
 }
 
@@ -2250,7 +2265,7 @@ int ast_res_pjsip_initialize_configuration(void)
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "srtp_tag_32", "no", OPT_BOOL_T, 1, FLDSET(struct ast_sip_endpoint, media.rtp.srtp_tag_32));
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "media_encryption_optimistic", "no", OPT_BOOL_T, 1, FLDSET(struct ast_sip_endpoint, media.rtp.encryption_optimistic));
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "g726_non_standard", "no", OPT_BOOL_T, 1, FLDSET(struct ast_sip_endpoint, media.g726_non_standard));
-	ast_sorcery_object_field_register_custom(sip_sorcery, "endpoint", "redirect_method", "user", redirect_handler, NULL, NULL, 0, 0);
+	ast_sorcery_object_field_register_custom(sip_sorcery, "endpoint", "redirect_method", "user", redirect_method_handler, redirect_method_to_str, NULL, 0, 0);
 	ast_sorcery_object_field_register_custom(sip_sorcery, "endpoint", "set_var", "", set_var_handler, set_var_to_str, set_var_to_vl, 0, 0);
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "message_context", "", OPT_STRINGFIELD_T, 0, STRFLDSET(struct ast_sip_endpoint, message_context));
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "accountcode", "", OPT_STRINGFIELD_T, 0, STRFLDSET(struct ast_sip_endpoint, accountcode));

--- a/res/res_pjsip/pjsip_manager.xml
+++ b/res/res_pjsip/pjsip_manager.xml
@@ -45,6 +45,9 @@
 				<parameter name="MatchHeader">
 					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip_endpoint_identifier_ip']/configFile[@name='pjsip.conf']/configObject[@name='identify']/configOption[@name='match_header']/synopsis/node())"/></para>
 				</parameter>
+				<parameter name="MatchRequestUri">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip_endpoint_identifier_ip']/configFile[@name='pjsip.conf']/configObject[@name='identify']/configOption[@name='match_request_uri']/synopsis/node())"/></para>
+				</parameter>
 				<parameter name="EndpointName">
 					<para>The name of the endpoint associated with this information.</para>
 				</parameter>
@@ -98,6 +101,18 @@
 				<parameter name="SupportPath">
 					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='aor']/configOption[@name='support_path']/synopsis/node())"/></para>
 				</parameter>
+				<parameter name="Qualify2xxOnly">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='aor']/configOption[@name='qualify_2xx_only']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="QualifyTimeout">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='aor']/configOption[@name='qualify_timeout']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="VoicemailExtension">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='aor']/configOption[@name='voicemail_extension']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="Contacts">
+					<para>A comma-separated list of contacts associated with this AoR.</para>
+				</parameter>
 				<parameter name="TotalContacts">
 					<para>The total number of contacts associated with this AoR.</para>
 				</parameter>
@@ -143,6 +158,24 @@
 				</parameter>
 				<parameter name="EndpointName">
 					<para>The name of the endpoint associated with this information.</para>
+				</parameter>
+				<parameter name="OauthClientid">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='auth']/configOption[@name='oauth_clientid']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="OauthSecret">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='auth']/configOption[@name='oauth_secret']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="PasswordDigest">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='auth']/configOption[@name='password_digest']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="RefreshToken">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='auth']/configOption[@name='refresh_token']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="SupportedAlgorithmsUac">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='auth']/configOption[@name='supported_algorithms_uac']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="SupportedAlgorithmsUas">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='auth']/configOption[@name='supported_algorithms_uas']/synopsis/node())"/></para>
 				</parameter>
 			</syntax>
 		</managerEventInstance>
@@ -223,6 +256,27 @@
 				<parameter name="WebsocketWriteTimeout">
 					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='transport']/configOption[@name='websocket_write_timeout']/synopsis/node())"/></para>
 				</parameter>
+				<parameter name="AllowReload">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='transport']/configOption[@name='allow_reload']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="AllowWildcardCerts">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='transport']/configOption[@name='allow_wildcard_certs']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="SymmetricTransport">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='transport']/configOption[@name='symmetric_transport']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="TcpKeepaliveEnable">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='transport']/configOption[@name='tcp_keepalive_enable']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="TcpKeepaliveIdleTime">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='transport']/configOption[@name='tcp_keepalive_idle_time']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="TcpKeepaliveIntervalTime">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='transport']/configOption[@name='tcp_keepalive_interval_time']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="TcpKeepaliveProbeCount">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='transport']/configOption[@name='tcp_keepalive_probe_count']/synopsis/node())"/></para>
+				</parameter>
 				<parameter name="EndpointName">
 					<para>The name of the endpoint associated with this information.</para>
 				</parameter>
@@ -244,9 +298,6 @@
 				</parameter>
 				<parameter name="Context">
 					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='context']/synopsis/node())"/></para>
-				</parameter>
-				<parameter name="Disallow">
-					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='disallow']/synopsis/node())"/></para>
 				</parameter>
 				<parameter name="Allow">
 					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='allow']/synopsis/node())"/></para>
@@ -524,11 +575,137 @@
 				<parameter name="SubscribeContext">
 					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='subscribe_context']/synopsis/node())"/></para>
 				</parameter>
-				<parameter name="Allowoverlap">
+				<parameter name="AllowOverlap">
 					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='allow_overlap']/synopsis/node())"/></para>
 				</parameter>
 				<parameter name="OverlapContext">
 					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='overlap_context']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="AcceptMultipleSdpAnswers">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='accept_multiple_sdp_answers']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="Acl">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='acl']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="AllowUnauthenticatedOptions">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='allow_unauthenticated_options']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="AsymmetricRtpCodec">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='asymmetric_rtp_codec']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="BindRtpToMediaAddress">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='bind_rtp_to_media_address']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="Bundle">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='bundle']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="CodecPrefsIncomingAnswer">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='codec_prefs_incoming_answer']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="CodecPrefsIncomingOffer">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='codec_prefs_incoming_offer']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="CodecPrefsOutgoingAnswer">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='codec_prefs_outgoing_answer']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="CodecPrefsOutgoingOffer">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='codec_prefs_outgoing_offer']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="ContactAcl">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='contact_acl']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="DtlsAutoGenerateCert">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='dtls_auto_generate_cert']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="DtlsFingerprint">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='dtls_fingerprint']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="FaxDetectTimeout">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='fax_detect_timeout']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="FollowEarlyMediaFork">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='follow_early_media_fork']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="G726NonStandard">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='g726_non_standard']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="GeolocIncomingCallProfile">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='geoloc_incoming_call_profile']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="GeolocOutgoingCallProfile">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='geoloc_outgoing_call_profile']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="Ignore183WithoutSdp">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='ignore_183_without_sdp']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="IncomingCallOfferPref">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='incoming_call_offer_pref']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="IncomingMwiMailbox">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='incoming_mwi_mailbox']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="MaxAudioStreams">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='max_audio_streams']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="MaxVideoStreams">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='max_video_streams']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="MwiSubscribeReplacesUnsolicited">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='mwi_subscribe_replaces_unsolicited']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="NotifyEarlyInuseRinging">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='notify_early_inuse_ringing']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="OutgoingCallOfferPref">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='outgoing_call_offer_pref']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="ReferBlindProgress">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='refer_blind_progress']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="RpidImmediate">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='rpid_immediate']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="RtcpMux">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='rtcp_mux']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="RtpKeepalive">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='rtp_keepalive']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="RtpTimeout">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='rtp_timeout']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="RtpTimeoutHold">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='rtp_timeout_hold']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="SecurityNegotiation">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='security_negotiation']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="SendAoc">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='send_aoc']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="SendHistoryInfo">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='send_history_info']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="StirShaken">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='stir_shaken']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="StirShakenProfile">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='stir_shaken_profile']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="SuppressMohOnSendonly">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='suppress_moh_on_sendonly']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="SuppressQ850ReasonHeaders">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='suppress_q850_reason_headers']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="Tenantid">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='tenantid']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="VoicemailExtension">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='voicemail_extension']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="Webrtc">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='webrtc']/synopsis/node())"/></para>
 				</parameter>
 			</syntax>
 		</managerEventInstance>
@@ -558,6 +735,12 @@
 				<parameter name="QualifyFrequency">
 					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='aor']/configOption[@name='qualify_frequency']/synopsis/node())"/></para>
 				</parameter>
+				<parameter name="QualifyTimeout">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='aor']/configOption[@name='qualify_timeout']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="Qualify2xxOnly">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='aor']/configOption[@name='qualify_2xx_only']/synopsis/node())"/></para>
+				</parameter>
 				<parameter name="AuthenticateQualify">
 					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='aor']/configOption[@name='authenticate_qualify']/synopsis/node())"/></para>
 				</parameter>
@@ -573,11 +756,17 @@
 				<parameter name="Mailboxes">
 					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='aor']/configOption[@name='mailboxes']/synopsis/node())"/></para>
 				</parameter>
+				<parameter name="VoicemailExtension">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='aor']/configOption[@name='voicemail_extension']/synopsis/node())"/></para>
+				</parameter>
 				<parameter name="OutboundProxy">
 					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='aor']/configOption[@name='outbound_proxy']/synopsis/node())"/></para>
 				</parameter>
 				<parameter name="SupportPath">
 					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='aor']/configOption[@name='support_path']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="Contacts">
+					<para>A comma-separated list of contacts associated with this AoR.</para>
 				</parameter>
 			</syntax>
 		</managerEventInstance>
@@ -612,6 +801,24 @@
 				</parameter>
 				<parameter name="NonceLifetime">
 					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='auth']/configOption[@name='nonce_lifetime']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="OauthClientid">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='auth']/configOption[@name='oauth_clientid']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="OauthSecret">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='auth']/configOption[@name='oauth_secret']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="PasswordDigest">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='auth']/configOption[@name='password_digest']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="RefreshToken">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='auth']/configOption[@name='refresh_token']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="SupportedAlgorithmsUac">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='auth']/configOption[@name='supported_algorithms_uac']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="SupportedAlgorithmsUas">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='auth']/configOption[@name='supported_algorithms_uas']/synopsis/node())"/></para>
 				</parameter>
 			</syntax>
 		</managerEventInstance>
@@ -687,6 +894,10 @@
 				<parameter name="RoundtripUsec">
 					<para>The round trip time in microseconds.</para>
 				</parameter>
+				<parameter name="Qualify2xxOnly">
+					<para>A boolean indicating whether to only consider a contact
+					available if the OPTIONS response has a 2xx status code.</para>
+				</parameter>
 			</syntax>
 		</managerEventInstance>
 	</managerEvent>
@@ -751,6 +962,10 @@
 					<para>The elapsed time in decimal seconds after which an OPTIONS
 					message is sent before the contact is considered unavailable.</para>
 				</parameter>
+				<parameter name="Qualify2xxOnly">
+					<para>Only consider a contact available if the OPTIONS response
+					has a 2xx status code.</para>
+				</parameter>
 			</syntax>
 		</managerEventInstance>
 	</managerEvent>
@@ -784,6 +999,9 @@
 				</parameter>
 				<parameter name="ActiveChannels">
 					<para>The number of active channels associated with this endpoint.</para>
+				</parameter>
+				<parameter name="Contacts">
+					<para>A comma-separated list of contacts associated with this AoR.</para>
 				</parameter>
 			</syntax>
 		</managerEventInstance>

--- a/res/res_pjsip_outbound_registration.c
+++ b/res/res_pjsip_outbound_registration.c
@@ -343,6 +343,96 @@
                         </para>
 		</description>
 	</manager>
+	<managerEvent language="en_US" name="OutboundRegistrationDetail">
+		<managerEventInstance class="EVENT_FLAG_COMMAND">
+			<since>
+				<version>12.0.0</version>
+			</since>
+			<synopsis>
+				Provides configuration details and status information about an
+				outbound registration.
+			</synopsis>
+			<syntax>
+				<parameter name="ObjectType">
+					<para>The object's type. This will always be 'registration'.</para>
+				</parameter>
+				<parameter name="ObjectName">
+					<para>The name of this object.</para>
+				</parameter>
+				<parameter name="MaxRetries">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip_outbound_registration']/configFile[@name='pjsip.conf']/configObject[@name='registration']/configOption[@name='max_retries']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="ClientUri">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip_outbound_registration']/configFile[@name='pjsip.conf']/configObject[@name='registration']/configOption[@name='client_uri']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="SecurityNegotiation">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip_outbound_registration']/configFile[@name='pjsip.conf']/configObject[@name='registration']/configOption[@name='security_negotiation']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="AuthRejectionPermanent">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip_outbound_registration']/configFile[@name='pjsip.conf']/configObject[@name='registration']/configOption[@name='auth_rejection_permanent']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="ServerUri">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip_outbound_registration']/configFile[@name='pjsip.conf']/configObject[@name='registration']/configOption[@name='server_uri']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="MaxRandomInitialDelay">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip_outbound_registration']/configFile[@name='pjsip.conf']/configObject[@name='registration']/configOption[@name='max_random_initial_delay']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="SupportPath">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip_outbound_registration']/configFile[@name='pjsip.conf']/configObject[@name='registration']/configOption[@name='support_path']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="RetryInterval">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip_outbound_registration']/configFile[@name='pjsip.conf']/configObject[@name='registration']/configOption[@name='retry_interval']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="ContactHeaderParams">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip_outbound_registration']/configFile[@name='pjsip.conf']/configObject[@name='registration']/configOption[@name='contact_header_params']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="Expiration">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip_outbound_registration']/configFile[@name='pjsip.conf']/configObject[@name='registration']/configOption[@name='expiration']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="Transport">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip_outbound_registration']/configFile[@name='pjsip.conf']/configObject[@name='registration']/configOption[@name='transport']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="Line">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip_outbound_registration']/configFile[@name='pjsip.conf']/configObject[@name='registration']/configOption[@name='line']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="ContactUser">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip_outbound_registration']/configFile[@name='pjsip.conf']/configObject[@name='registration']/configOption[@name='contact_user']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="Endpoint">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip_outbound_registration']/configFile[@name='pjsip.conf']/configObject[@name='registration']/configOption[@name='endpoint']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="UserAgent">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip_outbound_registration']/configFile[@name='pjsip.conf']/configObject[@name='registration']/configOption[@name='user_agent']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="ForbiddenRetryInterval">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip_outbound_registration']/configFile[@name='pjsip.conf']/configObject[@name='registration']/configOption[@name='forbidden_retry_interval']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="OutboundAuth">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip_outbound_registration']/configFile[@name='pjsip.conf']/configObject[@name='registration']/configOption[@name='outbound_auth']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="OutboundProxy">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip_outbound_registration']/configFile[@name='pjsip.conf']/configObject[@name='registration']/configOption[@name='outbound_proxy']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="FatalRetryInterval">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip_outbound_registration']/configFile[@name='pjsip.conf']/configObject[@name='registration']/configOption[@name='fatal_retry_interval']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="SupportOutbound">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip_outbound_registration']/configFile[@name='pjsip.conf']/configObject[@name='registration']/configOption[@name='support_outbound']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="Status">
+					<para>The current status of this registration. Will be one of:</para>
+					<enumlist>
+						<enum name="Registered"/>
+						<enum name="Unregistered"/>
+						<enum name="Rejected"/>
+					</enumlist>
+				</parameter>
+				<parameter name="NextReg">
+					<para>The number of seconds until the next registration.</para>
+				</parameter>
+			</syntax>
+		</managerEventInstance>
+	</managerEvent>
  ***/
 
 /* forward declarations */

--- a/res/res_pjsip_pubsub.c
+++ b/res/res_pjsip_pubsub.c
@@ -54,7 +54,7 @@
 			<version>12.0.0</version>
 		</since>
 		<synopsis>
-			Lists subscriptions.
+			Lists inbound subscriptions.
 		</synopsis>
 		<syntax />
 		<description>
@@ -65,12 +65,80 @@
                         </para>
 		</description>
 	</manager>
+	<managerEvent language="en_US" name="InboundSubscriptionDetail">
+		<managerEventInstance class="EVENT_FLAG_COMMAND">
+			<since>
+				<version>12.0.0</version>
+			</since>
+			<synopsis>
+				Provides details about an inbound subscription - one in which Asterisk
+				handles SUBSCRIBE requests and periodically sends NOTIFYs to its
+				subscribers.
+			</synopsis>
+			<syntax>
+				<parameter name="Role">
+					<para>Asterisk's role for this subscription. This will always be
+					<literal>Notifier</literal>.</para>
+				</parameter>
+				<parameter name="Endpoint">
+					<para>The name of the endpoint associated with this
+					subscription.</para>
+				</parameter>
+				<parameter name="Callid">
+					<para>The CallID of the dialog associated with this
+					subscription.</para>
+				</parameter>
+				<parameter name="State">
+					<para>The current state of the subscription.</para>
+				</parameter>
+				<parameter name="Callerid">
+					<para>The Caller ID of the endpoint associated with this
+					subscription.</para>
+				</parameter>
+				<parameter name="SubscriptionType">
+					<para>Asterisk currently supports the following subscription types, but
+					this could also be extended by third-party modules so this list may not
+					be exhaustive:</para>
+					<enumlist>
+						<enum name="mwi"/>
+						<enum name="extension_state"/>
+					</enumlist>
+				</parameter>
+				<parameter name="Extension">
+					<para>If the <literal>SubscriptionType</literal> is
+					<literal>extension_state</literal> this will be the monitored
+					extension.</para>
+				</parameter>
+				<parameter name="ExtensionStates">
+					<para>If the <literal>SubscriptionType</literal> is
+					<literal>extension_state</literal> this will be the monitored
+					extension's state.</para>
+					<enumlist>
+						<enum name="Idle"/>
+						<enum name="InUse"/>
+						<enum name="Busy"/>
+						<enum name="Unavailable"/>
+						<enum name="Ringing"/>
+						<enum name="InUse&amp;Ringing"/>
+						<enum name="Hold"/>
+						<enum name="InUse&amp;Hold"/>
+						<enum name="Unknown"/>
+					</enumlist>
+				</parameter>
+				<parameter name="Mailboxes">
+					<para>If the <literal>SubscriptionType</literal> is
+					<literal>mwi</literal> this will be a comma-separated list of
+					mailboxes.</para>
+				</parameter>
+			</syntax>
+		</managerEventInstance>
+	</managerEvent>
 	<manager name="PJSIPShowSubscriptionsOutbound" language="en_US">
 		<since>
 			<version>12.0.0</version>
 		</since>
 		<synopsis>
-			Lists subscriptions.
+			Lists outbound subscriptions.
 		</synopsis>
 		<syntax />
 		<description>
@@ -81,6 +149,73 @@
                         </para>
 		</description>
 	</manager>
+	<managerEvent language="en_US" name="OutboundSubscriptionDetail">
+		<managerEventInstance class="EVENT_FLAG_COMMAND">
+			<since>
+				<version>12.0.0</version>
+			</since>
+			<synopsis>
+				Provides details about an outbound subscription - one in which Asterisk
+				sends SUBSCRIBE requests and periodically receives NOTIFYs.
+			</synopsis>
+			<syntax>
+				<parameter name="Role">
+					<para>Asterisk's role for this subscription. This will always be
+					<literal>Subscriber</literal>.</para>
+				</parameter>
+				<parameter name="Endpoint">
+					<para>The name of the endpoint associated with this
+					subscription.</para>
+				</parameter>
+				<parameter name="Callid">
+					<para>The CallID of the dialog associated with this
+					subscription.</para>
+				</parameter>
+				<parameter name="State">
+					<para>The current state of the subscription.</para>
+				</parameter>
+				<parameter name="Callerid">
+					<para>The Caller ID of the endpoint associated with this
+					subscription.</para>
+				</parameter>
+				<parameter name="SubscriptionType">
+					<para>Asterisk currently supports the following subscription types, but
+					this could also be extended by third-party modules so this list may not
+					be exhaustive:</para>
+					<enumlist>
+						<enum name="mwi"/>
+						<enum name="extension_state"/>
+					</enumlist>
+				</parameter>
+				<parameter name="Extension">
+					<para>If the <literal>SubscriptionType</literal> is
+					<literal>extension_state</literal> this will be the monitored
+					extension.</para>
+				</parameter>
+				<parameter name="ExtensionStates">
+					<para>If the <literal>SubscriptionType</literal> is
+					<literal>extension_state</literal> this will be the monitored
+					extension's state.</para>
+					<enumlist>
+						<enum name="Idle"/>
+						<enum name="InUse"/>
+						<enum name="Busy"/>
+						<enum name="Unavailable"/>
+						<enum name="Ringing"/>
+						<enum name="InUse&amp;Ringing"/>
+						<enum name="Hold"/>
+						<enum name="InUse&amp;Hold"/>
+						<enum name="Unknown"/>
+					</enumlist>
+				</parameter>
+				<parameter name="Mailboxes">
+					<para>If the <literal>SubscriptionType</literal> is
+					<literal>mwi</literal> this will be a comma-separated list of
+					mailboxes.</para>
+				</parameter>
+			</syntax>
+		</managerEventInstance>
+	</managerEvent>
 	<manager name="PJSIPShowResourceLists" language="en_US">
 		<since>
 			<version>13.0.0</version>
@@ -97,6 +232,37 @@
                         </para>
 		</description>
 	</manager>
+	<managerEvent language="en_US" name="ResourceListDetail">
+		<managerEventInstance class="EVENT_FLAG_COMMAND">
+			<since>
+				<version>13.0.0</version>
+			</since>
+			<synopsis>Provides details about a resource list.</synopsis>
+			<syntax>
+				<parameter name="ObjectType">
+					<para>The object's type. This will always be 'resource_list'.</para>
+				</parameter>
+				<parameter name="ObjectName">
+					<para>The name of this object.</para>
+				</parameter>
+				<parameter name="Event">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip_pubsub']/configFile[@name='pjsip.conf']/configObject[@name='resource_list']/configOption[@name='event']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="FullState">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip_pubsub']/configFile[@name='pjsip.conf']/configObject[@name='resource_list']/configOption[@name='full_state']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="ListItem">
+					<para>A comma-separated list of resources that belong to this resource list.</para>
+				</parameter>
+				<parameter name="NotificationBatchInterval">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip_pubsub']/configFile[@name='pjsip.conf']/configObject[@name='resource_list']/configOption[@name='notification_batch_interval']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="ResourceDisplayName">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip_pubsub']/configFile[@name='pjsip.conf']/configObject[@name='resource_list']/configOption[@name='resource_display_name']/synopsis/node())"/></para>
+				</parameter>
+			</syntax>
+		</managerEventInstance>
+	</managerEvent>
 
 	<configInfo name="res_pjsip_pubsub" language="en_US">
 		<synopsis>Module that implements publish and subscribe support.</synopsis>

--- a/res/res_pjsip_registrar.c
+++ b/res/res_pjsip_registrar.c
@@ -82,6 +82,71 @@
 			</para>
 		</description>
 	</manager>
+	<managerEvent language="en_US" name="InboundRegistrationDetail">
+		<managerEventInstance class="EVENT_FLAG_COMMAND">
+			<since>
+				<version>12.0.0</version>
+			</since>
+			<synopsis>Provide details about the Address of Record (AoR) associated
+			with a registration.</synopsis>
+			<syntax>
+				<parameter name="ObjectType">
+					<para>The object's type. This will always be 'aor'.</para>
+				</parameter>
+				<parameter name="ObjectName">
+					<para>The name of this object.</para>
+				</parameter>
+				<parameter name="MinimumExpiration">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='aor']/configOption[@name='minimum_expiration']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="DefaultExpiration">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='aor']/configOption[@name='default_expiration']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="QualifyTimeout">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='aor']/configOption[@name='qualify_timeout']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="Qualify2xxOnly">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='aor']/configOption[@name='qualify_2xx_only']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="Mailboxes">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='aor']/configOption[@name='mailboxes']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="SupportPath">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='aor']/configOption[@name='support_path']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="RemoveUnavailable">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='aor']/configOption[@name='remove_unavailable']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="VoicemailExtension">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='aor']/configOption[@name='voicemail_extension']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="MaxContacts">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='aor']/configOption[@name='max_contacts']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="AuthenticateQualify">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='aor']/configOption[@name='authenticate_qualify']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="MaximumExpiration">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='aor']/configOption[@name='maximum_expiration']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="QualifyFrequency">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='aor']/configOption[@name='qualify_frequency']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="RemoveExisting">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='aor']/configOption[@name='remove_existing']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="OutboundProxy">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='aor']/configOption[@name='outbound_proxy']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="Contacts">
+					<para>A comma-separated list of contacts associated with this AoR.</para>
+				</parameter>
+				<parameter name="Contact">
+					<para>The specific contact associated with this registration.</para>
+				</parameter>
+			</syntax>
+		</managerEventInstance>
+	</managerEvent>
  ***/
 
 static int pj_max_hostname = PJ_MAX_HOSTNAME;


### PR DESCRIPTION
Most of this patch is adding missing PJSIP-related event
documentation, but the one functional change was adding a sorcery
to-string handler for endpoint's `redirect_method` which was not
showing up in the AMI event details or `pjsip show endpoint
<endpoint>` output.

The rest of the changes are summarized below:

* app_agent_pool.c: Typo fix Epoche -> Epoch.
* stasis_bridges.c: Add missing AttendedTransfer properties.
* stasis_channels.c: Add missing AgentLogoff properties.
* pjsip_manager.xml:
  - Add missing AorList properties.
  - Add missing AorDetail properties.
  - Add missing ContactList properties.
  - Add missing ContactStatusDetail properties.
  - Add missing EventDetail properties.
  - Add missing AuthList properties.
  - Add missing AuthDetail properties.
  - Add missing TransportDetail properties.
  - Add missing EndpointList properties.
  - Add missing IdentifyDetail properties.
* res_pjsip_registrar.c: Add missing InboundRegistrationDetail documentation.
* res_pjsip_pubsub.c:
  - Add missing ResourceListDetail documentation.
  - Add missing InboundSubscriptionDetail documentation.
  - Add missing OutboundSubscriptionDetail documentation.
* res_pjsip_outbound_registration.c: Add missing OutboundRegistrationDetail documentation.