### PR TITLE
bridge_channel: don't set cause code on channel during bridge delete if already set

### DIFF
--- a/main/bridge_channel.c
+++ b/main/bridge_channel.c
@@ -278,13 +278,23 @@ static void bridge_channel_poke(struct ast_bridge_channel *bridge_channel)
  */
 static int channel_set_cause(struct ast_channel *chan, int cause)
 {
+	int current_cause;
 	ast_channel_lock(chan);
+	current_cause = ast_channel_hangupcause(chan);
+
+	/* if the hangupcause is already set, leave it */
+	if (current_cause > 0) {
+		ast_channel_unlock(chan);
+		return current_cause;
+	}
+
 	if (cause <= 0) {
 		cause = ast_channel_hangupcause(chan);
 		if (cause <= 0) {
 			cause = AST_CAUSE_NORMAL_CLEARING;
 		}
 	}
+
 	ast_channel_hangupcause_set(chan, cause);
 	ast_channel_unlock(chan);
 	return cause;


### PR DESCRIPTION
Due to a potential race condition via ARI when hanging up a channel hangup with cause
while also deleting a bridge containing that channel, the bridge delete can over-write
the hangup cause code resulting in Normal Call Clearing instead of the set value.

With this change, bridge deletion will only set the hangup code if it hasn't been
previously set.

Resolves: #1124
