### PR TITLE
Introduces support for real-time text conversation over RTP (RFC 4103).

### DIFF
--- a/bridges/bridge_native_rtp.c
+++ b/bridges/bridge_native_rtp.c
@@ -246,7 +246,16 @@ static int rtp_glue_data_get(struct ast_channel *c0, struct rtp_glue_data *glue0
 	}
 	ast_debug(2, "%p, From media bridging, glue video result 1: %d, instance %p, 2: %d, instance %p\n",
 			glue0->cb->allow_vrtp_remote, glue0->video.result, &glue0->video.instance, glue1->video.result, &glue1->video.instance);
-	/* there is no allow_trtp_remote function implemented, so this this logic is not needed for real-time text */
+	if (glue0->text.result == glue1->text.result && glue1->text.result == AST_RTP_GLUE_RESULT_REMOTE) {
+		if (glue0->cb->allow_trtp_remote && !glue0->cb->allow_trtp_remote(c0, glue1->text.instance)) {
+			/* If the allow_trtp_remote indicates that remote isn't allowed, revert to local bridge */
+			glue0->text.result = glue1->text.result = AST_RTP_GLUE_RESULT_LOCAL;
+		} else if (glue1->cb->allow_trtp_remote && !glue1->cb->allow_trtp_remote(c1, glue0->text.instance)) {
+			glue0->text.result = glue1->text.result = AST_RTP_GLUE_RESULT_LOCAL;
+		}
+	}
+	ast_debug(2, "%p, From media bridging, glue text result 1: %d, instance %p, 2: %d, instance %p\n",
+			glue0->cb->allow_trtp_remote, glue0->text.result, &glue0->text.instance, glue1->text.result, &glue1->text.instance);
 	/* If we are carrying video, and both sides are not going to remotely bridge... fail the native bridge */
 	if (glue0->video.instance && glue1->video.instance) {
 		if (glue0->video.result != AST_RTP_GLUE_RESULT_FORBID

--- a/bridges/bridge_native_rtp.c
+++ b/bridges/bridge_native_rtp.c
@@ -461,8 +461,8 @@ static void native_rtp_bridge_start(struct ast_bridge *bridge, struct ast_channe
 			/* Send both channels to remote */
 			data0->remote_cb = glue0->cb;
 			data1->remote_cb = glue1->cb;
-			glue0->cb->update_peer(bc0->chan, glue1->audio.instance, glue1->video.instance, NULL, cap1, 0);
-			glue1->cb->update_peer(bc1->chan, glue0->audio.instance, glue0->video.instance, NULL, cap0, 0);
+			glue0->cb->update_peer(bc0->chan, glue1->audio.instance, glue1->video.instance, glue1->text.instance, cap1, 0);
+			glue1->cb->update_peer(bc1->chan, glue0->audio.instance, glue0->video.instance, glue0->text.instance, cap0, 0);
 			ast_verb(4, "Remotely bridged '%s' and '%s' - media will flow directly between them\n",
 				ast_channel_name(bc0->chan), ast_channel_name(bc1->chan));
 		} else {
@@ -476,10 +476,10 @@ static void native_rtp_bridge_start(struct ast_bridge *bridge, struct ast_channe
 				bridge->uniqueid, ast_channel_name(target));
 			if (bc0->chan == target) {
 				data0->remote_cb = glue0->cb;
-				glue0->cb->update_peer(bc0->chan, glue1->audio.instance, glue1->video.instance, NULL, cap1, 0);
+				glue0->cb->update_peer(bc0->chan, glue1->audio.instance, glue1->video.instance, glue1->text.instance, cap1, 0);
 			} else {
 				data1->remote_cb = glue1->cb;
-				glue1->cb->update_peer(bc1->chan, glue0->audio.instance, glue0->video.instance, NULL, cap0, 0);
+				glue1->cb->update_peer(bc1->chan, glue0->audio.instance, glue0->video.instance, glue0->text.instance, cap0, 0);
 			}
 		}
 

--- a/bridges/bridge_native_rtp.c
+++ b/bridges/bridge_native_rtp.c
@@ -428,15 +428,12 @@ static void native_rtp_bridge_start(struct ast_bridge *bridge, struct ast_channe
 		/* check if we actually have audio, video or text - in this order */
 		if (glue0->audio.instance && glue1->audio.instance) {
 			remote_rtp_bridge_start_helper(glue0->audio.instance, glue1->audio.instance);
-		} else {
-			if (glue0->video.instance && glue1->video.instance) {
-				remote_rtp_bridge_start_helper(glue0->video.instance, glue1->video.instance);
-			} else {
-				if (glue0->text.instance && glue1->text.instance) {
-					remote_rtp_bridge_start_helper(glue0->text.instance, glue1->text.instance);
-				}
-			}
+		} else if (glue0->video.instance && glue1->video.instance) {
+			remote_rtp_bridge_start_helper(glue0->video.instance, glue1->video.instance);
+		} else if (glue0->text.instance && glue1->text.instance) {
+			remote_rtp_bridge_start_helper(glue0->text.instance, glue1->text.instance);
 		}
+
 		ast_verb(4, "Locally RTP bridged '%s' and '%s' in stack\n",
 			ast_channel_name(bc0->chan), ast_channel_name(bc1->chan));
 		break;
@@ -604,14 +601,10 @@ static void native_rtp_bridge_stop(struct ast_bridge *bridge, struct ast_channel
 		/* check if we actually have audio, video or text - in this order */
 		if (glue0->audio.instance && glue1->audio.instance) {
 			remote_rtp_bridge_stop_helper(glue0->audio.instance,  glue1->audio.instance);
-		} else {
-			if (glue0->video.instance && glue1->video.instance) {
-				remote_rtp_bridge_stop_helper(glue0->video.instance,  glue1->video.instance);
-			} else {
-				if (glue0->text.instance && glue1->text.instance) {
-					remote_rtp_bridge_stop_helper(glue0->text.instance,  glue1->text.instance);
-				}
-			}
+		} else if (glue0->video.instance && glue1->video.instance) {
+			remote_rtp_bridge_stop_helper(glue0->video.instance,  glue1->video.instance);
+		} else if (glue0->text.instance && glue1->text.instance) {
+			remote_rtp_bridge_stop_helper(glue0->text.instance,  glue1->text.instance);
 		}
 		break;
 	case AST_RTP_GLUE_RESULT_REMOTE:

--- a/channels/chan_pjsip.c
+++ b/channels/chan_pjsip.c
@@ -391,6 +391,7 @@ struct rtp_direct_media_data {
 	struct ast_rtp_instance *vrtp;
 	struct ast_format_cap *cap;
 	struct ast_sip_session *session;
+	struct ast_rtp_instance *trtp;
 };
 
 static void rtp_direct_media_data_destroy(void *data)
@@ -400,12 +401,14 @@ static void rtp_direct_media_data_destroy(void *data)
 	ao2_cleanup(cdata->session);
 	ao2_cleanup(cdata->cap);
 	ao2_cleanup(cdata->vrtp);
+	ao2_cleanup(cdata->trtp);
 	ao2_cleanup(cdata->rtp);
 	ao2_cleanup(cdata->chan);
 }
 
 static struct rtp_direct_media_data *rtp_direct_media_data_create(
 	struct ast_channel *chan, struct ast_rtp_instance *rtp, struct ast_rtp_instance *vrtp,
+	struct ast_rtp_instance *trtp,
 	const struct ast_format_cap *cap, struct ast_sip_session *session)
 {
 	struct rtp_direct_media_data *cdata = ao2_alloc(sizeof(*cdata), rtp_direct_media_data_destroy);
@@ -417,6 +420,7 @@ static struct rtp_direct_media_data *rtp_direct_media_data_create(
 	cdata->chan = ao2_bump(chan);
 	cdata->rtp = ao2_bump(rtp);
 	cdata->vrtp = ao2_bump(vrtp);
+	cdata->trtp = ao2_bump(trtp);
 	cdata->cap = ao2_bump((struct ast_format_cap *)cap);
 	cdata->session = ao2_bump(session);
 
@@ -432,7 +436,7 @@ static int send_direct_media_request(void *data)
 	int res = 0;
 
 	/* XXX In an ideal world each media stream would be direct, but for now preserve behavior
-	 * and connect only the default media sessions for audio and video.
+	 * and connect only the default media sessions for audio, video, and text.
 	 */
 
 	/* The channel needs to be locked when checking for RTP changes.
@@ -448,6 +452,10 @@ static int send_direct_media_request(void *data)
 	if (session->active_media_state->default_session[AST_MEDIA_TYPE_VIDEO]) {
 		changed |= check_for_rtp_changes(
 			cdata->chan, cdata->vrtp, session->active_media_state->default_session[AST_MEDIA_TYPE_VIDEO], session);
+	}
+	if (session->active_media_state->default_session[AST_MEDIA_TYPE_TEXT]) {
+		changed |= check_for_rtp_changes(
+			cdata->chan, cdata->trtp, session->active_media_state->default_session[AST_MEDIA_TYPE_TEXT], session);
 	}
 	ast_channel_unlock(cdata->chan);
 
@@ -499,7 +507,7 @@ static int chan_pjsip_set_rtp_peer(struct ast_channel *chan,
 		SCOPE_EXIT_RTN_VALUE(0, "NAT is active\n");
 	}
 
-	cdata = rtp_direct_media_data_create(chan, rtp, vrtp, cap, session);
+	cdata = rtp_direct_media_data_create(chan, rtp, vrtp, tpeer, cap, session);
 	if (!cdata) {
 		SCOPE_EXIT_RTN_VALUE(0);
 	}

--- a/channels/chan_pjsip.c
+++ b/channels/chan_pjsip.c
@@ -1068,7 +1068,11 @@ static int chan_pjsip_write_stream(struct ast_channel *ast, int stream_num, stru
 				ast_channel_name(ast), stream_num, ast_codec_media_type2str(media->type));
 			return 0;
 		} else if (media->write_callback) {
-			ast_debug(3, "Text data to write %.*s\n",frame->datalen,(char*)frame->data.ptr);
+			if (frame->datalen > 0) {
+				ast_debug(3, "Writing text data: %.*s\n",frame->datalen,(char*)frame->data.ptr);
+			} else {
+				ast_debug(3, "Writing text idle packet\n");
+			}
 			res = media->write_callback(session, media, frame);
 		}
 		break;

--- a/channels/chan_rtp.c
+++ b/channels/chan_rtp.c
@@ -444,6 +444,12 @@ static enum ast_rtp_glue_result chan_rtp_get_vrtp_peer(struct ast_channel *chan,
 	return AST_RTP_GLUE_RESULT_FORBID;
 }
 
+/*! \brief Function called by RTP engine to get local text RTP peer */
+static enum ast_rtp_glue_result chan_rtp_get_trtp_peer(struct ast_channel *chan, struct ast_rtp_instance **instance)
+{
+	return AST_RTP_GLUE_RESULT_FORBID;
+}
+
 /*! \brief Function called by RTP engine to get local audio RTP peer */
 static enum ast_rtp_glue_result chan_rtp_get_rtp_peer(struct ast_channel *chan, struct ast_rtp_instance **instance)
 {
@@ -471,6 +477,7 @@ static struct ast_rtp_glue unicast_rtp_glue = {
 	.type = "UnicastRTP",
 	.get_rtp_info = chan_rtp_get_rtp_peer,
 	.get_vrtp_info = chan_rtp_get_vrtp_peer,
+	.get_trtp_info = chan_rtp_get_trtp_peer,
 	.get_codec = chan_rtp_get_codec,
 	.update_peer = chan_rtp_set_rtp_peer,
 };

--- a/channels/pjsip/dialplan_functions.c
+++ b/channels/pjsip/dialplan_functions.c
@@ -91,6 +91,8 @@ static int channel_read_rtp(struct ast_channel *chan, const char *type, const ch
 		media = session->active_media_state->default_session[AST_MEDIA_TYPE_AUDIO];
 	} else if (!strcmp(field, "video")) {
 		media = session->active_media_state->default_session[AST_MEDIA_TYPE_VIDEO];
+	} else if (!strcmp(field, "text")) {
+		media = session->active_media_state->default_session[AST_MEDIA_TYPE_TEXT];
 	} else {
 		ast_log(AST_LOG_WARNING, "Unknown media type field '%s' for 'rtp' information\n", field);
 		return -1;

--- a/channels/pjsip/dialplan_functions.c
+++ b/channels/pjsip/dialplan_functions.c
@@ -159,6 +159,8 @@ static int channel_read_rtcp(struct ast_channel *chan, const char *type, const c
 		media = session->active_media_state->default_session[AST_MEDIA_TYPE_AUDIO];
 	} else if (!strcmp(field, "video")) {
 		media = session->active_media_state->default_session[AST_MEDIA_TYPE_VIDEO];
+	} else if (!strcmp(field, "text")) {
+		media = session->active_media_state->default_session[AST_MEDIA_TYPE_TEXT];
 	} else {
 		ast_log(AST_LOG_WARNING, "Unknown media type field '%s' for 'rtcp' information\n", field);
 		return -1;
@@ -940,6 +942,8 @@ int pjsip_acf_media_offer_read(struct ast_channel *chan, const char *cmd, char *
 		return media_offer_read_av(channel->session, buf, len, AST_MEDIA_TYPE_AUDIO);
 	} else if (!strcmp(data, "video")) {
 		return media_offer_read_av(channel->session, buf, len, AST_MEDIA_TYPE_VIDEO);
+	} else if (!strcmp(data, "text")) {
+		return media_offer_read_av(channel->session, buf, len, AST_MEDIA_TYPE_TEXT);
 	} else {
 		/* Ensure that the buffer is empty */
 		buf[0] = '\0';
@@ -972,6 +976,8 @@ int pjsip_acf_media_offer_write(struct ast_channel *chan, const char *cmd, char 
 		mdata.media_type = AST_MEDIA_TYPE_AUDIO;
 	} else if (!strcmp(data, "video")) {
 		mdata.media_type = AST_MEDIA_TYPE_VIDEO;
+	} else if (!strcmp(data, "text")) {
+		mdata.media_type = AST_MEDIA_TYPE_TEXT;
 	}
 
 	return ast_sip_push_task_wait_serializer(channel->session->serializer, media_offer_write_av, &mdata);

--- a/configs/samples/pjsip.conf.sample
+++ b/configs/samples/pjsip.conf.sample
@@ -376,6 +376,14 @@
 ;
 ;stir_shaken=no
 ;stir_shaken_profile=my_profile
+;
+; T140/RED real-time text support.
+;
+;allow=red
+;allow=t140
+;tos_text=0
+;cos_text=0
+;max_text_streams=1
 
 ;[6001]
 ;type=auth

--- a/configs/samples/pjsip.conf.sample
+++ b/configs/samples/pjsip.conf.sample
@@ -802,8 +802,10 @@
 ;sdp_session=Asterisk   ; String used for the SDP session s line (default:
                         ; "Asterisk")
 ;tos_audio=0    ; DSCP TOS bits for audio streams (default: "0")
+;tos_text=0     ; DSCP TOS bits for text streams (default: "0")
 ;tos_video=0    ; DSCP TOS bits for video streams (default: "0")
 ;cos_audio=0    ; Priority for audio streams (default: "0")
+;cos_text=0     ; Priority for text streams (default: "0")
 ;cos_video=0    ; Priority for video streams (default: "0")
 ;allow_subscribe=yes    ; Determines if endpoint is allowed to initiate
                         ; subscriptions with Asterisk (default: "yes")
@@ -911,6 +913,8 @@
                               ; (Cisco SPA) to be able to indicate and pick up
                               ; ringing devices.
 ;max_audio_streams= ; The maximum number of allowed negotiated audio streams
+                    ; (default: 1)
+;max_text_streams=  ; The maximum number of allowed negotiated text streams
                     ; (default: 1)
 ;max_video_streams= ; The maximum number of allowed negotiated video streams
                     ; (default: 1)

--- a/contrib/ast-db-manage/config/versions/65b5ac60e54a_rtt_options.py
+++ b/contrib/ast-db-manage/config/versions/65b5ac60e54a_rtt_options.py
@@ -1,0 +1,25 @@
+"""Add rtt options
+
+Revision ID: 65b5ac60e54a
+Revises: abdc9ede147d
+Create Date: 2025-02-21 12:35:43.615049
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '65b5ac60e54a'
+down_revision = 'abdc9ede147d'
+
+from alembic import op
+import sqlalchemy as sa
+
+def upgrade():
+    op.add_column('ps_endpoints', sa.Column('tos_text', sa.String(10)))
+    op.add_column('ps_endpoints', sa.Column('cos_text', sa.Integer))
+    op.add_column('ps_endpoints', sa.Column('max_text_streams', sa.Integer))
+
+def downgrade():
+    op.drop_column('ps_endpoints', 'tos_text')
+    op.drop_column('ps_endpoints', 'cos_text')
+    op.drop_column('ps_endpoints', 'max_text_streams')
+    

--- a/contrib/ast-db-manage/config/versions/65b5ac60e54a_rtt_options.py
+++ b/contrib/ast-db-manage/config/versions/65b5ac60e54a_rtt_options.py
@@ -1,14 +1,14 @@
 """Add rtt options
 
 Revision ID: 65b5ac60e54a
-Revises: abdc9ede147d
+Revises: bb6d54e22913
 Create Date: 2025-02-21 12:35:43.615049
 
 """
 
 # revision identifiers, used by Alembic.
 revision = '65b5ac60e54a'
-down_revision = 'abdc9ede147d'
+down_revision = 'bb6d54e22913'
 
 from alembic import op
 import sqlalchemy as sa

--- a/contrib/ast-db-manage/config/versions/65b5ac60e54a_rtt_options.py
+++ b/contrib/ast-db-manage/config/versions/65b5ac60e54a_rtt_options.py
@@ -8,7 +8,7 @@ Create Date: 2025-02-21 12:35:43.615049
 
 # revision identifiers, used by Alembic.
 revision = '65b5ac60e54a'
-down_revision = 'bb6d54e22913'
+down_revision = '2285f2ace275'
 
 from alembic import op
 import sqlalchemy as sa

--- a/contrib/ast-db-manage/config/versions/65b5ac60e54a_rtt_options.py
+++ b/contrib/ast-db-manage/config/versions/65b5ac60e54a_rtt_options.py
@@ -22,4 +22,3 @@ def downgrade():
     op.drop_column('ps_endpoints', 'tos_text')
     op.drop_column('ps_endpoints', 'cos_text')
     op.drop_column('ps_endpoints', 'max_text_streams')
-    

--- a/contrib/ast-db-manage/config/versions/65b5ac60e54a_rtt_options.py
+++ b/contrib/ast-db-manage/config/versions/65b5ac60e54a_rtt_options.py
@@ -1,7 +1,7 @@
 """Add rtt options
 
 Revision ID: 65b5ac60e54a
-Revises: bb6d54e22913
+Revises: 2285f2ace275
 Create Date: 2025-02-21 12:35:43.615049
 
 """

--- a/include/asterisk/res_pjsip.h
+++ b/include/asterisk/res_pjsip.h
@@ -1059,6 +1059,12 @@ struct ast_sip_endpoint_media_configuration {
 	struct ast_stream_codec_negotiation_prefs codec_prefs_incoming_answer;
 	/*! Codec negotiation prefs for outgoing answers */
 	struct ast_stream_codec_negotiation_prefs codec_prefs_outgoing_answer;
+	/*! DSCP TOS bits for text streams */
+	unsigned int tos_text;
+	/*! Priority for text streams */
+	unsigned int cos_text;
+	/*! Maximum number of text streams to offer/accept */
+	unsigned int max_text_streams;
 };
 
 /*!

--- a/include/asterisk/rtp_engine.h
+++ b/include/asterisk/rtp_engine.h
@@ -803,7 +803,12 @@ struct ast_rtp_glue {
 	 * \note This function may be NULL for a given channel driver. This should be accounted for and if that is the case, this function is not used.
 	 */
 	int (*allow_vrtp_remote)(struct ast_channel *chan1, struct ast_rtp_instance *instance);
-	/* there is no allow_trtp_remote function implemented */
+	/*!
+	 * \brief Used to prevent two channels from remotely bridging text rtp if the channel tech has a
+	 *        reason for prohibiting it based on qualities that need to be compared from both channels.
+	 * \note This function may be NULL for a given channel driver. This should be accounted for and if that is the case, this function is not used.
+	 */
+	int (*allow_trtp_remote)(struct ast_channel *chan1, struct ast_rtp_instance *instance);
 	/*!
 	 * \brief Callback for retrieving the RTP instance carrying text
 	 * \note This function increases the reference count on the returned RTP instance.

--- a/include/asterisk/rtp_engine.h
+++ b/include/asterisk/rtp_engine.h
@@ -803,7 +803,7 @@ struct ast_rtp_glue {
 	 * \note This function may be NULL for a given channel driver. This should be accounted for and if that is the case, this function is not used.
 	 */
 	int (*allow_vrtp_remote)(struct ast_channel *chan1, struct ast_rtp_instance *instance);
-
+	/* there is no allow_trtp_remote function implemented */
 	/*!
 	 * \brief Callback for retrieving the RTP instance carrying text
 	 * \note This function increases the reference count on the returned RTP instance.
@@ -1083,7 +1083,7 @@ void ast_rtp_instance_set_data(struct ast_rtp_instance *instance, void *data);
  *
  * \code
  * struct *blob = ast_rtp_instance_get_data(instance);
- ( \endcode
+ * \endcode
  *
  * This gets the data pointer on the RTP instance pointed to by 'instance'.
  *

--- a/main/bridge_channel.c
+++ b/main/bridge_channel.c
@@ -2447,7 +2447,7 @@ static void bridge_channel_handle_write(struct ast_bridge_channel *bridge_channe
 			ast_channel_name(bridge_channel->chan), fr->datalen, (char *)fr->data.ptr);
 			goto T140_RED;
 		}
-		ast_debug(1, "Sending TEXT frame with old (SIP MESSAGE)  method to '%s': %*.s\n",
+		ast_debug(1, "Sending TEXT frame with via SIP MESSAGE method to '%s': %*.s\n",
 			ast_channel_name(bridge_channel->chan), fr->datalen, (char *)fr->data.ptr);
 		sendtext_safe(bridge_channel->chan, fr);
 		break;

--- a/main/channel.c
+++ b/main/channel.c
@@ -1121,7 +1121,7 @@ static int __ast_queue_frame(struct ast_channel *chan, struct ast_frame *fin, in
 			/* Save the most recent frame */
 			if (!AST_LIST_NEXT(cur, frame_list)) {
 				break;
-			} else if (cur->frametype == AST_FRAME_VOICE || cur->frametype == AST_FRAME_VIDEO || cur->frametype == AST_FRAME_NULL) {
+			} else if (cur->frametype == AST_FRAME_VOICE || cur->frametype == AST_FRAME_VIDEO || cur->frametype == AST_FRAME_TEXT || cur->frametype == AST_FRAME_NULL) {
 				if (++count > 64) {
 					break;
 				}
@@ -3717,7 +3717,7 @@ static struct ast_frame *__ast_read(struct ast_channel *chan, int dropaudio, int
 			default:
 				break;
 			}
-		} else if (f->frametype == AST_FRAME_VOICE || f->frametype == AST_FRAME_VIDEO) {
+		} else if (f->frametype == AST_FRAME_VOICE || f->frametype == AST_FRAME_VIDEO || f->frametype == AST_FRAME_TEXT) {
 			if (ast_channel_tech(chan) && ast_channel_tech(chan)->read_stream) {
 				stream = ast_stream_topology_get_stream(ast_channel_get_stream_topology(chan), f->stream_num);
 				default_stream = ast_channel_get_default_stream(chan, ast_format_get_type(f->subclass.format));
@@ -3756,7 +3756,7 @@ static struct ast_frame *__ast_read(struct ast_channel *chan, int dropaudio, int
 			 * thing different is that we need to find the default stream so we know whether to invoke the
 			 * default stream logic or not (such as transcoding).
 			 */
-			if (f && (f->frametype == AST_FRAME_VOICE || f->frametype == AST_FRAME_VIDEO)) {
+			if (f && (f->frametype == AST_FRAME_VOICE || f->frametype == AST_FRAME_VIDEO || f->frametype == AST_FRAME_TEXT)) {
 				stream = ast_stream_topology_get_stream(ast_channel_get_stream_topology(chan), f->stream_num);
 				default_stream = ast_channel_get_default_stream(chan, ast_format_get_type(f->subclass.format));
 			}
@@ -3766,7 +3766,7 @@ static struct ast_frame *__ast_read(struct ast_channel *chan, int dropaudio, int
 			/* Since this channel driver does not support multistream determine the default stream this frame
 			 * originated from and update the frame to include it.
 			 */
-			if (f && (f->frametype == AST_FRAME_VOICE || f->frametype == AST_FRAME_VIDEO)) {
+			if (f && (f->frametype == AST_FRAME_VOICE || f->frametype == AST_FRAME_VIDEO || f->frametype == AST_FRAME_TEXT)) {
 				stream = default_stream = ast_channel_get_default_stream(chan, ast_format_get_type(f->subclass.format));
 				if (!stream) {
 					ast_frfree(f);
@@ -5218,12 +5218,12 @@ int ast_write_stream(struct ast_channel *chan, int stream_num, struct ast_frame 
 		}
 		stream = ast_stream_topology_get_stream(ast_channel_get_stream_topology(chan), stream_num);
 		default_stream = ast_channel_get_default_stream(chan, ast_stream_get_type(stream));
-	} else if (fr->frametype == AST_FRAME_VOICE || fr->frametype == AST_FRAME_VIDEO || fr->frametype == AST_FRAME_MODEM) {
+	} else if (fr->frametype == AST_FRAME_VOICE || fr->frametype == AST_FRAME_VIDEO || fr->frametype == AST_FRAME_TEXT || fr->frametype == AST_FRAME_MODEM) {
 		/* If we haven't been told of a stream then we need to figure out which once we need */
 		enum ast_media_type type = AST_MEDIA_TYPE_UNKNOWN;
 
 		/* Some frame types have a fixed media type */
-		if (fr->frametype == AST_FRAME_VOICE || fr->frametype == AST_FRAME_VIDEO) {
+		if (fr->frametype == AST_FRAME_VOICE || fr->frametype == AST_FRAME_VIDEO || fr->frametype == AST_FRAME_TEXT) {
 			type = ast_format_get_type(fr->subclass.format);
 		} else if (fr->frametype == AST_FRAME_MODEM) {
 			type = AST_MEDIA_TYPE_IMAGE;
@@ -5308,7 +5308,8 @@ int ast_write_stream(struct ast_channel *chan, int stream_num, struct ast_frame 
 				res = 0;
 			}
 		} else if (stream == default_stream) {
-			if (ast_format_cmp(fr->subclass.format, ast_format_t140) == AST_FORMAT_CMP_EQUAL) {
+			if (ast_format_cmp(fr->subclass.format, ast_format_t140) == AST_FORMAT_CMP_EQUAL ||
+				ast_format_cmp(fr->subclass.format, ast_format_t140_red) == AST_FORMAT_CMP_EQUAL) {
 				res = (ast_channel_tech(chan)->write_text == NULL) ? 0 :
 					ast_channel_tech(chan)->write_text(chan, fr);
 			} else {

--- a/main/channel.c
+++ b/main/channel.c
@@ -3717,7 +3717,11 @@ static struct ast_frame *__ast_read(struct ast_channel *chan, int dropaudio, int
 			default:
 				break;
 			}
-		} else if (f->frametype == AST_FRAME_VOICE || f->frametype == AST_FRAME_VIDEO || f->frametype == AST_FRAME_TEXT) {
+		/* Text messages over SIP MESSAGE have no stream codec topology, leaving f->subclass.format as NULL.
+		 * We must bypass this block for standalone text frames to prevent them from being dropped.
+		 */
+		} else if (f->frametype == AST_FRAME_VOICE || f->frametype == AST_FRAME_VIDEO ||
+					( f->frametype == AST_FRAME_TEXT && f->subclass.format)) {
 			if (ast_channel_tech(chan) && ast_channel_tech(chan)->read_stream) {
 				stream = ast_stream_topology_get_stream(ast_channel_get_stream_topology(chan), f->stream_num);
 				default_stream = ast_channel_get_default_stream(chan, ast_format_get_type(f->subclass.format));
@@ -3756,7 +3760,11 @@ static struct ast_frame *__ast_read(struct ast_channel *chan, int dropaudio, int
 			 * thing different is that we need to find the default stream so we know whether to invoke the
 			 * default stream logic or not (such as transcoding).
 			 */
-			if (f && (f->frametype == AST_FRAME_VOICE || f->frametype == AST_FRAME_VIDEO || f->frametype == AST_FRAME_TEXT)) {
+			/* Text messages based on SIP MESSAGE) have no stream codec topology, leaving f->subclass.format as NULL.
+			 * We must bypass this block for standalone text frames to prevent them from being dropped.
+			 */
+			if (f && (f->frametype == AST_FRAME_VOICE || f->frametype == AST_FRAME_VIDEO ||
+				(f->frametype == AST_FRAME_TEXT && f->subclass.format))) {
 				stream = ast_stream_topology_get_stream(ast_channel_get_stream_topology(chan), f->stream_num);
 				default_stream = ast_channel_get_default_stream(chan, ast_format_get_type(f->subclass.format));
 			}
@@ -3766,7 +3774,11 @@ static struct ast_frame *__ast_read(struct ast_channel *chan, int dropaudio, int
 			/* Since this channel driver does not support multistream determine the default stream this frame
 			 * originated from and update the frame to include it.
 			 */
-			if (f && (f->frametype == AST_FRAME_VOICE || f->frametype == AST_FRAME_VIDEO || f->frametype == AST_FRAME_TEXT)) {
+			/* Text messages based on SIP MESSAGE) have no stream codec topology, leaving f->subclass.format as NULL.
+			 * We must bypass this block for standalone text frames to prevent them from being dropped.
+			 */
+			if (f && (f->frametype == AST_FRAME_VOICE || f->frametype == AST_FRAME_VIDEO ||
+				( f->frametype == AST_FRAME_TEXT && f->subclass.format))) {
 				stream = default_stream = ast_channel_get_default_stream(chan, ast_format_get_type(f->subclass.format));
 				if (!stream) {
 					ast_frfree(f);

--- a/main/channel.c
+++ b/main/channel.c
@@ -2586,6 +2586,7 @@ void ast_hangup(struct ast_channel *chan)
 		ast_closestream(ast_channel_vstream(chan));
 		ast_channel_vstream_set(chan, NULL);
 	}
+
 	if (ast_channel_sched(chan)) {
 		ast_sched_context_destroy(ast_channel_sched(chan));
 		ast_channel_sched_set(chan, NULL);
@@ -4771,6 +4772,7 @@ char *ast_recvtext(struct ast_channel *chan, int timeout)
 	return buf;
 }
 
+/* Sending text data from dialplan, not used for relaying text data */
 int ast_sendtext_data(struct ast_channel *chan, struct ast_msg_data *msg)
 {
 	int res = 0;
@@ -4799,6 +4801,7 @@ int ast_sendtext_data(struct ast_channel *chan, struct ast_msg_data *msg)
 		f.frametype = AST_FRAME_TEXT;
 		f.datalen = body_len;
 		f.mallocd = AST_MALLOCD_DATA;
+		f.stream_num = ast_stream_get_position(ast_channel_get_default_stream(chan, AST_MEDIA_TYPE_TEXT));
 		f.data.ptr = ast_strdup(body);
 		if (f.data.ptr) {
 			res = ast_channel_tech(chan)->write_text(chan, &f);
@@ -4829,6 +4832,7 @@ int ast_sendtext_data(struct ast_channel *chan, struct ast_msg_data *msg)
 	return res;
 }
 
+/* Sending text data from dialplan, not used for relaying text data */
 int ast_sendtext(struct ast_channel *chan, const char *text)
 {
 	struct ast_msg_data *msg;
@@ -5037,10 +5041,23 @@ int ast_prod(struct ast_channel *chan)
 	return 0;
 }
 
+/* currently unused */
 int ast_write_video(struct ast_channel *chan, struct ast_frame *fr)
 {
 	int res;
 	if (!ast_channel_tech(chan)->write_video)
+		return 0;
+	res = ast_write(chan, fr);
+	if (!res)
+		res = 1;
+	return res;
+}
+
+/* currently unused */
+int ast_write_text(struct ast_channel *chan, struct ast_frame *fr)
+{
+	int res;
+	if (!ast_channel_tech(chan)->write_text)
 		return 0;
 	res = ast_write(chan, fr);
 	if (!res)
@@ -5284,12 +5301,22 @@ int ast_write_stream(struct ast_channel *chan, int stream_num, struct ast_frame 
 		break;
 	case AST_FRAME_TEXT:
 		CHECK_BLOCKING(chan);
-		if (ast_format_cmp(fr->subclass.format, ast_format_t140) == AST_FORMAT_CMP_EQUAL) {
-			res = (ast_channel_tech(chan)->write_text == NULL) ? 0 :
-				ast_channel_tech(chan)->write_text(chan, fr);
+		if (ast_channel_tech(chan)->write_stream) {
+			if (stream) {
+				res = ast_channel_tech(chan)->write_stream(chan, ast_stream_get_position(stream), fr);
+			} else {
+				res = 0;
+			}
+		} else if (stream == default_stream) {
+			if (ast_format_cmp(fr->subclass.format, ast_format_t140) == AST_FORMAT_CMP_EQUAL) {
+				res = (ast_channel_tech(chan)->write_text == NULL) ? 0 :
+					ast_channel_tech(chan)->write_text(chan, fr);
+			} else {
+				res = (ast_channel_tech(chan)->send_text == NULL) ? 0 :
+					ast_channel_tech(chan)->send_text(chan, (char *) fr->data.ptr);
+			}
 		} else {
-			res = (ast_channel_tech(chan)->send_text == NULL) ? 0 :
-				ast_channel_tech(chan)->send_text(chan, (char *) fr->data.ptr);
+			res = 0;
 		}
 		ast_clear_flag(ast_channel_flags(chan), AST_FLAG_BLOCKING);
 		break;

--- a/main/channel.c
+++ b/main/channel.c
@@ -3721,7 +3721,7 @@ static struct ast_frame *__ast_read(struct ast_channel *chan, int dropaudio, int
 		 * We must bypass this block for standalone text frames to prevent them from being dropped.
 		 */
 		} else if (f->frametype == AST_FRAME_VOICE || f->frametype == AST_FRAME_VIDEO ||
-					( f->frametype == AST_FRAME_TEXT && f->subclass.format)) {
+					(f->frametype == AST_FRAME_TEXT && f->subclass.format)) {
 			if (ast_channel_tech(chan) && ast_channel_tech(chan)->read_stream) {
 				stream = ast_stream_topology_get_stream(ast_channel_get_stream_topology(chan), f->stream_num);
 				default_stream = ast_channel_get_default_stream(chan, ast_format_get_type(f->subclass.format));
@@ -3778,7 +3778,7 @@ static struct ast_frame *__ast_read(struct ast_channel *chan, int dropaudio, int
 			 * We must bypass this block for standalone text frames to prevent them from being dropped.
 			 */
 			if (f && (f->frametype == AST_FRAME_VOICE || f->frametype == AST_FRAME_VIDEO ||
-				( f->frametype == AST_FRAME_TEXT && f->subclass.format))) {
+				(f->frametype == AST_FRAME_TEXT && f->subclass.format))) {
 				stream = default_stream = ast_channel_get_default_stream(chan, ast_format_get_type(f->subclass.format));
 				if (!stream) {
 					ast_frfree(f);

--- a/main/channel.c
+++ b/main/channel.c
@@ -3760,7 +3760,7 @@ static struct ast_frame *__ast_read(struct ast_channel *chan, int dropaudio, int
 			 * thing different is that we need to find the default stream so we know whether to invoke the
 			 * default stream logic or not (such as transcoding).
 			 */
-			/* Text messages based on SIP MESSAGE) have no stream codec topology, leaving f->subclass.format as NULL.
+			/* Text messages based on SIP MESSAGE have no stream codec topology, leaving f->subclass.format as NULL.
 			 * We must bypass this block for standalone text frames to prevent them from being dropped.
 			 */
 			if (f && (f->frametype == AST_FRAME_VOICE || f->frametype == AST_FRAME_VIDEO ||
@@ -3774,7 +3774,7 @@ static struct ast_frame *__ast_read(struct ast_channel *chan, int dropaudio, int
 			/* Since this channel driver does not support multistream determine the default stream this frame
 			 * originated from and update the frame to include it.
 			 */
-			/* Text messages based on SIP MESSAGE) have no stream codec topology, leaving f->subclass.format as NULL.
+			/* Text messages based on SIP MESSAGE have no stream codec topology, leaving f->subclass.format as NULL.
 			 * We must bypass this block for standalone text frames to prevent them from being dropped.
 			 */
 			if (f && (f->frametype == AST_FRAME_VOICE || f->frametype == AST_FRAME_VIDEO ||
@@ -5230,7 +5230,9 @@ int ast_write_stream(struct ast_channel *chan, int stream_num, struct ast_frame 
 		}
 		stream = ast_stream_topology_get_stream(ast_channel_get_stream_topology(chan), stream_num);
 		default_stream = ast_channel_get_default_stream(chan, ast_stream_get_type(stream));
-	} else if (fr->frametype == AST_FRAME_VOICE || fr->frametype == AST_FRAME_VIDEO || fr->frametype == AST_FRAME_TEXT || fr->frametype == AST_FRAME_MODEM) {
+	} else if (fr->frametype == AST_FRAME_VOICE || fr->frametype == AST_FRAME_VIDEO
+		|| (fr->frametype == AST_FRAME_TEXT && fr->subclass.format) || fr->frametype == AST_FRAME_MODEM) {
+		/* Text messages based on SIP MESSAGE have no stream codec topology, leaving fr->subclass.format as NULL */
 		/* If we haven't been told of a stream then we need to figure out which once we need */
 		enum ast_media_type type = AST_MEDIA_TYPE_UNKNOWN;
 
@@ -11257,4 +11259,3 @@ void ast_channel_clear_flag(struct ast_channel *chan, unsigned int flag)
 	ast_clear_flag(ast_channel_flags(chan), flag);
 	ast_channel_unlock(chan);
 }
-

--- a/main/codec.c
+++ b/main/codec.c
@@ -383,6 +383,7 @@ unsigned int ast_codec_samples_count(struct ast_frame *frame)
 
 	if ((frame->frametype != AST_FRAME_VOICE) &&
 		(frame->frametype != AST_FRAME_VIDEO) &&
+		(frame->frametype != AST_FRAME_TEXT) &&
 		(frame->frametype != AST_FRAME_IMAGE)) {
 		return 0;
 	}

--- a/main/frame.c
+++ b/main/frame.c
@@ -136,6 +136,7 @@ static void __frame_free(struct ast_frame *fr, int cache)
 		if (frames && frames->size < FRAME_CACHE_MAX_SIZE) {
 			if (fr->frametype == AST_FRAME_VOICE
 				|| fr->frametype == AST_FRAME_VIDEO
+				|| fr->frametype == AST_FRAME_TEXT
 				|| fr->frametype == AST_FRAME_IMAGE) {
 				ao2_cleanup(fr->subclass.format);
 			} else if (fr->frametype == AST_FRAME_CONTROL && fr->subclass.integer == AST_CONTROL_ANSWER) {
@@ -160,6 +161,7 @@ static void __frame_free(struct ast_frame *fr, int cache)
 	if (fr->mallocd & AST_MALLOCD_HDR) {
 		if (fr->frametype == AST_FRAME_VOICE
 			|| fr->frametype == AST_FRAME_VIDEO
+			|| fr->frametype == AST_FRAME_TEXT
 			|| fr->frametype == AST_FRAME_IMAGE) {
 			ao2_cleanup(fr->subclass.format);
 		} else if (fr->frametype == AST_FRAME_CONTROL && fr->subclass.integer == AST_CONTROL_ANSWER) {
@@ -220,7 +222,7 @@ struct ast_frame *__ast_frisolate(struct ast_frame *fr, const char *file, int li
 		out->frametype = fr->frametype;
 		out->subclass = fr->subclass;
 		if ((fr->frametype == AST_FRAME_VOICE) || (fr->frametype == AST_FRAME_VIDEO) ||
-			(fr->frametype == AST_FRAME_IMAGE)) {
+			(fr->frametype == AST_FRAME_TEXT) || (fr->frametype == AST_FRAME_IMAGE)) {
 			ao2_bump(out->subclass.format);
 		} else if (fr->frametype == AST_FRAME_VOICE && fr->subclass.integer == AST_CONTROL_ANSWER) {
 			ao2_bump(out->subclass.topology);
@@ -352,7 +354,7 @@ struct ast_frame *__ast_frdup(const struct ast_frame *f, const char *file, int l
 	out->frametype = f->frametype;
 	out->subclass = f->subclass;
 	if ((f->frametype == AST_FRAME_VOICE) || (f->frametype == AST_FRAME_VIDEO) ||
-		(f->frametype == AST_FRAME_IMAGE)) {
+		(f->frametype == AST_FRAME_TEXT) || (f->frametype == AST_FRAME_IMAGE)) {
 		ao2_bump(out->subclass.format);
 	} else if (f->frametype == AST_FRAME_CONTROL && f->subclass.integer == AST_CONTROL_ANSWER) {
 		ao2_bump(out->subclass.topology);
@@ -756,6 +758,9 @@ void ast_frame_dump(const char *name, struct ast_frame *f, char *prefix)
 		return;
 	}
 	if (f->frametype == AST_FRAME_VIDEO) {
+		return;
+	}
+	if (f->frametype == AST_FRAME_TEXT) {
 		return;
 	}
 	if (f->frametype == AST_FRAME_RTCP) {

--- a/main/rtp_engine.c
+++ b/main/rtp_engine.c
@@ -2469,8 +2469,12 @@ void ast_rtp_instance_early_bridge_make_compatible(struct ast_channel *c_dst, st
 		*vinstance_dst = NULL, *vinstance_src = NULL,
 		*tinstance_dst = NULL, *tinstance_src = NULL;
 	struct ast_rtp_glue *glue_dst, *glue_src;
-	enum ast_rtp_glue_result audio_glue_dst_res = AST_RTP_GLUE_RESULT_FORBID, video_glue_dst_res = AST_RTP_GLUE_RESULT_FORBID;
-	enum ast_rtp_glue_result audio_glue_src_res = AST_RTP_GLUE_RESULT_FORBID, video_glue_src_res = AST_RTP_GLUE_RESULT_FORBID;
+	enum ast_rtp_glue_result audio_glue_dst_res = AST_RTP_GLUE_RESULT_FORBID,
+		video_glue_dst_res = AST_RTP_GLUE_RESULT_FORBID,
+		text_glue_dst_res = AST_RTP_GLUE_RESULT_FORBID;
+	enum ast_rtp_glue_result audio_glue_src_res = AST_RTP_GLUE_RESULT_FORBID,
+		video_glue_src_res = AST_RTP_GLUE_RESULT_FORBID,
+		text_glue_src_res = AST_RTP_GLUE_RESULT_FORBID;
 	struct ast_format_cap *cap_dst = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
 	struct ast_format_cap *cap_src = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
 
@@ -2489,9 +2493,11 @@ void ast_rtp_instance_early_bridge_make_compatible(struct ast_channel *c_dst, st
 
 	audio_glue_dst_res = glue_dst->get_rtp_info(c_dst, &instance_dst);
 	video_glue_dst_res = glue_dst->get_vrtp_info ? glue_dst->get_vrtp_info(c_dst, &vinstance_dst) : AST_RTP_GLUE_RESULT_FORBID;
+	text_glue_dst_res = glue_dst->get_trtp_info ? glue_dst->get_trtp_info(c_dst, &tinstance_dst) : AST_RTP_GLUE_RESULT_FORBID;
 
 	audio_glue_src_res = glue_src->get_rtp_info(c_src, &instance_src);
 	video_glue_src_res = glue_src->get_vrtp_info ? glue_src->get_vrtp_info(c_src, &vinstance_src) : AST_RTP_GLUE_RESULT_FORBID;
+	text_glue_src_res = glue_src->get_trtp_info ? glue_src->get_trtp_info(c_src, &tinstance_src) : AST_RTP_GLUE_RESULT_FORBID;
 
 	/* If we are carrying video, and both sides are not going to remotely bridge... fail the native bridge */
 	if (video_glue_dst_res != AST_RTP_GLUE_RESULT_FORBID && (audio_glue_dst_res != AST_RTP_GLUE_RESULT_REMOTE || video_glue_dst_res != AST_RTP_GLUE_RESULT_REMOTE)) {
@@ -2504,6 +2510,20 @@ void ast_rtp_instance_early_bridge_make_compatible(struct ast_channel *c_dst, st
 		glue_dst->get_codec(c_dst, cap_dst);
 	}
 	if (audio_glue_src_res == AST_RTP_GLUE_RESULT_REMOTE && (video_glue_src_res == AST_RTP_GLUE_RESULT_FORBID || video_glue_src_res == AST_RTP_GLUE_RESULT_REMOTE) && glue_src->get_codec) {
+		glue_src->get_codec(c_src, cap_src);
+	}
+
+	/* If we are carrying text, and both sides are not going to remotely bridge... fail the native bridge */
+	if (text_glue_dst_res != AST_RTP_GLUE_RESULT_FORBID && (audio_glue_dst_res != AST_RTP_GLUE_RESULT_REMOTE || text_glue_dst_res != AST_RTP_GLUE_RESULT_REMOTE)) {
+		audio_glue_dst_res = AST_RTP_GLUE_RESULT_FORBID;
+	}
+	if (text_glue_src_res != AST_RTP_GLUE_RESULT_FORBID && (audio_glue_src_res != AST_RTP_GLUE_RESULT_REMOTE || text_glue_src_res != AST_RTP_GLUE_RESULT_REMOTE)) {
+		audio_glue_src_res = AST_RTP_GLUE_RESULT_FORBID;
+	}
+	if (audio_glue_dst_res == AST_RTP_GLUE_RESULT_REMOTE && (text_glue_dst_res == AST_RTP_GLUE_RESULT_FORBID || text_glue_dst_res == AST_RTP_GLUE_RESULT_REMOTE) && glue_dst->get_codec) {
+		glue_dst->get_codec(c_dst, cap_dst);
+	}
+	if (audio_glue_src_res == AST_RTP_GLUE_RESULT_REMOTE && (text_glue_src_res == AST_RTP_GLUE_RESULT_FORBID || text_glue_src_res == AST_RTP_GLUE_RESULT_REMOTE) && glue_src->get_codec) {
 		glue_src->get_codec(c_src, cap_src);
 	}
 

--- a/res/res_format_attr_red.c
+++ b/res/res_format_attr_red.c
@@ -1,0 +1,281 @@
+/*
+ * Asterisk -- An open source telephony toolkit.
+ *
+ * Copyright (C) 2025, GILAWA Ltd
+ *
+ * Henning Westerholt <hw@gilawa.com>
+ *
+ * See http://www.asterisk.org for more information about
+ * the Asterisk project. Please do not directly contact
+ * any of the maintainers of this project for assistance;
+ * the project provides a web site, mailing lists and IRC
+ * channels for your use.
+ *
+ * This program is free software, distributed under the terms of
+ * the GNU General Public License Version 2. See the LICENSE file
+ * at the top of the source tree.
+ */
+
+/*!
+ * \file
+ * \brief RED format attribute interface
+ *
+ * \author Henning Westerholt <hw@gilawa.com>
+ *
+ * \note https://www.rfc-editor.org/rfc/rfc4103.html
+ */
+
+/*** MODULEINFO
+	<support_level>core</support_level>
+ ***/
+
+#include "asterisk.h"
+
+#include <ctype.h>                      /* for tolower */
+
+#include "asterisk/module.h"
+#include "asterisk/format.h"
+#include "asterisk/logger.h"            /* for ast_log, LOG_WARNING */
+#include "asterisk/strings.h"           /* for ast_str_append */
+#include "asterisk/utils.h"             /* for ast_free */
+#include "asterisk/rtp_engine.h"        /* for AST_RED_MAX_GENERATION */
+
+/*
+ * From RFC 4103: "Therefore, text/t140 is RECOMMENDED
+ * to be the only payload type in the RTP stream."
+ * For this reason we only support uniform payload types.
+ *
+ * If in the future this attribute should be used also for other redundant rtp streams,
+ * it needs to be adapted together with the other infrastructure supporting it.
+ */
+struct red_attr {
+	int red_num_gen; /* Number of generations */
+	int red_payload; /* Payload for each generation (actually related to t140) */
+	int cps;         /* Characters per second */
+};
+
+static struct red_attr default_red_attr = {
+	.red_num_gen = 2,
+	.red_payload = 98, /* default type that two test clients used */
+	.cps = 30
+};
+
+static void red_destroy(struct ast_format *format)
+{
+	struct red_attr *attr = ast_format_get_attribute_data(format);
+	ast_free(attr);
+}
+
+static int red_clone(const struct ast_format *src, struct ast_format *dst)
+{
+	struct red_attr *original = ast_format_get_attribute_data(src);
+	struct red_attr *attr = ast_malloc(sizeof(*attr));
+
+	if (!attr) {
+		return -1;
+	}
+
+	if (original) {
+		*attr = *original;
+	} else {
+		*attr = default_red_attr;
+	}
+
+	ast_format_set_attribute_data(dst, attr);
+	return 0;
+}
+
+static struct ast_format *red_parse_sdp_fmtp(const struct ast_format *format, const char *attributes)
+{
+	char *attribs = ast_strdupa(attributes);
+	char *rest = NULL;
+	struct ast_format *cloned;
+	struct red_attr *attr;
+	int red_num_gen = -1;
+	int red_payload = -1;
+
+	cloned = ast_format_clone(format);
+	if (!cloned) {
+		return NULL;
+	}
+	attr = ast_format_get_attribute_data(cloned);
+
+	attribs = strtok_r(attribs, "/", &rest);
+	/* number of redundant generations is one less of the attributes */
+	while (attribs && red_num_gen++ < AST_RED_MAX_GENERATION-1) {
+		if (sscanf(attribs, "%30u", &red_payload) == 1) {
+			attr->red_payload = red_payload;
+		}
+		attribs = strtok_r(NULL, "/", &rest);
+	}
+
+	attr->red_num_gen = red_num_gen;
+
+	return cloned;
+}
+
+static void red_generate_sdp_fmtp(const struct ast_format *format, unsigned int payload, struct ast_str **str)
+{
+	struct red_attr *attr = ast_format_get_attribute_data(format);
+	int base_fmtp_size;
+	int original_size;
+	if (!attr) {
+		ast_log(LOG_ERROR, "Invalid RED attributes\n");
+		return;
+	}
+
+	/*
+	* Generate the SDP fmtp line for RED
+	* Assuming attr->red_payload holds the payload types for redundancy
+	* and attr->red_num_gen holds the number of generations
+	*/
+	original_size = ast_str_strlen(*str);
+	base_fmtp_size = ast_str_append(str, 0, "a=fmtp:%u ", payload);
+
+	if (attr->red_num_gen > 0) {
+		/* attributes are one more as the number of generations */
+		for (int i = 0; i < attr->red_num_gen + 1; i++) {
+			ast_str_append(str, 0, "%d/", attr->red_payload);
+		}
+	}
+
+	if (base_fmtp_size == ast_str_strlen(*str) - original_size) {
+		ast_str_truncate(*str, original_size);
+	} else {
+		ast_str_truncate(*str, -1);
+		ast_str_append(str, 0, "\r\n");
+	}
+
+	ast_debug(3, "RED sdp written: %s\n", ast_str_buffer(*str));
+}
+
+
+static const void *red_attribute_get(const struct ast_format *format, const char *name)
+{
+	struct red_attr *attr = ast_format_get_attribute_data(format);
+	int *val;
+
+	if (!strcasecmp(name, "red_num_gen")) {
+		val = &attr->red_num_gen;
+	} else if (!strcasecmp(name, "red_payload")) {
+		val = &attr->red_payload;
+	} else if (!strcasecmp(name, "cps")) {
+		val = &attr->cps;
+	} else {
+		ast_log(LOG_WARNING, "unknown attribute type %s\n", name);
+		return NULL;
+	}
+
+	return val;
+}
+
+
+static struct ast_format *red_attribute_set(const struct ast_format *format, const char *name, const char *value)
+{
+	struct ast_format *cloned;
+	struct red_attr *attr;
+	unsigned int val;
+
+	if (sscanf(value, "%30u", &val) != 1) {
+		ast_log(LOG_WARNING, "Unknown value '%s' for attribute type '%s'\n",
+			value, name);
+		return NULL;
+	}
+
+	cloned = ast_format_clone(format);
+	if (!cloned) {
+		return NULL;
+	}
+	attr = ast_format_get_attribute_data(cloned);
+
+	if (!strcasecmp(name, "red_num_gen")) {
+		attr->red_num_gen = val;
+	} else if (!strcasecmp(name, "red_payload")) {
+		attr->red_payload = val;
+	} else if (!strcasecmp(name, "cps")) {
+		attr->cps = val;
+	} else {
+		ast_log(LOG_WARNING, "unknown attribute type %s\n", name);
+	}
+
+	return cloned;
+}
+
+
+static struct ast_format *red_getjoint(const struct ast_format *format1, const struct ast_format *format2)
+{
+	struct red_attr *attr1 = ast_format_get_attribute_data(format1);
+	struct red_attr *attr2 = ast_format_get_attribute_data(format2);
+	struct ast_format *jointformat;
+	struct red_attr *attr_res;
+	/* To re-use offered RED payload types */
+	unsigned int use_side = 0;
+
+	if (!attr1) {
+		attr1 = &default_red_attr;
+		use_side = 2;
+	}
+
+	if (!attr2) {
+		attr2 = &default_red_attr;
+		use_side = 1;
+	}
+
+	jointformat = ast_format_clone(use_side == 2 ? format2 : format1);
+	if (!jointformat) {
+		return NULL;
+	}
+
+	/* Get the resulting attributes for the joint format */
+	attr_res = ast_format_get_attribute_data(jointformat);
+
+	/* Determine joint attributes */
+	if (attr1->red_num_gen == 0 || attr2->red_num_gen == 0) {
+		/* If either format has no redundancy, set joint to no redundancy */
+		attr_res->red_num_gen = 0;
+	} else {
+		/*
+		* If both formats have redundancy, take the minimum number of generations.
+		* Some tested clients only support e.g. 2 generations and it would be a waste
+		* of bandwitdh or could even lead to incompatibilities.
+		*/
+		attr_res->red_num_gen = MIN(attr1->red_num_gen, attr2->red_num_gen);
+		attr_res->red_payload = (use_side == 2) ? attr2->red_payload : attr1->red_payload;
+	}
+
+	ast_debug(3, "RED final joint: generations %d, payload %d\n", attr_res->red_num_gen,
+		attr_res->red_payload);
+
+	return jointformat;
+}
+
+static struct ast_format_interface red_interface = {
+	.format_destroy = red_destroy,
+	.format_clone = red_clone,
+	.format_cmp = NULL,
+	.format_get_joint = red_getjoint,
+	.format_attribute_set = red_attribute_set,
+	.format_attribute_get = red_attribute_get,
+	.format_parse_sdp_fmtp = red_parse_sdp_fmtp,
+	.format_generate_sdp_fmtp = red_generate_sdp_fmtp,
+};
+
+static int load_module(void)
+{
+	if (ast_format_interface_register("red", &red_interface)) {
+		return AST_MODULE_LOAD_DECLINE;
+	}
+	return AST_MODULE_LOAD_SUCCESS;
+}
+
+static int unload_module(void)
+{
+	return 0;
+}
+
+AST_MODULE_INFO(ASTERISK_GPL_KEY, AST_MODFLAG_LOAD_ORDER, "RED Format Attribute Module",
+	.support_level = AST_MODULE_SUPPORT_CORE,
+	.load = load_module,
+	.unload = unload_module,
+	.load_pri = AST_MODPRI_CHANNEL_DEPEND,
+);

--- a/res/res_format_attr_red.c
+++ b/res/res_format_attr_red.c
@@ -110,6 +110,7 @@ static struct ast_format *red_parse_sdp_fmtp(const struct ast_format *format, co
 	}
 
 	attr->red_num_gen = red_num_gen;
+	ast_debug(3, "RED sdp parsed, number of generations %d\n", red_num_gen);
 
 	return cloned;
 }
@@ -146,7 +147,7 @@ static void red_generate_sdp_fmtp(const struct ast_format *format, unsigned int 
 		ast_str_append(str, 0, "\r\n");
 	}
 
-	ast_debug(3, "RED sdp written: %s\n", ast_str_buffer(*str));
+	ast_debug(3, "RED sdp generated: %s\n", ast_str_buffer(*str));
 }
 
 

--- a/res/res_format_attr_red.c
+++ b/res/res_format_attr_red.c
@@ -99,14 +99,32 @@ static struct ast_format *red_parse_sdp_fmtp(const struct ast_format *format, co
 		return NULL;
 	}
 	attr = ast_format_get_attribute_data(cloned);
+	/*
+	 * RTP payload mapping is established before the optional fmtp attribute
+	 * is parsed.  Keep the cloned defaults during that first, empty pass.
+	 */
+	if (ast_strlen_zero(attributes)) {
+		return cloned;
+	}
 
 	attribs = strtok_r(attribs, "/", &rest);
 	/* number of redundant generations is one less of the attributes */
 	while (attribs && red_num_gen++ < AST_RED_MAX_GENERATION-1) {
-		if (sscanf(attribs, "%30u", &red_payload) == 1) {
-			attr->red_payload = red_payload;
+		unsigned int parsed_payload;
+		char trailing;
+
+		if (sscanf(attribs, "%u%c", &parsed_payload, &trailing) != 1 || parsed_payload > 127
+			|| (red_payload != -1 && red_payload != parsed_payload)) {
+			ao2_ref(cloned, -1);
+			return NULL;
 		}
+		red_payload = parsed_payload;
+		attr->red_payload = parsed_payload;
 		attribs = strtok_r(NULL, "/", &rest);
+	}
+	if (attribs || red_payload == -1) {
+		ao2_ref(cloned, -1);
+		return NULL;
 	}
 
 	attr->red_num_gen = red_num_gen;

--- a/res/res_format_attr_red.c
+++ b/res/res_format_attr_red.c
@@ -236,9 +236,9 @@ static struct ast_format *red_getjoint(const struct ast_format *format1, const s
 		attr_res->red_num_gen = 0;
 	} else {
 		/*
-		* If both formats have redundancy, take the minimum number of generations.
-		* Some tested clients only support e.g. 2 generations and it would be a waste
-		* of bandwitdh or could even lead to incompatibilities.
+		* If both formats have redundancy, take the minimum number of
+		* generations to save bandwidth and avoid compatibility issues.
+		* Some tested clients only support e.g. 2 generations.
 		*/
 		attr_res->red_num_gen = MIN(attr1->red_num_gen, attr2->red_num_gen);
 		attr_res->red_payload = (use_side == 2) ? attr2->red_payload : attr1->red_payload;

--- a/res/res_pjsip/pjsip_config.xml
+++ b/res/res_pjsip/pjsip_config.xml
@@ -448,6 +448,45 @@
 						</enumlist>
 					</description>
 				</configOption>
+				<configOption name="max_text_streams" default="1">
+					<since>
+						<version>22.7.0</version>
+						<version>21.12.0</version>
+						<version>20.17.0</version>
+					</since>
+					<synopsis>
+						Maximum number of text streams
+					</synopsis>
+					<description>
+						<para>
+						Maximum number of text streams to accept. This is useful in situations
+						where you want to limit the number of text streams that can be sent to
+						the client.
+						</para>
+					</description>
+				</configOption>
+				<configOption name="tos_text" default="0">
+					<since>
+						<version>22.7.0</version>
+						<version>21.12.0</version>
+						<version>20.17.0</version>
+					</since>
+					<synopsis>DSCP TOS bits for text streams</synopsis>
+					<description><para>
+						See https://docs.asterisk.org/Configuration/Channel-Drivers/IP-Quality-of-Service for more information about QoS settings
+					</para></description>
+				</configOption>
+				<configOption name="cos_text" default="0">
+					<since>
+						<version>22.7.0</version>
+						<version>21.12.0</version>
+						<version>20.17.0</version>
+					</since>
+					<synopsis>Priority for text streams</synopsis>
+					<description><para>
+						See https://docs.asterisk.org/Configuration/Channel-Drivers/IP-Quality-of-Service for more information about QoS settings
+					</para></description>
+				</configOption>
 				<configOption name="direct_media_method" default="invite">
 					<since>
 						<version>12.2.0</version>

--- a/res/res_pjsip/pjsip_config.xml
+++ b/res/res_pjsip/pjsip_config.xml
@@ -450,9 +450,10 @@
 				</configOption>
 				<configOption name="max_text_streams" default="1">
 					<since>
-						<version>22.7.0</version>
-						<version>21.12.0</version>
-						<version>20.17.0</version>
+						<version>23.5.0</version>
+						<version>22.11.0</version>
+						<version>21.13.0</version>
+						<version>20.21.0</version>
 					</since>
 					<synopsis>
 						Maximum number of text streams
@@ -467,9 +468,10 @@
 				</configOption>
 				<configOption name="tos_text" default="0">
 					<since>
-						<version>22.7.0</version>
-						<version>21.12.0</version>
-						<version>20.17.0</version>
+						<version>23.5.0</version>
+						<version>22.11.0</version>
+						<version>21.13.0</version>
+						<version>20.21.0</version>
 					</since>
 					<synopsis>DSCP TOS bits for text streams</synopsis>
 					<description><para>
@@ -478,9 +480,10 @@
 				</configOption>
 				<configOption name="cos_text" default="0">
 					<since>
-						<version>22.7.0</version>
-						<version>21.12.0</version>
-						<version>20.17.0</version>
+						<version>23.5.0</version>
+						<version>22.11.0</version>
+						<version>21.13.0</version>
+						<version>20.21.0</version>
 					</since>
 					<synopsis>Priority for text streams</synopsis>
 					<description><para>

--- a/res/res_pjsip/pjsip_config.xml
+++ b/res/res_pjsip/pjsip_config.xml
@@ -452,7 +452,6 @@
 					<since>
 						<version>23.5.0</version>
 						<version>22.11.0</version>
-						<version>21.13.0</version>
 						<version>20.21.0</version>
 					</since>
 					<synopsis>
@@ -470,7 +469,6 @@
 					<since>
 						<version>23.5.0</version>
 						<version>22.11.0</version>
-						<version>21.13.0</version>
 						<version>20.21.0</version>
 					</since>
 					<synopsis>DSCP TOS bits for text streams</synopsis>
@@ -482,7 +480,6 @@
 					<since>
 						<version>23.5.0</version>
 						<version>22.11.0</version>
-						<version>21.13.0</version>
 						<version>20.21.0</version>
 					</since>
 					<synopsis>Priority for text streams</synopsis>

--- a/res/res_pjsip/pjsip_configuration.c
+++ b/res/res_pjsip/pjsip_configuration.c
@@ -1168,6 +1168,8 @@ static int tos_handler(const struct aco_option *opt,
 		endpoint->media.tos_audio = value;
 	} else if (!strcmp(var->name, "tos_video")) {
 		endpoint->media.tos_video = value;
+	} else if (!strcmp(var->name, "tos_text")) {
+		endpoint->media.tos_text = value;
 	} else {
 		/* If we reach this point, someone called the tos_handler when they shouldn't have. */
 		ast_assert(0);
@@ -1191,6 +1193,16 @@ static int tos_video_to_str(const void *obj, const intptr_t *args, char **buf)
 	const struct ast_sip_endpoint *endpoint = obj;
 
 	if (ast_asprintf(buf, "%u", endpoint->media.tos_video) == -1) {
+		return -1;
+	}
+	return 0;
+}
+
+static int tos_text_to_str(const void *obj, const intptr_t *args, char **buf)
+{
+	const struct ast_sip_endpoint *endpoint = obj;
+
+	if (ast_asprintf(buf, "%u", endpoint->media.tos_text) == -1) {
 		return -1;
 	}
 	return 0;
@@ -2355,8 +2367,10 @@ int ast_res_pjsip_initialize_configuration(void)
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "sdp_session", "Asterisk", OPT_STRINGFIELD_T, 0, STRFLDSET(struct ast_sip_endpoint, media.sdpsession));
 	ast_sorcery_object_field_register_custom(sip_sorcery, "endpoint", "tos_audio", "0", tos_handler, tos_audio_to_str, NULL, 0, 0);
 	ast_sorcery_object_field_register_custom(sip_sorcery, "endpoint", "tos_video", "0", tos_handler, tos_video_to_str, NULL, 0, 0);
+	ast_sorcery_object_field_register_custom(sip_sorcery, "endpoint", "tos_text", "0", tos_handler, tos_text_to_str, NULL, 0, 0);
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "cos_audio", "0", OPT_UINT_T, 0, FLDSET(struct ast_sip_endpoint, media.cos_audio));
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "cos_video", "0", OPT_UINT_T, 0, FLDSET(struct ast_sip_endpoint, media.cos_video));
+	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "cos_text", "0", OPT_UINT_T, 0, FLDSET(struct ast_sip_endpoint, media.cos_text));
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "allow_subscribe", "yes", OPT_BOOL_T, 1, FLDSET(struct ast_sip_endpoint, subscription.allow));
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "sub_min_expiry", "0", OPT_UINT_T, 0, FLDSET(struct ast_sip_endpoint, subscription.minexpiry));
 	ast_sorcery_object_field_register_custom(sip_sorcery, "endpoint", "from_user", "", from_user_handler, from_user_to_str, NULL, 0, 0);
@@ -2398,6 +2412,7 @@ int ast_res_pjsip_initialize_configuration(void)
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "notify_early_inuse_ringing", "no", OPT_BOOL_T, 1, FLDSET(struct ast_sip_endpoint, notify_early_inuse_ringing));
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "max_audio_streams", "1", OPT_UINT_T, 0, FLDSET(struct ast_sip_endpoint, media.max_audio_streams));
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "max_video_streams", "1", OPT_UINT_T, 0, FLDSET(struct ast_sip_endpoint, media.max_video_streams));
+	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "max_text_streams", "1", OPT_UINT_T, 0, FLDSET(struct ast_sip_endpoint, media.max_text_streams));
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "bundle", "no", OPT_BOOL_T, 1, FLDSET(struct ast_sip_endpoint, media.bundle));
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "webrtc", "no", OPT_YESNO_T, 1, FLDSET(struct ast_sip_endpoint, media.webrtc));
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "incoming_mwi_mailbox", "", OPT_STRINGFIELD_T, 0, STRFLDSET(struct ast_sip_endpoint, incoming_mwi_mailbox));

--- a/res/res_pjsip/pjsip_manager.xml
+++ b/res/res_pjsip/pjsip_manager.xml
@@ -503,11 +503,17 @@
 				<parameter name="TosVideo">
 					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='tos_video']/synopsis/node())"/></para>
 				</parameter>
+				<parameter name="TosText">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='tos_text']/synopsis/node())"/></para>
+				</parameter>
 				<parameter name="CosAudio">
 					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='cos_audio']/synopsis/node())"/></para>
 				</parameter>
 				<parameter name="CosVideo">
 					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='cos_video']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="CosText">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='cos_text']/synopsis/node())"/></para>
 				</parameter>
 				<parameter name="AllowSubscribe">
 					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='allow_subscribe']/synopsis/node())"/></para>
@@ -649,6 +655,9 @@
 				</parameter>
 				<parameter name="MaxAudioStreams">
 					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='max_audio_streams']/synopsis/node())"/></para>
+				</parameter>
+				<parameter name="MaxTextStreams">
+					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='max_text_streams']/synopsis/node())"/></para>
 				</parameter>
 				<parameter name="MaxVideoStreams">
 					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip']/configFile[@name='pjsip.conf']/configObject[@name='endpoint']/configOption[@name='max_video_streams']/synopsis/node())"/></para>

--- a/res/res_pjsip_sdp_rtp.c
+++ b/res/res_pjsip_sdp_rtp.c
@@ -2174,7 +2174,7 @@ static int create_outgoing_sdp_stream(struct ast_sip_session *session, struct as
 	}
 
 	/* Add non-codec formats */
-	if (ast_sip_session_is_pending_stream_default(session, stream) && media_type != AST_MEDIA_TYPE_VIDEO
+	if (ast_sip_session_is_pending_stream_default(session, stream) && media_type == AST_MEDIA_TYPE_AUDIO
 		&& media->desc.fmt_count < PJMEDIA_MAX_SDP_FMT) {
 		for (index = 1LL; index <= AST_RTP_MAX; index <<= 1) {
 			if (!(noncodec & index)) {

--- a/res/res_pjsip_sdp_rtp.c
+++ b/res/res_pjsip_sdp_rtp.c
@@ -67,6 +67,7 @@ static struct ast_sockaddr address_rtp;
 
 static const char STR_AUDIO[] = "audio";
 static const char STR_VIDEO[] = "video";
+static const char STR_TEXT[] = "text";
 
 static int send_keepalive(const void *data)
 {
@@ -306,6 +307,10 @@ static int create_rtp(struct ast_sip_session *session, struct ast_sip_session_me
 			(session->endpoint->media.tos_audio || session->endpoint->media.cos_audio)) {
 		ast_rtp_instance_set_qos(session_media->rtp, session->endpoint->media.tos_audio,
 				session->endpoint->media.cos_audio, "SIP RTP Audio");
+	} else if (session_media->type == AST_MEDIA_TYPE_TEXT &&
+			(session->endpoint->media.tos_text || session->endpoint->media.cos_text)) {
+		ast_rtp_instance_set_qos(session_media->rtp, session->endpoint->media.tos_text,
+				session->endpoint->media.cos_text, "SIP RTP Text");
 	} else if (session_media->type == AST_MEDIA_TYPE_VIDEO) {
 		ast_rtp_instance_set_prop(session_media->rtp, AST_RTP_PROPERTY_RETRANS_RECV, session->endpoint->media.webrtc);
 		ast_rtp_instance_set_prop(session_media->rtp, AST_RTP_PROPERTY_RETRANS_SEND, session->endpoint->media.webrtc);
@@ -389,7 +394,6 @@ static void get_codecs(struct ast_sip_session *session, const struct pjmedia_sdp
 				struct ast_format *format_parsed;
 
 				ast_copy_pj_str(fmt_param, &fmtp.fmt_param, sizeof(fmt_param));
-
 				format_parsed = ast_format_parse_sdp_fmtp(format, fmt_param);
 				if (format_parsed) {
 					ast_rtp_codecs_payload_replace_format(codecs, num, format_parsed);
@@ -472,6 +476,41 @@ static int apply_cap_to_bundled(struct ast_sip_session_media *session_media,
 	return 0;
 }
 
+static struct ast_format_cap *get_incoming_call_offer_cap(
+	struct ast_sip_session *session, struct ast_sip_session_media *session_media,
+	const struct pjmedia_sdp_media *stream)
+{
+	struct ast_format_cap *incoming_call_offer_cap;
+	struct ast_format_cap *remote;
+	struct ast_rtp_codecs codecs = AST_RTP_CODECS_NULL_INIT;
+	SCOPE_ENTER(1, "%s\n", ast_sip_session_get_name(session));
+
+	remote = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
+	if (!remote) {
+		ast_log(LOG_ERROR, "Failed to allocate %s incoming remote capabilities\n",
+				ast_codec_media_type2str(session_media->type));
+		SCOPE_EXIT_RTN_VALUE(NULL, "Couldn't allocate caps\n");
+	}
+
+	/* Get the peer's capabilities*/
+	get_codecs(session, stream, &codecs, session_media, remote);
+
+	incoming_call_offer_cap = ast_sip_session_create_joint_call_cap(
+		session, session_media->type, remote);
+
+	ao2_ref(remote, -1);
+
+	if (!incoming_call_offer_cap || ast_format_cap_empty(incoming_call_offer_cap)) {
+		ao2_cleanup(incoming_call_offer_cap);
+		ast_rtp_codecs_payloads_destroy(&codecs);
+		SCOPE_EXIT_RTN_VALUE(NULL, "No incoming call offer caps\n");
+	}
+
+	ast_rtp_codecs_payloads_destroy(&codecs);
+
+	SCOPE_EXIT_RTN_VALUE(incoming_call_offer_cap);
+}
+
 static struct ast_format_cap *set_incoming_call_offer_cap(
 	struct ast_sip_session *session, struct ast_sip_session_media *session_media,
 	const struct pjmedia_sdp_media *stream)
@@ -489,7 +528,7 @@ static struct ast_format_cap *set_incoming_call_offer_cap(
 		SCOPE_EXIT_RTN_VALUE(NULL, "Couldn't allocate caps\n");
 	}
 
-	/* Get the peer's capabilities*/
+	/* Get the peer's capabilities */
 	get_codecs(session, stream, &codecs, session_media, remote);
 
 	incoming_call_offer_cap = ast_sip_session_create_joint_call_cap(
@@ -1555,6 +1594,46 @@ static void set_session_media_remotely_held(struct ast_sip_session_media *sessio
 	}
 }
 
+
+/*! \brief Function which checks for RED in a session and initialize it if needed */
+static void check_red_support(struct ast_sip_session *session, struct ast_sip_session_media *session_media,
+	struct ast_format *format_parsed)
+{
+	/*
+	 * To keep API compatibility, we are using an array here, even if the red codec
+	 * is using only an integer internally, similar as the other codec attributes.
+	 * The rtp red support from asterisk expect the primary payload also added to
+	 * the array, therefore we need one more element.
+	 */
+	int red_pt_array[AST_RED_MAX_GENERATION+1];
+	memset(red_pt_array, 0, sizeof(red_pt_array));
+
+	if (!session || !session_media || !format_parsed) {
+		ast_log(LOG_ERROR, "Could not initialize RED codec support needed for real-time text on session %s\n",
+			ast_sip_session_get_name(session));
+		return;
+	}
+
+	if (ast_format_cap_has_type(session->endpoint->media.codecs, AST_MEDIA_TYPE_TEXT)) {
+		if (ast_format_attribute_get(format_parsed, "red_payload") != NULL &&
+				strcasecmp(ast_format_get_name(format_parsed), "RED") == 0) {
+			int red_payload = *(int*)ast_format_attribute_get(format_parsed, "red_payload");
+			int red_num_gen = *(int*)ast_format_attribute_get(format_parsed, "red_num_gen");
+			if (red_payload != -1 && red_num_gen != -1) {
+				for (int x = 0; x < red_num_gen+1; x++) {
+					red_pt_array[x] = red_payload;
+				}
+				if (ast_rtp_red_init(session_media->rtp, 300, red_pt_array, red_num_gen) < 0) {
+					ast_log(LOG_ERROR, "Failed to initialize RED on rtp instance for real-time text on session %s\n",
+						ast_sip_session_get_name(session));
+				}
+			}
+			ast_debug(3, "RED init success for session %s with %d payload and %d generations\n",
+				ast_sip_session_get_name(session), red_payload, red_num_gen);
+		}
+	}
+}
+
 /*! \brief Function which negotiates an incoming media stream */
 static int negotiate_incoming_sdp_stream(struct ast_sip_session *session,
 	struct ast_sip_session_media *session_media, const pjmedia_sdp_session *sdp,
@@ -1825,6 +1904,8 @@ static int create_outgoing_sdp_stream(struct ast_sip_session *session, struct as
 	AST_VECTOR(, int) sample_rates;
 	/* In case we can't init the sample rates, still try to do the rest. */
 	int build_dtmf_sample_rates = 1;
+	/* Temporary store the t140 payload for redundant text payload adaptations */
+	int t140_payload = 0;
 
 	SCOPE_ENTER(1, "%s Type: %s %s\n", ast_sip_session_get_name(session),
 		ast_codec_media_type2str(media_type), ast_str_tmp(128, ast_stream_to_str(stream, &STR_TMP)));
@@ -1983,6 +2064,28 @@ static int create_outgoing_sdp_stream(struct ast_sip_session *session, struct as
 		build_dtmf_sample_rates = 0;
 	}
 
+	/* if we are using text with rtp redundancy, we need to match the t140 payload inside the RED sdp */
+	for (index = 0; index < ast_format_cap_count(caps); ++index) {
+		struct ast_format *format = ast_format_cap_get_format(caps, index);
+		if (ast_format_get_type(format) == AST_MEDIA_TYPE_TEXT && strcasecmp(ast_format_get_name(format), "T140") == 0) {
+			if (session_media_transport != session_media) {
+				if ((rtp_code = ast_rtp_codecs_payload_code(ast_rtp_instance_get_codecs(session_media_transport->rtp), 1, format, 0)) == -1) {
+					ast_log(LOG_WARNING, "Unable to get rtp codec payload code for %s\n", ast_format_get_name(format));
+					ao2_ref(format, -1);
+					continue;
+				}
+			} else {
+				if ((rtp_code = ast_rtp_codecs_payload_code(ast_rtp_instance_get_codecs(session_media->rtp), 1, format, 0)) == -1) {
+					ast_log(LOG_WARNING, "Unable to get rtp codec payload code for %s\n", ast_format_get_name(format));
+					ao2_ref(format, -1);
+					continue;
+				}
+			}
+			t140_payload = rtp_code;
+			ast_debug(3, "Got t140 payload %d for session %s\n", t140_payload, ast_sip_session_get_name(session));
+		}
+	}
+
 	for (index = 0; index < ast_format_cap_count(caps); ++index) {
 		struct ast_format *format = ast_format_cap_get_format(caps, index);
 
@@ -2020,6 +2123,16 @@ static int create_outgoing_sdp_stream(struct ast_sip_session *session, struct as
 			}
 		}
 
+		/* if we are using text with rtp redundancy, we need to match the t140 payload inside the RED sdp */
+		if (ast_format_get_type(format) == AST_MEDIA_TYPE_TEXT && strncasecmp(ast_format_get_name(format), "RED", 3) == 0) {
+			if (ast_format_attribute_get(format, "red_payload") != NULL &&
+					 (*(int *)ast_format_attribute_get(format, "red_payload") != t140_payload)) {
+				char tmp[10];
+				snprintf(tmp, 10, "%d", t140_payload);
+				format = ast_format_attribute_set(format, "red_payload", tmp);
+				ast_debug(3, "Set RED payload to %s\n", tmp);
+			}
+		}
 		if ((attr = generate_rtpmap_attr(session, media, pool, rtp_code, 1, format, 0))) {
 			int i, added = 0;
 			int newrate = ast_rtp_lookup_sample_rate2(1, format, 0);
@@ -2240,6 +2353,8 @@ static int apply_negotiated_sdp_stream(struct ast_sip_session *session,
 	int res;
 	int rtp_timeout;
 	struct ast_sip_session_media *session_media_transport;
+	struct ast_format_cap *joint;
+	struct ast_format *format_parsed;
 	SCOPE_ENTER(1, "%s Stream: %s\n", ast_sip_session_get_name(session),
 		ast_str_tmp(128, ast_stream_to_str(asterisk_stream, &STR_TMP)));
 
@@ -2312,6 +2427,17 @@ static int apply_negotiated_sdp_stream(struct ast_sip_session *session,
 
 	if (set_caps(session, session_media, session_media_transport, remote_stream, 0, asterisk_stream)) {
 		SCOPE_EXIT_RTN_VALUE(-1, "set_caps failed\n");
+	}
+
+	joint = get_incoming_call_offer_cap(session, session_media, remote_stream);
+	if (joint) {
+		/* If RED support is enabled we need to set it up */
+		format_parsed = ast_format_cap_get_compatible_format(joint, ast_format_t140_red);
+		if (format_parsed) {
+			check_red_support(session, session_media, format_parsed);
+			ao2_ref(format_parsed, -1);
+		}
+		ao2_ref(joint, -1);
 	}
 
 	/* Set the channel uniqueid on the RTP instance now that it is becoming active */
@@ -2468,6 +2594,17 @@ static struct ast_sip_session_sdp_handler video_sdp_handler = {
 	.stream_destroy = stream_destroy,
 };
 
+/*! \brief SDP handler for 'text' media stream */
+static struct ast_sip_session_sdp_handler text_sdp_handler = {
+	.id = STR_TEXT,
+	.negotiate_incoming_sdp_stream = negotiate_incoming_sdp_stream,
+	.create_outgoing_sdp_stream = create_outgoing_sdp_stream,
+	.apply_negotiated_sdp_stream = apply_negotiated_sdp_stream,
+	.change_outgoing_sdp_stream_media_address = change_outgoing_sdp_stream_media_address,
+	.stream_stop = stream_stop,
+	.stream_destroy = stream_destroy,
+};
+
 static int video_info_incoming_request(struct ast_sip_session *session, struct pjsip_rx_data *rdata)
 {
 	struct pjsip_transaction *tsx;
@@ -2501,6 +2638,7 @@ static int unload_module(void)
 	ast_sip_session_unregister_supplement(&video_info_supplement);
 	ast_sip_session_unregister_sdp_handler(&video_sdp_handler, STR_VIDEO);
 	ast_sip_session_unregister_sdp_handler(&audio_sdp_handler, STR_AUDIO);
+	ast_sip_session_unregister_sdp_handler(&text_sdp_handler, STR_TEXT);
 
 	if (sched) {
 		ast_sched_context_destroy(sched);
@@ -2544,6 +2682,11 @@ static int load_module(void)
 
 	if (ast_sip_session_register_sdp_handler(&video_sdp_handler, STR_VIDEO)) {
 		ast_log(LOG_ERROR, "Unable to register SDP handler for %s stream type\n", STR_VIDEO);
+		goto end;
+	}
+
+	if (ast_sip_session_register_sdp_handler(&text_sdp_handler, STR_TEXT)) {
+		ast_log(LOG_ERROR, "Unable to register SDP handler for %s stream type\n", STR_TEXT);
 		goto end;
 	}
 

--- a/res/res_pjsip_sdp_rtp.c
+++ b/res/res_pjsip_sdp_rtp.c
@@ -1619,7 +1619,12 @@ static void check_red_support(struct ast_sip_session *session, struct ast_sip_se
 				strcasecmp(ast_format_get_name(format_parsed), "RED") == 0) {
 			int red_payload = *(int*)ast_format_attribute_get(format_parsed, "red_payload");
 			int red_num_gen = *(int*)ast_format_attribute_get(format_parsed, "red_num_gen");
-			if (red_payload != -1 && red_num_gen != -1) {
+			/* Already checked in the red sdp parser, just to be save */
+			if (red_num_gen > AST_RED_MAX_GENERATION) {
+				ast_log(LOG_ERROR, "Number of generations %d exceeded on session %s\n",
+					red_num_gen, ast_sip_session_get_name(session));
+
+			} else if (red_payload != -1 && red_num_gen != -1) {
 				for (int x = 0; x < red_num_gen+1; x++) {
 					red_pt_array[x] = red_payload;
 				}

--- a/res/res_pjsip_sdp_rtp.c
+++ b/res/res_pjsip_sdp_rtp.c
@@ -2089,6 +2089,7 @@ static int create_outgoing_sdp_stream(struct ast_sip_session *session, struct as
 			t140_payload = rtp_code;
 			ast_debug(3, "Got t140 payload %d for session %s\n", t140_payload, ast_sip_session_get_name(session));
 		}
+		ao2_ref(format, -1);
 	}
 
 	for (index = 0; index < ast_format_cap_count(caps); ++index) {
@@ -2133,8 +2134,15 @@ static int create_outgoing_sdp_stream(struct ast_sip_session *session, struct as
 			if (ast_format_attribute_get(format, "red_payload") != NULL &&
 					 (*(int *)ast_format_attribute_get(format, "red_payload") != t140_payload)) {
 				char tmp[10];
+				struct ast_format *updated_format;
 				snprintf(tmp, 10, "%d", t140_payload);
-				format = ast_format_attribute_set(format, "red_payload", tmp);
+				updated_format = ast_format_attribute_set(format, "red_payload", tmp);
+				if (!updated_format) {
+					ao2_ref(format, -1);
+					continue;
+				}
+				ao2_ref(format, -1);
+				format = updated_format;
 				ast_debug(3, "Set RED payload to %s\n", tmp);
 			}
 		}
@@ -2441,8 +2449,12 @@ static int apply_negotiated_sdp_stream(struct ast_sip_session *session,
 		if (format_parsed) {
 			check_red_support(session, session_media, format_parsed);
 			ao2_ref(format_parsed, -1);
+		} else {
+			ast_rtp_red_init(session_media->rtp, 0, NULL, -1);
 		}
 		ao2_ref(joint, -1);
+	} else {
+		ast_rtp_red_init(session_media->rtp, 0, NULL, -1);
 	}
 
 	/* Set the channel uniqueid on the RTP instance now that it is becoming active */

--- a/res/res_pjsip_sdp_rtp.c
+++ b/res/res_pjsip_sdp_rtp.c
@@ -1601,8 +1601,8 @@ static void check_red_support(struct ast_sip_session *session, struct ast_sip_se
 {
 	/*
 	 * To keep API compatibility, we are using an array here, even if the red codec
-	 * is using only an integer internally, similar as the other codec attributes.
-	 * The rtp red support from asterisk expect the primary payload also added to
+	 * is using only an integer internally - similar to the other codec attributes.
+	 * The rtp red support from Asterisk expects the primary payload to be added to
 	 * the array, therefore we need one more element.
 	 */
 	int red_pt_array[AST_RED_MAX_GENERATION+1];
@@ -1619,7 +1619,7 @@ static void check_red_support(struct ast_sip_session *session, struct ast_sip_se
 				strcasecmp(ast_format_get_name(format_parsed), "RED") == 0) {
 			int red_payload = *(int*)ast_format_attribute_get(format_parsed, "red_payload");
 			int red_num_gen = *(int*)ast_format_attribute_get(format_parsed, "red_num_gen");
-			/* Already checked in the red sdp parser, just to be save */
+			/* Already checked in the red sdp parser, just to be safe */
 			if (red_num_gen > AST_RED_MAX_GENERATION) {
 				ast_log(LOG_ERROR, "Number of generations %d exceeded on session %s\n",
 					red_num_gen, ast_sip_session_get_name(session));

--- a/res/res_pjsip_session.c
+++ b/res/res_pjsip_session.c
@@ -608,8 +608,9 @@ static int is_stream_limitation_reached(enum ast_media_type type, const struct a
 	case AST_MEDIA_TYPE_IMAGE:
 		/* We don't have an option for image (T.38) streams so cap it to one. */
 		return (type_streams[type] > 0);
-	case AST_MEDIA_TYPE_UNKNOWN:
 	case AST_MEDIA_TYPE_TEXT:
+		return !(type_streams[type] < endpoint->media.max_text_streams);
+	case AST_MEDIA_TYPE_UNKNOWN:
 	default:
 		/* We don't want any unknown or "other" streams on our endpoint,
 		 * so always just say we've reached the limit

--- a/res/res_pjsip_session.c
+++ b/res/res_pjsip_session.c
@@ -2441,8 +2441,9 @@ static int sip_session_refresh(struct ast_sip_session *session,
 					SCOPE_EXIT_EXPR(continue);
 				}
 
-				/* Enforce the configured allowed codecs on audio and video streams */
-				if ((ast_stream_get_type(stream) == AST_MEDIA_TYPE_AUDIO || ast_stream_get_type(stream) == AST_MEDIA_TYPE_VIDEO) &&
+				/* Enforce the configured allowed codecs on audio, video and text streams */
+				if ((ast_stream_get_type(stream) == AST_MEDIA_TYPE_AUDIO || ast_stream_get_type(stream) == AST_MEDIA_TYPE_VIDEO
+					|| ast_stream_get_type(stream) == AST_MEDIA_TYPE_TEXT) &&
 					!ast_stream_get_metadata(stream, "pjsip_session_refresh")) {
 					struct ast_format_cap *joint_cap;
 
@@ -2488,7 +2489,6 @@ static int sip_session_refresh(struct ast_sip_session *session,
 				}
 
 				++type_streams[ast_stream_get_type(stream)];
-
 				SCOPE_EXIT();
 			}
 

--- a/res/res_pjsip_session/pjsip_session_caps.c
+++ b/res/res_pjsip_session/pjsip_session_caps.c
@@ -128,30 +128,31 @@ struct ast_format_cap *ast_sip_create_joint_call_cap(const struct ast_format_cap
 }
 
 /*
- * Fix preferences for real time text calls when we are supporting t140 and red codecs
+ * Get preferences for real time text calls when we are supporting t140 and red codecs.
  * If the remote party only supports t140, we should not offer redundancy
  */
-static void fix_t140_red_pref(const struct ast_sip_session *session, enum ast_media_type media_type) {
+static struct ast_flags get_t140_red_pref(const struct ast_sip_session *session, enum ast_media_type media_type) {
 	int res = 0;
-	struct ast_flags *pref = &session->endpoint->media.outgoing_call_offer_pref;
+	struct ast_flags pref = session->endpoint->media.outgoing_call_offer_pref;
 
 	if (media_type == AST_MEDIA_TYPE_TEXT && session->call_direction == AST_SIP_SESSION_OUTGOING_CALL) {
-		if (strcmp(ast_sip_call_codec_pref_to_str(*pref), "local_merge") == 0) {
+		if (strcmp(ast_sip_call_codec_pref_to_str(pref), "local_merge") == 0) {
 			ast_debug(3, "text call with local_merge preference, change to local for endpoint %s\n",
 				ast_sorcery_object_get_id(session->endpoint));
-			res = ast_sip_call_codec_str_to_pref(pref, "local", 1);
+			res = ast_sip_call_codec_str_to_pref(&pref, "local", 1);
 		} else {
-			if (strcmp(ast_sip_call_codec_pref_to_str(*pref), "remote_merge") == 0) {
+			if (strcmp(ast_sip_call_codec_pref_to_str(pref), "remote_merge") == 0) {
 				ast_debug(3, "text call with remote_merge preference, change to remote for endpoint %s\n",
 					ast_sorcery_object_get_id(session->endpoint));
-				res = ast_sip_call_codec_str_to_pref(pref, "remote", 1);
+				res = ast_sip_call_codec_str_to_pref(&pref, "remote", 1);
 			}
 		}
 	}
 	if (res != 0) {
-		ast_log(LOG_ERROR, "Could not fix preferences for real-time text calls for endpoint %s\n",
+		ast_log(LOG_ERROR, "Could not get preferences for real-time text calls for endpoint %s\n",
 			ast_sorcery_object_get_id(session->endpoint));
 	}
+	return pref;
 }
 
 struct ast_stream *ast_sip_session_create_joint_call_stream(const struct ast_sip_session *session,
@@ -161,12 +162,12 @@ struct ast_stream *ast_sip_session_create_joint_call_stream(const struct ast_sip
 	const struct ast_format_cap *remote = ast_stream_get_formats(remote_stream);
 	enum ast_media_type media_type = ast_stream_get_type(remote_stream);
 	struct ast_format_cap *joint;
+	struct ast_flags outgoing_pref = get_t140_red_pref(session, media_type);
 
-	fix_t140_red_pref(session, media_type);
 	joint = ast_sip_create_joint_call_cap(remote,
 		session->endpoint->media.codecs, media_type,
 		session->call_direction == AST_SIP_SESSION_OUTGOING_CALL
-				? session->endpoint->media.outgoing_call_offer_pref
+				? outgoing_pref
 				: session->endpoint->media.incoming_call_offer_pref);
 
 	ast_stream_set_formats(joint_stream, joint);
@@ -182,12 +183,12 @@ struct ast_format_cap *ast_sip_session_create_joint_call_cap(
 	const struct ast_format_cap *remote)
 {
 	struct ast_format_cap *joint;
+	struct ast_flags outgoing_pref = get_t140_red_pref(session, media_type);
 
-	fix_t140_red_pref(session, media_type);
 	joint = ast_sip_create_joint_call_cap(remote,
 		session->endpoint->media.codecs, media_type,
 		session->call_direction == AST_SIP_SESSION_OUTGOING_CALL
-				? session->endpoint->media.outgoing_call_offer_pref
+				? outgoing_pref
 				: session->endpoint->media.incoming_call_offer_pref);
 
 	log_caps(LOG_DEBUG, session, media_type, session->endpoint->media.codecs, remote, joint);

--- a/res/res_rtp_asterisk.c
+++ b/res/res_rtp_asterisk.c
@@ -9269,31 +9269,6 @@ static void ast_rtp_remote_address_set(struct ast_rtp_instance *instance, struct
 	}
 }
 
-/*!
- * \brief Write t140 redundancy frame
- *
- * \param data primary data to be buffered
- *
- * Scheduler callback
- */
-static int red_write(const void *data)
-{
-	struct ast_rtp_instance *instance = (struct ast_rtp_instance *) data;
-	struct ast_rtp *rtp;
-
-	ao2_lock(instance);
-	rtp = ast_rtp_instance_get_data(instance);
-	if (!rtp || !rtp->red) {
-		ao2_unlock(instance);
-		ast_log(LOG_ERROR, "Could not get rtp from instance or RED handler for real-time text\n");
-		return 0;
-	}
-
-	ao2_unlock(instance);
-
-	return 1;
-}
-
 /*! \pre instance is locked */
 static int rtp_red_init(struct ast_rtp_instance *instance, int buffer_time, int *payloads, int generations)
 {
@@ -9321,13 +9296,6 @@ static int rtp_red_init(struct ast_rtp_instance *instance, int buffer_time, int 
 		rtp->red->t140red_data[x*4] = rtp->red->pt[x];
 	}
 	rtp->red->t140red_data[x*4] = rtp->red->pt[x] = payloads[x]; /* primary pt */
-	ao2_ref(instance, +1);
-	rtp->red->schedid = ast_sched_add(rtp->sched, buffer_time, red_write, instance);
-	if (rtp->red->schedid < 0) {
-		ao2_ref(instance, -1);
-		ast_log(LOG_WARNING, "scheduling red_write for real-time text failed for stream %s\n",
-			 ast_rtp_instance_get_cname(instance));
-	}
 	ast_debug(3, "Init RED for stream %s, primary payload %d with %d generations\n",
 		ast_rtp_instance_get_cname(instance), payloads[x], generations);
 

--- a/res/res_rtp_asterisk.c
+++ b/res/res_rtp_asterisk.c
@@ -7470,8 +7470,13 @@ static int bridge_p2p_rtp_write(struct ast_rtp_instance *instance,
 		int is_text = payload_type->asterisk_format
 				&& payload_type->format
 				&& ast_format_get_type(payload_type->format) == AST_MEDIA_TYPE_TEXT;
-		ast_debug_rtp(5, "(%p, %p) RTP remote address is null, most likely RTP has been stopped\n",
-			instance, instance1);
+		if (is_text) {
+			ast_debug_rtp(5, "(%p, %p) RTP remote address is null, audio RTP is probably stopped while text is still active\n",
+				instance, instance1);
+		} else {
+			ast_debug_rtp(5, "(%p, %p) RTP remote address is null, most likely RTP has been stopped\n",
+				instance, instance1);
+		}
 		ao2_unlock(instance1);
 		ao2_lock(instance);
 		return is_text ? -1 : 0;

--- a/res/res_rtp_asterisk.c
+++ b/res/res_rtp_asterisk.c
@@ -624,9 +624,10 @@ struct ast_rtcp {
 struct rtp_red {
 	struct ast_frame t140;  /*!< Primary data  */
 	struct ast_frame t140red;   /*!< Redundant t140*/
-	unsigned char pt[AST_RED_MAX_GENERATION];  /*!< Payload types for redundancy data */
-	unsigned char ts[AST_RED_MAX_GENERATION]; /*!< Time stamps */
-	unsigned char len[AST_RED_MAX_GENERATION]; /*!< length of each generation */
+	/* We are encoding the primary payload type also in this array, so we need one more element */
+	unsigned char pt[AST_RED_MAX_GENERATION+1];  /*!< Payload types for redundancy data */
+	unsigned char ts[AST_RED_MAX_GENERATION+1]; /*!< Time stamps */
+	unsigned char len[AST_RED_MAX_GENERATION+1]; /*!< length of each generation */
 	int num_gen; /*!< Number of generations */
 	int schedid; /*!< Timer id */
 	unsigned char t140red_data[64000];
@@ -5717,7 +5718,7 @@ static int ast_rtp_write(struct ast_rtp_instance *instance, struct ast_frame *fr
 	}
 
 	if (rtp->red) {
-		/* return 0; */
+		ast_rtp_red_buffer(instance, frame);
 		/* no primary data or generations to send */
 		if ((frame = red_t140_to_red(rtp->red)) == NULL)
 			return 0;
@@ -8146,9 +8147,11 @@ static struct ast_frame *ast_rtp_interpret(struct ast_rtp_instance *instance, st
 		*data = 0xBD;
 	}
 
-	if (ast_format_cmp(rtp->f.subclass.format, ast_format_t140_red) == AST_FORMAT_CMP_EQUAL) {
-		unsigned char *data = rtp->f.data.ptr;
-		unsigned char *header_end;
+	if (rtp->f.datalen <= 0) {
+		return AST_LIST_FIRST(&frames) ? AST_LIST_FIRST(&frames) : &ast_null_frame;
+	} else if (ast_format_cmp(rtp->f.subclass.format, ast_format_t140_red) == AST_FORMAT_CMP_EQUAL) {
+		unsigned char* data = rtp->f.data.ptr;
+		unsigned char* header_end;
 		int num_generations;
 		int header_length;
 		int len;
@@ -8190,6 +8193,9 @@ static struct ast_frame *ast_rtp_interpret(struct ast_rtp_instance *instance, st
 
 			rtp->f.data.ptr += len;
 			rtp->f.datalen -= len;
+		}
+		if (rtp->f.datalen < 0) {
+			return AST_LIST_FIRST(&frames) ? AST_LIST_FIRST(&frames) : &ast_null_frame;
 		}
 	}
 
@@ -9268,13 +9274,17 @@ static void ast_rtp_remote_address_set(struct ast_rtp_instance *instance, struct
  */
 static int red_write(const void *data)
 {
-	struct ast_rtp_instance *instance = (struct ast_rtp_instance*) data;
-	struct ast_rtp *rtp = ast_rtp_instance_get_data(instance);
+	struct ast_rtp_instance *instance = (struct ast_rtp_instance *) data;
+	struct ast_rtp *rtp;
 
 	ao2_lock(instance);
-	if (rtp->red->t140.datalen > 0) {
-		ast_rtp_write(instance, &rtp->red->t140);
+	rtp = ast_rtp_instance_get_data(instance);
+	if (!rtp || !rtp->red) {
+		ao2_unlock(instance);
+		ast_log(LOG_ERROR, "Could not get rtp from instance or RED handler for real-time text\n");
+		return 0;
 	}
+
 	ao2_unlock(instance);
 
 	return 1;
@@ -9307,7 +9317,15 @@ static int rtp_red_init(struct ast_rtp_instance *instance, int buffer_time, int 
 		rtp->red->t140red_data[x*4] = rtp->red->pt[x];
 	}
 	rtp->red->t140red_data[x*4] = rtp->red->pt[x] = payloads[x]; /* primary pt */
+	ao2_ref(instance, +1);
 	rtp->red->schedid = ast_sched_add(rtp->sched, buffer_time, red_write, instance);
+	if (rtp->red->schedid < 0) {
+		ao2_ref(instance, -1);
+		ast_log(LOG_WARNING, "scheduling red_write for real-time text failed for stream %s\n",
+			 ast_rtp_instance_get_cname(instance));
+	}
+	ast_debug(3, "Init RED for stream %s, primary payload %d with %d generations\n",
+		ast_rtp_instance_get_cname(instance), payloads[x], generations);
 
 	return 0;
 }
@@ -9332,6 +9350,14 @@ static int rtp_red_buffer(struct ast_rtp_instance *instance, struct ast_frame *f
 		int space_available = 0;
 
 		if (red->t140.datalen > 0) {
+			/*
+			* Avoid merging command and regular T.140 text packets by flushing the
+			* previous T.140 packets. When realtime text packets are to be sent, the
+			* text is accumulated in a buffer and sent regularly by a timer.  It can
+			* happen that commands such as a backspace, CR, or LF get merged with
+			* regular text. This breaks some UAs. In recent tests it could not be
+			* reproduced, but its probably better to keep it.
+			*/
 			const unsigned char *primary = red->buf_data;
 
 			/* There is something already in the T.140 buffer */
@@ -9543,9 +9569,11 @@ static void ast_rtp_stop(struct ast_rtp_instance *instance)
 		rtp->transport_wide_cc.schedid = -1;
         }
 
-	if (rtp->red) {
+	if (rtp->red && rtp->red->schedid > -1) {
 		ao2_unlock(instance);
-		AST_SCHED_DEL(rtp->sched, rtp->red->schedid);
+		if (!ast_sched_del(rtp->sched, rtp->red->schedid)) {
+			ao2_ref(instance, -1);
+		}
 		ao2_lock(instance);
 		ast_free(rtp->red);
 		rtp->red = NULL;

--- a/res/res_rtp_asterisk.c
+++ b/res/res_rtp_asterisk.c
@@ -7467,11 +7467,14 @@ static int bridge_p2p_rtp_write(struct ast_rtp_instance *instance,
 	ast_rtp_instance_get_remote_address(instance1, &remote_address);
 
 	if (ast_sockaddr_isnull(&remote_address)) {
+		int is_text = payload_type->asterisk_format
+				&& payload_type->format
+				&& ast_format_get_type(payload_type->format) == AST_MEDIA_TYPE_TEXT;
 		ast_debug_rtp(5, "(%p, %p) RTP remote address is null, most likely RTP has been stopped\n",
 			instance, instance1);
 		ao2_unlock(instance1);
 		ao2_lock(instance);
-		return 0;
+		return is_text ? -1 : 0;
 	}
 
 	/* If the marker bit has been explicitly set turn it on */

--- a/res/res_rtp_asterisk.c
+++ b/res/res_rtp_asterisk.c
@@ -9269,6 +9269,31 @@ static void ast_rtp_remote_address_set(struct ast_rtp_instance *instance, struct
 	}
 }
 
+/*!
+ * \brief Write t140 redundancy frame
+ *
+ * \param data primary data to be buffered
+ *
+ * Scheduler callback
+ */
+static int red_write(const void *data)
+{
+	struct ast_rtp_instance *instance = (struct ast_rtp_instance *) data;
+	struct ast_rtp *rtp;
+
+	ao2_lock(instance);
+	rtp = ast_rtp_instance_get_data(instance);
+	if (!rtp || !rtp->red) {
+		ao2_unlock(instance);
+		ast_log(LOG_ERROR, "Could not get rtp from instance or RED handler for real-time text\n");
+		return 0;
+	}
+
+	ao2_unlock(instance);
+
+	return 1;
+}
+
 /*! \pre instance is locked */
 static int rtp_red_init(struct ast_rtp_instance *instance, int buffer_time, int *payloads, int generations)
 {
@@ -9296,6 +9321,13 @@ static int rtp_red_init(struct ast_rtp_instance *instance, int buffer_time, int 
 		rtp->red->t140red_data[x*4] = rtp->red->pt[x];
 	}
 	rtp->red->t140red_data[x*4] = rtp->red->pt[x] = payloads[x]; /* primary pt */
+	ao2_ref(instance, +1);
+	rtp->red->schedid = ast_sched_add(rtp->sched, buffer_time, red_write, instance);
+	if (rtp->red->schedid < 0) {
+		ao2_ref(instance, -1);
+		ast_log(LOG_WARNING, "scheduling red_write for real-time text failed for stream %s\n",
+			 ast_rtp_instance_get_cname(instance));
+	}
 	ast_debug(3, "Init RED for stream %s, primary payload %d with %d generations\n",
 		ast_rtp_instance_get_cname(instance), payloads[x], generations);
 

--- a/res/res_rtp_asterisk.c
+++ b/res/res_rtp_asterisk.c
@@ -8157,47 +8157,65 @@ static struct ast_frame *ast_rtp_interpret(struct ast_rtp_instance *instance, st
 		*data = 0xBD;
 	} else if (ast_format_cmp(rtp->f.subclass.format, ast_format_t140_red) == AST_FORMAT_CMP_EQUAL) {
 		unsigned char *data = rtp->f.data.ptr;
-		unsigned char *header_end;
+		unsigned char *data_end = data + rtp->f.datalen;
+		unsigned char *header_end = data;
+		unsigned char *block_length;
 		int num_generations;
 		int header_length;
 		int len;
-		int diff =(int)seqno - (prev_seqno+1); /* if diff = 0, no drop*/
-		int x;
+		int diff = ((int)seqno - (prev_seqno + 1)) & 0xffff; /* if diff equals 0, no drop */
 
-		ast_debug(2, "processing RED with %d bytes\n", rtp->f.datalen);
+		ast_debug(2, "processing T140 RED with %d bytes\n", rtp->f.datalen);
+		/* format ast_format_t140_red became ast_format_t140 */
 		ao2_replace(rtp->f.subclass.format, ast_format_t140);
-		header_end = memchr(data, ((*data) & 0x7f), rtp->f.datalen);
-		if (header_end == NULL) {
+		/*
+		 * RFC 2198 - paragraph 3: | F | block PT | timestamp offset | block length |
+		 * Bit F is zero for the last header block, search it
+		 */
+		while (header_end < data_end && (*header_end & 0x80)) {
+			header_end += 4;
+		}
+		/* If last header not found */
+		if (header_end >= data_end) {
 			return AST_LIST_FIRST(&frames) ? AST_LIST_FIRST(&frames) : &ast_null_frame;
 		}
+		/* Last header len is one: |0| Block PT | */
 		header_end++;
 
 		header_length = header_end - data;
 		num_generations = header_length / 4;
 		len = header_length;
 
-		if (!diff) {
-			for (x = 0; x < num_generations; x++)
-				len += data[x * 4 + 3];
-
-			if (!(rtp->f.datalen - len))
+		if (prev_seqno == 0 || diff == 0 || diff > 10) {
+			/* If starting or successive rtp seqno or the sender cycled => go to current payload */
+			for (block_length = data + 2; block_length < header_end; block_length += 4) {
+				len += ((0x03 & (int)(*block_length)) << 8) + *(block_length + 1); /* 10 bits integer */
+			}
+			if (!(rtp->f.datalen - len)) {
+				/* payload empty */
 				return AST_LIST_FIRST(&frames) ? AST_LIST_FIRST(&frames) : &ast_null_frame;
-
+			}
+			/* set current */
 			rtp->f.data.ptr += len;
 			rtp->f.datalen -= len;
-		} else if (diff > num_generations && diff < 10) {
+		} else if (diff < 0) {
+			/* If packet inversion or redundant => ignore */
+			return AST_LIST_FIRST(&frames) ? AST_LIST_FIRST(&frames) : &ast_null_frame;
+		} else if (diff > num_generations) {
+			/* If too much to fix previous generations */
 			len -= 3;
 			rtp->f.data.ptr += len;
 			rtp->f.datalen -= len;
-
 			data = rtp->f.data.ptr;
 			*data++ = 0xEF;
 			*data++ = 0xBF;
 			*data = 0xBD;
 		} else {
-			for ( x = 0; x < num_generations - diff; x++)
-				len += data[x * 4 + 3];
-
+			/* If can fix (diff) lost packets => go to the (diff)th redundant payload */
+			for (block_length = data + 2; block_length < header_end - diff * 4; block_length += 4) {
+				len += ((0x03 & (int)(*block_length)) << 8) + *(block_length + 1); /* 10 bits integer */
+			}
+			/* set the current and fixing redundant payloads */
 			rtp->f.data.ptr += len;
 			rtp->f.datalen -= len;
 		}

--- a/res/res_rtp_asterisk.c
+++ b/res/res_rtp_asterisk.c
@@ -4414,10 +4414,14 @@ static int ast_rtp_destroy(struct ast_rtp_instance *instance)
 	}
 
 	/* Destroy RED if it was being used */
-	if (rtp->red) {
+	/* only needed for chan_sip compatibility, should be removed after completely getting rid of it */
+	if (rtp->red && rtp->red->schedid > -1) {
 		ao2_unlock(instance);
-		AST_SCHED_DEL(rtp->sched, rtp->red->schedid);
+		if (!AST_SCHED_DEL(rtp->sched, rtp->red->schedid)) {
+			ao2_ref(instance, -1);
+		}
 		ao2_lock(instance);
+		rtp->red->schedid = -1;
 		ast_free(rtp->red);
 		rtp->red = NULL;
 	}

--- a/res/res_rtp_asterisk.c
+++ b/res/res_rtp_asterisk.c
@@ -9272,6 +9272,8 @@ static void ast_rtp_remote_address_set(struct ast_rtp_instance *instance, struct
 /*!
  * \brief Write t140 redundancy frame
  *
+ * Write a t140 redundancy frame,  only needed for chan_sip compatibility,
+ * should be removed after completely getting rid of it
  * \param data primary data to be buffered
  *
  * Scheduler callback
@@ -9288,7 +9290,9 @@ static int red_write(const void *data)
 		ast_log(LOG_ERROR, "Could not get rtp from instance or RED handler for real-time text\n");
 		return 0;
 	}
-
+	if (rtp->red->t140.datalen > 0) {
+		ast_rtp_write(instance, &rtp->red->t140);
+	}
 	ao2_unlock(instance);
 
 	return 1;
@@ -9297,6 +9301,7 @@ static int red_write(const void *data)
 /*! \pre instance is locked */
 static int rtp_red_init(struct ast_rtp_instance *instance, int buffer_time, int *payloads, int generations)
 {
+	const char *chanid;
 	struct ast_rtp *rtp = ast_rtp_instance_get_data(instance);
 	int x;
 
@@ -9321,12 +9326,21 @@ static int rtp_red_init(struct ast_rtp_instance *instance, int buffer_time, int 
 		rtp->red->t140red_data[x*4] = rtp->red->pt[x];
 	}
 	rtp->red->t140red_data[x*4] = rtp->red->pt[x] = payloads[x]; /* primary pt */
-	ao2_ref(instance, +1);
-	rtp->red->schedid = ast_sched_add(rtp->sched, buffer_time, red_write, instance);
-	if (rtp->red->schedid < 0) {
-		ao2_ref(instance, -1);
-		ast_log(LOG_WARNING, "scheduling red_write for real-time text failed for stream %s\n",
-			 ast_rtp_instance_get_cname(instance));
+	/* only needed for chan_sip compatibility, should be removed after completely getting rid of it */
+	chanid = ast_rtp_instance_get_channel_id(instance);
+	if (!ast_strlen_zero(chanid)) {
+		struct ast_channel *chan = ast_channel_get_by_uniqueid(chanid);
+		if (chan && ast_strings_equal(ast_channel_tech(chan)->type, "SIP")) {
+			ast_debug(3, "RED scheduler started for SIP channel\n");
+			ao2_ref(instance, +1);
+			rtp->red->schedid = ast_sched_add(rtp->sched, buffer_time, red_write, instance);
+			if (rtp->red->schedid < 0) {
+				ao2_ref(instance, -1);
+				ast_log(LOG_WARNING, "scheduling red_write for real-time text failed for stream %s\n",
+						ast_rtp_instance_get_cname(instance));
+			}
+		}
+		ao2_cleanup(chan);
 	}
 	ast_debug(3, "Init RED for stream %s, primary payload %d with %d generations\n",
 		ast_rtp_instance_get_cname(instance), payloads[x], generations);

--- a/res/res_rtp_asterisk.c
+++ b/res/res_rtp_asterisk.c
@@ -5706,7 +5706,12 @@ static int ast_rtp_write(struct ast_rtp_instance *instance, struct ast_frame *fr
 	}
 
 	/* If there is no data length we can't very well send the packet */
-	if (!frame->datalen) {
+	if (!frame->datalen && frame->frametype != AST_FRAME_TEXT) {
+		/* RFC 4103:
+		 * When valid T.140 data has been sent and no new T.140 data is
+		* available for transmission after the selected buffering time, an
+		* empty T140block SHOULD be transmitted.
+		*/
 		ast_debug_rtp(1, "(%p) RTP received frame with no data for instance, so dropping frame\n", instance);
 		return 0;
 	}
@@ -8140,24 +8145,22 @@ static struct ast_frame *ast_rtp_interpret(struct ast_rtp_instance *instance, st
 		&& ((int)seqno - (prev_seqno + 1) < 10)) {
 		unsigned char *data = rtp->f.data.ptr;
 
+		ast_debug(2, "processing T140 with %d bytes \n", rtp->f.datalen);
 		memmove(rtp->f.data.ptr+3, rtp->f.data.ptr, rtp->f.datalen);
 		rtp->f.datalen +=3;
 		*data++ = 0xEF;
 		*data++ = 0xBF;
 		*data = 0xBD;
-	}
-
-	if (rtp->f.datalen <= 0) {
-		return AST_LIST_FIRST(&frames) ? AST_LIST_FIRST(&frames) : &ast_null_frame;
 	} else if (ast_format_cmp(rtp->f.subclass.format, ast_format_t140_red) == AST_FORMAT_CMP_EQUAL) {
-		unsigned char* data = rtp->f.data.ptr;
-		unsigned char* header_end;
+		unsigned char *data = rtp->f.data.ptr;
+		unsigned char *header_end;
 		int num_generations;
 		int header_length;
 		int len;
 		int diff =(int)seqno - (prev_seqno+1); /* if diff = 0, no drop*/
 		int x;
 
+		ast_debug(2, "processing RED with %d bytes\n", rtp->f.datalen);
 		ao2_replace(rtp->f.subclass.format, ast_format_t140);
 		header_end = memchr(data, ((*data) & 0x7f), rtp->f.datalen);
 		if (header_end == NULL) {
@@ -8224,6 +8227,7 @@ static struct ast_frame *ast_rtp_interpret(struct ast_rtp_instance *instance, st
 		rtp->f.subclass.frame_ending = mark ? 1 : 0;
 	} else if (ast_format_get_type(rtp->f.subclass.format) == AST_MEDIA_TYPE_TEXT) {
 		/* TEXT -- samples is # of samples vs. 1000 */
+		ast_debug(2, "processing AST_MEDIA_TYPE_TEXT, length %d\n", rtp->f.datalen);
 		if (!rtp->lastitexttimestamp)
 			rtp->lastitexttimestamp = timestamp;
 		rtp->f.samples = timestamp - rtp->lastitexttimestamp;

--- a/res/res_rtp_asterisk.c
+++ b/res/res_rtp_asterisk.c
@@ -9587,6 +9587,7 @@ static void ast_rtp_stop(struct ast_rtp_instance *instance)
 		rtp->transport_wide_cc.schedid = -1;
         }
 
+	/* only needed for chan_sip compatibility, should be removed after completely getting rid of it */
 	if (rtp->red && rtp->red->schedid > -1) {
 		ao2_unlock(instance);
 		if (!ast_sched_del(rtp->sched, rtp->red->schedid)) {

--- a/res/res_rtp_asterisk.c
+++ b/res/res_rtp_asterisk.c
@@ -4415,13 +4415,14 @@ static int ast_rtp_destroy(struct ast_rtp_instance *instance)
 
 	/* Destroy RED if it was being used */
 	/* only needed for chan_sip compatibility, should be removed after completely getting rid of it */
-	if (rtp->red && rtp->red->schedid > -1) {
-		ao2_unlock(instance);
-		if (!AST_SCHED_DEL(rtp->sched, rtp->red->schedid)) {
-			ao2_ref(instance, -1);
+	if (rtp->red) {
+		if (rtp->red->schedid > -1) {
+			ao2_unlock(instance);
+			if (!AST_SCHED_DEL(rtp->sched, rtp->red->schedid)) {
+				ao2_ref(instance, -1);
+			}
+			ao2_lock(instance);
 		}
-		ao2_lock(instance);
-		rtp->red->schedid = -1;
 		ast_free(rtp->red);
 		rtp->red = NULL;
 	}
@@ -7923,6 +7924,54 @@ static void rtp_instance_parse_extmap_extensions(struct ast_rtp_instance *instan
 	}
 }
 
+struct red_payload_layout {
+	size_t header_length; /*!< Combined redundant and primary RED header length. */
+	size_t primary_offset; /*!< Offset of the primary T.140 block in the RED payload. */
+	size_t redundant_length[AST_RED_MAX_GENERATION]; /*!< Length of each redundant block. */
+	size_t redundant_count; /*!< Number of redundant blocks preceding the primary block. */
+};
+
+/* Parse and validate the RFC 2198 RED headers without modifying the packet. */
+static int red_payload_layout_parse(const unsigned char *data, size_t data_length,
+	struct red_payload_layout *layout)
+{
+	size_t offset = 0;
+	size_t payload_offset;
+
+	memset(layout, 0, sizeof(*layout));
+	for (;;) {
+		/* Every header must begin inside the received payload. */
+		if (offset >= data_length) {
+			return -1;
+		}
+		/* F=0 identifies the final one-byte header for the primary block. */
+		if (!(data[offset] & 0x80)) {
+			layout->header_length = ++offset;
+			break;
+		}
+		/* An F=1 redundant header is four bytes and must fit our generation limit. */
+		if (data_length - offset < 4
+			|| layout->redundant_count >= ARRAY_LEN(layout->redundant_length)) {
+			return -1;
+		}
+		/* The redundant block length is the low 10 bits of header bytes two and three. */
+		layout->redundant_length[layout->redundant_count++] =
+			((size_t) (data[offset + 2] & 0x03) << 8) | data[offset + 3];
+		offset += 4;
+	}
+
+	/* Walk the redundant blocks, validating each length and locating the primary block. */
+	payload_offset = layout->header_length;
+	for (offset = 0; offset < layout->redundant_count; ++offset) {
+		if (layout->redundant_length[offset] > data_length - payload_offset) {
+			return -1;
+		}
+		payload_offset += layout->redundant_length[offset];
+	}
+	layout->primary_offset = payload_offset;
+	return 0;
+}
+
 static struct ast_frame *ast_rtp_interpret(struct ast_rtp_instance *instance, struct ast_srtp *srtp,
 	const struct ast_sockaddr *remote_address, unsigned char *read_area, int length, int prev_seqno,
 	unsigned int bundled)
@@ -8165,71 +8214,55 @@ static struct ast_frame *ast_rtp_interpret(struct ast_rtp_instance *instance, st
 		*data = 0xBD;
 	} else if (ast_format_cmp(rtp->f.subclass.format, ast_format_t140_red) == AST_FORMAT_CMP_EQUAL) {
 		unsigned char *data = rtp->f.data.ptr;
-		unsigned char *data_end = data + rtp->f.datalen;
-		unsigned char *header_end = data;
-		unsigned char *block_length;
-		int num_generations;
-		int header_length;
-		int len;
-		int diff = ((int)seqno - (prev_seqno + 1)) & 0xffff; /* if diff equals 0, no drop */
+		struct red_payload_layout layout;
+		size_t payload_offset;
+		size_t payload_length;
+		size_t generation;
+		int diff = (int16_t) ((uint16_t) seqno - (uint16_t) (prev_seqno + 1));
 
 		ast_debug(2, "processing T140 RED with %d bytes\n", rtp->f.datalen);
-		/* format ast_format_t140_red became ast_format_t140 */
 		ao2_replace(rtp->f.subclass.format, ast_format_t140);
-		/*
-		 * RFC 2198 - paragraph 3: | F | block PT | timestamp offset | block length |
-		 * Bit F is zero for the last header block, search it
-		 */
-		while (header_end < data_end && (*header_end & 0x80)) {
-			header_end += 4;
-		}
-		/* If last header not found */
-		if (header_end >= data_end) {
+		if (red_payload_layout_parse(data, rtp->f.datalen, &layout)) {
+			ast_debug_rtp(1, "Dropping malformed T.140 RED packet\n");
 			return AST_LIST_FIRST(&frames) ? AST_LIST_FIRST(&frames) : &ast_null_frame;
 		}
-		/* Last header len is one: |0| Block PT | */
-		header_end++;
-
-		header_length = header_end - data;
-		num_generations = header_length / 4;
-		len = header_length;
 
 		if (prev_seqno == 0 || diff == 0 || diff > 10) {
-			/* If starting or successive rtp seqno or the sender cycled => go to current payload */
-			for (block_length = data + 2; block_length < header_end; block_length += 4) {
-				len += ((0x03 & (int)(*block_length)) << 8) + *(block_length + 1); /* 10 bits integer */
-			}
-			if (!(rtp->f.datalen - len)) {
-				/* payload empty */
-				return AST_LIST_FIRST(&frames) ? AST_LIST_FIRST(&frames) : &ast_null_frame;
-			}
-			/* set current */
-			rtp->f.data.ptr += len;
-			rtp->f.datalen -= len;
+			payload_offset = layout.primary_offset;
 		} else if (diff < 0) {
-			/* If packet inversion or redundant => ignore */
 			return AST_LIST_FIRST(&frames) ? AST_LIST_FIRST(&frames) : &ast_null_frame;
-		} else if (diff > num_generations) {
-			/* If too much to fix previous generations */
-			len -= 3;
-			rtp->f.data.ptr += len;
-			rtp->f.datalen -= len;
-			data = rtp->f.data.ptr;
-			*data++ = 0xEF;
-			*data++ = 0xBF;
-			*data = 0xBD;
-		} else {
-			/* If can fix (diff) lost packets => go to the (diff)th redundant payload */
-			for (block_length = data + 2; block_length < header_end - diff * 4; block_length += 4) {
-				len += ((0x03 & (int)(*block_length)) << 8) + *(block_length + 1); /* 10 bits integer */
+		} else if (diff > layout.redundant_count) {
+			/* The missing packets exceed the available RED generations, so use the primary payload. */
+			payload_offset = layout.primary_offset;
+			payload_length = rtp->f.datalen - payload_offset;
+			if (rtp->f.datalen >= 3 && payload_length <= (size_t) rtp->f.datalen - 3) {
+				/* Move the primary payload forward to make room for the loss marker. */
+				memmove(data + 3, data + payload_offset, payload_length);
+				/* Prefix U+FFFD (UTF-8 EF BF BD) to mark text lost beyond RED recovery. */
+				data[0] = 0xEF;
+				data[1] = 0xBF;
+				data[2] = 0xBD;
+				rtp->f.data.ptr = data;
+				rtp->f.datalen = payload_length + 3;
+				ast_debug_rtp(1, "Missing packets exceed the available RED generations, set marker in packet\n");
+				goto red_done;
 			}
-			/* set the current and fixing redundant payloads */
-			rtp->f.data.ptr += len;
-			rtp->f.datalen -= len;
+		} else {
+			/* Skip older generations and include only the missing generations plus the primary payload. */
+			payload_offset = layout.header_length;
+			for (generation = 0; generation < layout.redundant_count - diff; ++generation) {
+				payload_offset += layout.redundant_length[generation];
+			}
 		}
-		if (rtp->f.datalen < 0) {
+		/* Expose the selected contiguous T.140 payload as the frame data. */
+		payload_length = rtp->f.datalen - payload_offset;
+		if (!payload_length) {
 			return AST_LIST_FIRST(&frames) ? AST_LIST_FIRST(&frames) : &ast_null_frame;
 		}
+		rtp->f.data.ptr = data + payload_offset;
+		rtp->f.datalen = payload_length;
+	red_done:
+		;
 	}
 
 	if (ast_format_get_type(rtp->f.subclass.format) == AST_MEDIA_TYPE_AUDIO) {
@@ -9335,10 +9368,26 @@ static int rtp_red_init(struct ast_rtp_instance *instance, int buffer_time, int 
 	struct ast_rtp *rtp = ast_rtp_instance_get_data(instance);
 	int x;
 
+	if (rtp->red) {
+		if (rtp->red->schedid > -1) {
+			ao2_unlock(instance);
+			if (!AST_SCHED_DEL(rtp->sched, rtp->red->schedid)) {
+				ao2_ref(instance, -1);
+			}
+			ao2_lock(instance);
+		}
+		ast_free(rtp->red);
+		rtp->red = NULL;
+	}
+	if (generations < 0) {
+		return 0;
+	}
+
 	rtp->red = ast_calloc(1, sizeof(*rtp->red));
 	if (!rtp->red) {
 		return -1;
 	}
+	rtp->red->schedid = -1;
 
 	rtp->red->t140.frametype = AST_FRAME_TEXT;
 	rtp->red->t140.subclass.format = ast_format_t140_red;
@@ -9618,12 +9667,14 @@ static void ast_rtp_stop(struct ast_rtp_instance *instance)
         }
 
 	/* only needed for chan_sip compatibility, should be removed after completely getting rid of it */
-	if (rtp->red && rtp->red->schedid > -1) {
-		ao2_unlock(instance);
-		if (!ast_sched_del(rtp->sched, rtp->red->schedid)) {
-			ao2_ref(instance, -1);
+	if (rtp->red) {
+		if (rtp->red->schedid > -1) {
+			ao2_unlock(instance);
+			if (!ast_sched_del(rtp->sched, rtp->red->schedid)) {
+				ao2_ref(instance, -1);
+			}
+			ao2_lock(instance);
 		}
-		ao2_lock(instance);
 		ast_free(rtp->red);
 		rtp->red = NULL;
 	}

--- a/res/res_rtp_asterisk.c
+++ b/res/res_rtp_asterisk.c
@@ -5546,10 +5546,7 @@ static struct ast_frame *red_t140_to_red(struct rtp_red *red)
 	memcpy(&data[len], red->t140.data.ptr, red->t140.datalen);
 	red->t140red.datalen = len + red->t140.datalen;
 
-	/* no primary data and no generations to send */
-	if (len == red->hdrlen && !red->t140.datalen) {
-		return NULL;
-	}
+	/* We need to continue even if we get no payload, to forward idle packets */
 
 	/* reset t.140 buffer */
 	red->t140.datalen = 0;
@@ -5729,9 +5726,7 @@ static int ast_rtp_write(struct ast_rtp_instance *instance, struct ast_frame *fr
 
 	if (rtp->red) {
 		ast_rtp_red_buffer(instance, frame);
-		/* no primary data or generations to send */
-		if ((frame = red_t140_to_red(rtp->red)) == NULL)
-			return 0;
+		frame = red_t140_to_red(rtp->red);
 	}
 
 	/* Grab the subclass and look up the payload we are going to use */
@@ -8256,9 +8251,7 @@ static struct ast_frame *ast_rtp_interpret(struct ast_rtp_instance *instance, st
 		}
 		/* Expose the selected contiguous T.140 payload as the frame data. */
 		payload_length = rtp->f.datalen - payload_offset;
-		if (!payload_length) {
-			return AST_LIST_FIRST(&frames) ? AST_LIST_FIRST(&frames) : &ast_null_frame;
-		}
+		/* Either we have payload available, or we need to send an idle packet without payload */
 		rtp->f.data.ptr = data + payload_offset;
 		rtp->f.datalen = payload_length;
 	red_done:
@@ -8290,7 +8283,7 @@ static struct ast_frame *ast_rtp_interpret(struct ast_rtp_instance *instance, st
 		rtp->f.subclass.frame_ending = mark ? 1 : 0;
 	} else if (ast_format_get_type(rtp->f.subclass.format) == AST_MEDIA_TYPE_TEXT) {
 		/* TEXT -- samples is # of samples vs. 1000 */
-		ast_debug(2, "processing AST_MEDIA_TYPE_TEXT, length %d\n", rtp->f.datalen);
+		ast_debug(2, "processing AST_MEDIA_TYPE_TEXT, payload length %d\n", rtp->f.datalen);
 		if (!rtp->lastitexttimestamp)
 			rtp->lastitexttimestamp = timestamp;
 		rtp->f.samples = timestamp - rtp->lastitexttimestamp;


### PR DESCRIPTION
* Co-authored-by: Henning Westerholt <hw@gilawa.com>

Based on a PR from Bharat Ramaswamy Nandakumar <bharat@bramsoft.com>
* Co-authored-by: Kevin Basov <kevin.basov@cgi.com>
* Co-authored-by: Sean Bright <sean@seanbright.com>

Previous changes from PR https://github.com/asterisk/asterisk/pull/998
* chan_pjsip - added write_text function to the pjsip_tech driver
* Added case for AST_FRAME_TEXT in chan_pjsip_write_stream
* Added case to handle text in chan_pjsip_write
* pjsip/dialplan_functions.c: added logic to handle media for TEXT
* res_pjsip.h: added variables to deal with endpoint media
* channel.c: added logic to add a stream_num for a frame
* frame.c: added code to handle and fix issues with red.
* res_pjsip_sdp_rtp.c: added logic to setup SDP.
* Added logic to handle tos and cos text
* Added logic to RED for red enabled
* res_pjsip_session.c: aded logic for max_text_streams
* res_rtp_asterisk.c: Added logic to handle Red and dealing with a repeating RTP
  issue
* pjsip_configuration.c: Added logic to handle text for PJSIP library

New additions:
* Maintain ABI compatibility
* Add alembic
* Add docs
* Adjust length based on stream
* fix whitespace formatting on some cases
* refactoring existing SDP attribute logic to use the existing framework
* fix redundant generation SDP payload mismatch
* remove not needed t140 debug fix, the t140 lengths are reset in the red case
* extend error logging and add some debug messages
* add more comment documentation regarding edge cases and workarounds
* add missing reference counting decrement for scheduler deletion
* add native bridging support for real-time RTP support
* add streaming support for real-time text
* update pjsip_config to new versions

UserNote: This introduces support for real-time text conversation over RTP (RFC 4103).
To enable it you need to add t140 and preferable also red as supported codecs.
You can configure this functionality by three new parameters in the endpoint
section of pjsip.conf: tos_text, cos_text and max_text_streams. If you are
using a database, please have a look to the upgrade notes.

UpgradeNote: This change introduce a schema modification for the ps_endpoint table by
alembic. If you don't use the scripts to update your database, please
adapt the table manually to the new structure. New fields were tos_text,
cos_text and max_text_streams.

Resolves: https://github.com/asterisk/asterisk/issues/997
Resolves: https://github.com/asterisk/asterisk/pull/1128