### PR TITLE
Add log-caller-id-name option to log Caller ID Name in queue log

### DIFF
--- a/configs/samples/queues.conf.sample
+++ b/configs/samples/queues.conf.sample
@@ -51,6 +51,15 @@ monitor-type = MixMonitor
 ;
 ;log_membername_as_agent = no
 ;
+; log-caller-id-name controls whether the Caller ID Name will be written to the
+; queue log. If enabled, and Caller ID would otherwise be logged (see
+; 'log-restricted-caller-id'), adds a 4th column to the ENTERQUEUE record which
+; contains the Caller ID Name. Any '|' characters in the Caller ID Name will be
+; replaced by a '_'. This setting applies globally to all queues.
+;
+; Default is 'no', which means the Caller ID Name is not stored.
+;log-caller-id-name = no
+;
 ; log-restricted-caller-id controls whether the Restricted Caller ID will be stored
 ; in the queue log.
 ; If log-restricted-caller-id=no then the Caller ID will be stripped if the Caller ID


### PR DESCRIPTION
Add log-caller-id-name option to log Caller ID Name in queue log

This patch introduces a new global configuration option, log-caller-id-name,
to queues.conf to control whether the Caller ID name is logged when a call enters a queue.

When log-caller-id-name=yes, the Caller ID name is logged
as parameter 4 in the queue log, provided it’s allowed by the
existing log_restricted_caller_id rules. If log-caller-id-name=no (the default),
the Caller ID name is omitted from the logs.

Fixes: #1091

UserNote: This patch adds a global configuration option, log-caller-id-name, to queues.conf
to control whether the Caller ID name is logged as parameter 4 when a call enters a queue.
When log-caller-id-name=yes, the Caller ID name is included in the queue log,
Any '|' characters in the caller ID name will be replaced with '_'.
(provided it’s allowed by the existing log_restricted_caller_id rules).
When log-caller-id-name=no (the default), the Caller ID name is omitted.