### PR TITLE
Revert "res_rtp_asterisk.c: Set Mark on rtp when timestamp skew is too big"

### DIFF
--- a/res/res_rtp_asterisk.c
+++ b/res/res_rtp_asterisk.c
@@ -5267,11 +5267,6 @@ static int rtp_raw_write(struct ast_rtp_instance *instance, struct ast_frame *fr
 	}
 
 	if (ast_test_flag(frame, AST_FRFLAG_HAS_TIMING_INFO)) {
-		if (abs(frame->ts * rate - (int)rtp->lastts) > MAX_TIMESTAMP_SKEW) {
-			ast_verbose("(%p) RTP audio difference is %d set mark\n",
-				instance, abs(frame->ts * rate - (int)rtp->lastts));
-			mark = 1;
-		}
 		rtp->lastts = frame->ts * rate;
 	}
 


### PR DESCRIPTION
This reverts commit f30ad96b3f467739c38ff415e80bffc4afff1da7.

The original change was not RFC compliant and caused issues because it set the RTP marker bit in cases when it shouldn't be set. See the linked issue #1135 for a detailed explanation.

Fixes: #1135.