### PR TITLE
swagger_model.py: Fix invalid escape sequence in get_list_parameter_type().

### DIFF
--- a/rest-api-templates/swagger_model.py
+++ b/rest-api-templates/swagger_model.py
@@ -464,7 +464,7 @@ def get_list_parameter_type(type_string):
     @param type_string: Type string to parse
     @returns Type parameter of the list, or None if not a List.
     """
-    list_match = re.match('^List\[(.*)\]$', type_string)
+    list_match = re.match(r'^List\[(.*)\]$', type_string)
     return list_match and list_match.group(1)
 
 


### PR DESCRIPTION
Recent python versions complain when backslashes in strings create invalid
escape sequences.  This causes issues for strings used as regex patterns like
`'^List\[(.*)\]$'` where you want the regex parser to treat `[` and `]`
as literals.  Double-backslashing is one way to fix it but simply converting
the string to a raw string `re.match(r'^List\[(.*)\]$', text)` is easier
and less error prone.
