### PR TITLE
Revert config.c commits 3cab4e7 and c157ee6 in master as they cause segfaults and spinloops.

### DIFF
--- a/main/config.c
+++ b/main/config.c
@@ -869,19 +869,11 @@ const char *ast_config_option(struct ast_config *cfg, const char *cat, const cha
 const char *ast_variable_retrieve(struct ast_config *config, const char *category, const char *variable)
 {
 	struct ast_variable *v;
-	const char *match = NULL;
-
-	/* We can't return as soon as we find a match, because if a config section overrides
-	 * something specified in a template, then the actual effective value is the last
-	 * one encountered, not the first one.
-	 * (This is like using the -1 index for the AST_CONFIG function.)
-	 * Also see ast_variable_find_last_in_list
-	 */
 
 	if (category) {
 		for (v = ast_variable_browse(config, category); v; v = v->next) {
 			if (!strcasecmp(variable, v->name)) {
-				match = v->value;
+				return v->value;
 			}
 		}
 	} else {
@@ -890,13 +882,13 @@ const char *ast_variable_retrieve(struct ast_config *config, const char *categor
 		for (cat = config->root; cat; cat = cat->next) {
 			for (v = cat->root; v; v = v->next) {
 				if (!strcasecmp(variable, v->name)) {
-					match = v->value;
+					return v->value;
 				}
 			}
 		}
 	}
 
-	return match;
+	return NULL;
 }
 
 const char *ast_variable_retrieve_filtered(struct ast_config *config,

--- a/main/config.c
+++ b/main/config.c
@@ -1645,19 +1645,13 @@ int ast_variable_delete(struct ast_category *category, const char *variable, con
 int ast_variable_update(struct ast_category *category, const char *variable,
 						const char *value, const char *match, unsigned int object)
 {
-	struct ast_variable *cur, *prev=NULL, *newer=NULL, *matchvar = NULL;
+	struct ast_variable *cur, *prev=NULL, *newer=NULL;
 
 	for (cur = category->root; cur; prev = cur, cur = cur->next) {
 		if (strcasecmp(cur->name, variable) ||
 			(!ast_strlen_zero(match) && strcasecmp(cur->value, match)))
 			continue;
-		matchvar = cur;
-	}
 
-	for (cur = category->root; cur; prev = cur, cur = cur->next) {
-		if (cur != matchvar) {
-			continue;
-		}
 		if (!(newer = ast_variable_new(variable, value, cur->file)))
 			return -1;
 


### PR DESCRIPTION
This reverts commit 3cab4e7ab4a3.

This commit causes crashes and spinloops in the manager UpdateConfig action.

Commit c157ee62f666 was a companion commit and is also reverted.

Resolves: #1147