### PR TITLE
action_redirect: remove after_bridge_goto_info

### DIFF
--- a/main/manager.c
+++ b/main/manager.c
@@ -96,6 +96,7 @@
 #include "asterisk/test.h"
 #include "asterisk/json.h"
 #include "asterisk/bridge.h"
+#include "asterisk/bridge_after.h"
 #include "asterisk/features_config.h"
 #include "asterisk/rtp_engine.h"
 #include "asterisk/format_cache.h"
@@ -3946,6 +3947,12 @@ static int action_sendtext(struct mansession *s, const struct message *m)
 	return 0;
 }
 
+static int async_goto_with_discard_bridge_after(struct ast_channel *chan, const char *context, const char *exten, int priority)
+{
+	ast_bridge_discard_after_goto(chan);
+	return ast_async_goto(chan, context, exten, priority);
+}
+
 /*! \brief  action_redirect: The redirect manager command */
 static int action_redirect(struct mansession *s, const struct message *m)
 {
@@ -4024,7 +4031,7 @@ static int action_redirect(struct mansession *s, const struct message *m)
 
 	if (ast_strlen_zero(name2)) {
 		/* Single channel redirect in progress. */
-		res = ast_async_goto(chan, context, exten, pi);
+		res = async_goto_with_discard_bridge_after(chan, context, exten, pi);
 		if (!res) {
 			astman_send_ack(s, m, "Redirect successful");
 		} else {
@@ -4063,12 +4070,12 @@ static int action_redirect(struct mansession *s, const struct message *m)
 	}
 	ast_channel_unlock(chan2);
 
-	res = ast_async_goto(chan, context, exten, pi);
+	res = async_goto_with_discard_bridge_after(chan, context, exten, pi);
 	if (!res) {
 		if (!ast_strlen_zero(context2)) {
-			res = ast_async_goto(chan2, context2, exten2, pi2);
+			res = async_goto_with_discard_bridge_after(chan2, context2, exten2, pi2);
 		} else {
-			res = ast_async_goto(chan2, context, exten, pi);
+			res = async_goto_with_discard_bridge_after(chan2, context, exten, pi);
 		}
 		if (!res) {
 			astman_send_ack(s, m, "Dual Redirect successful");


### PR DESCRIPTION
Under certain circumstances the context/extens/prio are stored in the
after_bridge_goto_info. This info is used when the bridge is broken by
for hangup of the other party. In the situation that the bridge is
broken by an AMI Redirect this info is not used but also not removed.
With the result that when the channel is put back in a bridge and the
bridge is broken the execution continues at the wrong
context/extens/prio.

Resolves: #1144