### PR TITLE
res_pjsip_outbound_registration.c: Remove xpointer reference to user_agent.

### DIFF
--- a/res/res_pjsip_outbound_registration.c
+++ b/res/res_pjsip_outbound_registration.c
@@ -395,9 +395,6 @@
 				<parameter name="Endpoint">
 					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip_outbound_registration']/configFile[@name='pjsip.conf']/configObject[@name='registration']/configOption[@name='endpoint']/synopsis/node())"/></para>
 				</parameter>
-				<parameter name="UserAgent">
-					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip_outbound_registration']/configFile[@name='pjsip.conf']/configObject[@name='registration']/configOption[@name='user_agent']/synopsis/node())"/></para>
-				</parameter>
 				<parameter name="ForbiddenRetryInterval">
 					<para><xi:include xpointer="xpointer(/docs/configInfo[@name='res_pjsip_outbound_registration']/configFile[@name='pjsip.conf']/configObject[@name='registration']/configOption[@name='forbidden_retry_interval']/synopsis/node())"/></para>
 				</parameter>


### PR DESCRIPTION
Commit e86f937e added AMI documentation to the module but the cherry-pick
from master to the 20 branch pulled in an xpointer reference to the
`user_agent` config option which doesn't actually exist in 20.  This causes
asterisk to fail to start because it can't load the core-en_US.xml
documentation file.  The CI cherry-pick tests should have caught this but
there was bug in the cherry-picker that was causing the commits to be
cherry-picked to the wrong branch.  Just removing the xpointer reference
resolves the issue.
