### PR TITLE
documentation: Update Gosub, Goto, and add new documentationtype.

### DIFF
--- a/apps/app_stack.c
+++ b/apps/app_stack.c
@@ -49,9 +49,9 @@
 			Jump to label, saving return address.
 		</synopsis>
 		<syntax>
-			<parameter name="context" />
-			<parameter name="exten" />
-			<parameter name="priority" required="true" hasparams="optional">
+			<parameter name="context" documentationtype="dialplan_context" />
+			<parameter name="extension" documentationtype="dialplan_extension" />
+			<parameter name="priority" documentationtype="dialplan_priority" required="true" hasparams="optional">
 				<argument name="arg1" multiple="true" required="true" />
 				<argument name="argN" />
 			</parameter>

--- a/doc/appdocsxml.dtd
+++ b/doc/appdocsxml.dtd
@@ -122,7 +122,7 @@
 
   <!ELEMENT description (para|note|warning|variablelist|enumlist|info|example|xi:include)*>
 
-  <!ELEMENT parameter (optionlist|enumlist|argument|para|note|warning|parameter|info|xi:include)*>
+  <!ELEMENT parameter (optionlist|enumlist|argument|para|note|warning|parameter|info|documentationtype|xi:include)*>
   <!ATTLIST parameter name CDATA "">
   <!ATTLIST parameter required (yes|no|true|false) "false">
   <!ATTLIST parameter multiple (yes|no|true|false) "false">
@@ -130,6 +130,7 @@
   <!ATTLIST parameter literal (yes|no|true|false) "false">
   <!ATTLIST parameter default CDATA "">
   <!ATTLIST parameter argsep CDATA ",">
+  <!ATTLIST parameter documentationtype CDATA "">
 
   <!ELEMENT optionlist (option+)>
   <!ELEMENT option (argument|para|note|warning|variablelist|enumlist|info|xi:include)*>

--- a/main/pbx_builtins.c
+++ b/main/pbx_builtins.c
@@ -227,9 +227,9 @@
 			Jump to a particular priority, extension, or context.
 		</synopsis>
 		<syntax>
-			<parameter name="context" />
-			<parameter name="extensions" />
-			<parameter name="priority" required="true" />
+			<parameter name="context" documentationtype="dialplan_context" />
+			<parameter name="extension" documentationtype="dialplan_extension" />
+			<parameter name="priority" documentationtype="dialplan_priority" required="true" />
 		</syntax>
 		<description>
 			<para>This application will set the current context, extension, and priority in the channel structure.


### PR DESCRIPTION
Gosub and Goto were not displaying their syntax correctly on the docs
site. This change adds a new way to specify an optional context, an
optional extension, and a required priority that the xml stylesheet can
parse without having to know which optional parameters come in which
order. In Asterisk, it looks like this:

  parameter name="context" documentationtype="dialplan_context"
  parameter name="extension" documentationtype="dialplan_extension"
  parameter name="priority" documentationtype="dialplan_priority" required="true"

The stylesheet will ignore the context and extension parameters, but for
priority, it will automatically inject the following:

  [[context,]extension,]priority

This is the correct oder for applications such as Gosub and Goto.
