### PR TITLE
ari_websockets: Fix frack if ARI config fails to load.

### DIFF
--- a/res/ari/ari_websockets.c
+++ b/res/ari/ari_websockets.c
@@ -697,6 +697,10 @@ static int ari_ws_session_shutdown_cb(void *ari_ws_session, void *arg, int flags
 
 static void ari_ws_session_registry_dtor(void)
 {
+	if (!ari_ws_session_registry) {
+		return;
+	}
+
 	ao2_callback(ari_ws_session_registry, OBJ_MULTIPLE | OBJ_NODATA,
 		ari_ws_session_shutdown_cb, NULL);
 


### PR DESCRIPTION
ari_ws_session_registry_dtor() wasn't checking that the container was valid
before running ao2_callback on it to shutdown registered sessions.
