### PR TITLE
asterisk.c: Add "pre-init" and "pre-module" capability to cli.conf.

### DIFF
--- a/configs/samples/cli.conf.sample
+++ b/configs/samples/cli.conf.sample
@@ -7,5 +7,21 @@
 ; Any commands listed in this section will get automatically executed
 ; when Asterisk starts as a daemon or foreground process (-c).
 ;
+; Commands with a value of "pre-init" will run just after the logger
+; is initialized but before all other core and module initialization.
+;
+; Commands with a value of "pre-module" will run just after core
+; initialization is done but before module initialization.
+;
+; These two values can be used for things like enabling debugging on
+; specific modules before they're loaded so you can see debug messages
+; generated during their initialization. Of course you can't run
+; commands from modules that haven't loaded yet.
+
+; Commands with a value of "yes" or "fully-booted" will run after all
+; core and module initialization is completed and just before
+; "Asterisk Ready" is printed on the console.
+;
+;core set debug 3 channels.c = pre-init
+;core set debug 3 res_pjsip.so = pre-module
 ;core set verbose 3 = yes
-;core set debug 1 = yes


### PR DESCRIPTION
Commands in the "[startup_commands]" section of cli.conf have historically run
after all core and module initialization has been completed and just before
"Asterisk Ready" is printed on the console. This meant that if you
wanted to debug initialization of a specific module, your only option
was to turn on debug for everything by setting "debug" in asterisk.conf.

This commit introduces options to allow you to run CLI commands earlier in
the asterisk startup process.

A command with a value of "pre-init" will run just after logger initialization
but before most core, and all module, initialization.

A command with a value of "pre-module" will run just after all core
initialization but before all module initialization.

A command with a value of "fully-booted" (or "yes" for backwards
compatibility) will run as they always have been...after all
initialization and just before "Asterisk Ready" is printed on the console.

This means you could do this...

```
[startup_commands]
core set debug 3 res_pjsip.so = pre-module
core set debug 0 res_pjsip.so = fully-booted
```

This would turn debugging on for res_pjsip.so to catch any module
initialization debug messages then turn it off again after the module is
loaded.

UserNote: In cli.conf, you can now define startup commands that run before
core initialization and before module initialization.
