### PR TITLE
contrib: Add systemd service and timer files for malloc trim.

### DIFF
--- a/contrib/systemd/asterisk-malloc-trim.service
+++ b/contrib/systemd/asterisk-malloc-trim.service
@@ -1,0 +1,9 @@
+# Run the `malloc trim` CLI command to return unused memory
+# to the OS.  Triggered automatically by asterisk-malloc-trim.timer.
+
+[Unit]
+Description=Runs Asterisk "malloc trim" CLI command
+
+[Service]
+Type=simple
+ExecStart=/usr/sbin/asterisk -rx "malloc trim"

--- a/contrib/systemd/asterisk-malloc-trim.timer
+++ b/contrib/systemd/asterisk-malloc-trim.timer
@@ -1,0 +1,29 @@
+# Systemd.timer file to periodically run the
+# `malloc trim` CLI command to return unused memory
+# to the OS.
+#
+# Don't modify this file to customize the start time.  Instead create file 
+# /etc/systemd/system/asterisk-malloc-trim.timer.d/10-oncalendar.conf
+# with the following contents:
+#
+# [Timer]
+# OnCalendar=<new time spec>
+#
+# Run `systemctl daemon-reload` after creating this file.
+#
+# OnCalendar isn't the only way to set when the unit runs.
+# See systemd.timer(5) and systemd.time(7) for more info.
+#
+
+[Unit]
+Description=Asterisk malloc-trim timer
+After=asterisk.service
+Requisite=asterisk.service
+
+[Timer]
+OnCalendar=00:15:00
+RandomizedDelaySec=3600
+Persistent=yes
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Adds two files to the contrib/systemd/ directory that can be installed
to periodically run "malloc trim" on Asterisk. These files do nothing
unless they are explicitly moved to the correct location on the system.
Users who are experiencing Asterisk memory issues can use this service
to potentially help combat the problem. These files can also be
configured to change the start time and interval. See systemd.timer(5)
and systemd.time(7) for more information.

UserNote: Service and timer files for systemd have been added to the
contrib/systemd/ directory. If you are experiencing memory issues,
install these files to have "malloc trim" periodically run on the
system.
