### PR TITLE
Prequisites for ARI Outbound Websockets

### DIFF
--- a/include/asterisk/http.h
+++ b/include/asterisk/http.h
@@ -141,6 +141,20 @@ struct ast_http_auth {
  */
 struct ast_http_auth *ast_http_get_auth(struct ast_variable *headers);
 
+/*!
+ * \brief Create an HTTP authorization header.
+ *
+ * The returned ast_variable must be freed with ast_variables_destroy()
+ *
+ * \param userid User ID or "<userid>:<password>".
+ * \param password Password if not in userid.
+ *
+ * \return ast_variable with name="Authorization" and value="Basic <base64enc>"
+ * \retval NULL if memory allocation failed.
+ */
+struct ast_variable *ast_http_create_basic_auth_header(const char *userid,
+	const char *password);
+
 /*! \brief Register a URI handler */
 int ast_http_uri_link(struct ast_http_uri *urihandler);
 

--- a/include/asterisk/http_websocket.h
+++ b/include/asterisk/http_websocket.h
@@ -397,7 +397,7 @@ AST_OPTIONAL_API(const char *, ast_websocket_session_id, (struct ast_websocket *
  * \brief Result code for a websocket client.
  */
 enum ast_websocket_result {
-	WS_OK,
+	WS_OK = 0,
 	WS_ALLOCATE_ERROR,
 	WS_KEY_ERROR,
 	WS_URI_PARSE_ERROR,
@@ -411,6 +411,7 @@ enum ast_websocket_result {
 	WS_NOT_SUPPORTED,
 	WS_WRITE_ERROR,
 	WS_CLIENT_START_ERROR,
+	WS_UNAUTHORIZED,
 };
 
 /*!
@@ -468,6 +469,9 @@ struct ast_websocket_client_options {
 	 * Secure websocket credentials
 	 */
 	struct ast_tls_config *tls_cfg;
+	const char *username;          /*!< Auth username */
+	const char *password;          /*!< Auth password */
+	int suppress_connection_msgs;  /*!< Suppress connection log messages */
 };
 
 /*!
@@ -509,5 +513,14 @@ AST_OPTIONAL_API(const char *, ast_websocket_client_accept_protocol,
  * \retval -1 on failure
  */
 AST_OPTIONAL_API(int, ast_websocket_set_timeout, (struct ast_websocket *session, int timeout), {return -1;});
+
+/*!
+ * \brief Convert a websocket result code to a string.
+ *
+ * \param result The result code to convert
+ *
+ * \return A string representation of the result code
+ */
+AST_OPTIONAL_API(const char *, ast_websocket_result_to_str, (enum ast_websocket_result result), {return "";});
 
 #endif

--- a/include/asterisk/md5.h
+++ b/include/asterisk/md5.h
@@ -23,6 +23,10 @@
 #ifndef _ASTERISK_MD5_H
 #define _ASTERISK_MD5_H
 
+#ifndef MD5_DIGEST_LENGTH
+#define MD5_DIGEST_LENGTH 16
+#endif
+
 struct MD5Context {
 	uint32_t buf[4];
 	uint32_t bits[2];
@@ -33,7 +37,7 @@ struct MD5Context {
 void MD5Init(struct MD5Context *context);
 void MD5Update(struct MD5Context *context, unsigned char const *buf,
 	       unsigned len);
-void MD5Final(unsigned char digest[16], struct MD5Context *context);
+void MD5Final(unsigned char digest[MD5_DIGEST_LENGTH], struct MD5Context *context);
 void MD5Transform(uint32_t buf[4], uint32_t const in[16]);
 
 #endif /* _ASTERISK_MD5_H */

--- a/include/asterisk/stasis_app.h
+++ b/include/asterisk/stasis_app.h
@@ -86,6 +86,16 @@ struct ao2_container *stasis_app_get_all(void);
 struct stasis_app *stasis_app_get_by_name(const char *name);
 
 /*!
+ * \brief Check if a Stasis application is registered.
+ *
+ * \param name The name of the registered Stasis application
+ *
+ * \return 1 if the application is registered.
+ * \return 0 if the application is not registered.
+ */
+int stasis_app_is_registered(const char *name);
+
+/*!
  * \brief Register a new Stasis application.
  *
  * If an application is already registered with the given name, the old
@@ -116,7 +126,7 @@ int stasis_app_register(const char *app_name, stasis_app_cb handler, void *data)
 int stasis_app_register_all(const char *app_name, stasis_app_cb handler, void *data);
 
 /*!
- * \brief Unregister a Stasis application.
+ * \brief Unregister a Stasis application and unsubscribe from all event sources.
  * \param app_name Name of the application to unregister.
  */
 void stasis_app_unregister(const char *app_name);
@@ -446,6 +456,20 @@ void stasis_app_control_execute_until_exhausted(
  */
 int stasis_app_control_is_done(
 	struct stasis_app_control *control);
+
+/*!
+ * \brief Set the failed flag on a control structure
+ *
+ * \param control Control object to be updated
+ */
+void stasis_app_control_mark_failed(struct stasis_app_control *control);
+
+/*!
+ * \brief Check if a control object is marked as "failed"
+ *
+ * \param control Control object to check
+ */
+int stasis_app_control_is_failed(const struct stasis_app_control *control);
 
 /*!
  * \brief Flush the control command queue.

--- a/include/asterisk/tcptls.h
+++ b/include/asterisk/tcptls.h
@@ -142,6 +142,7 @@ struct ast_tcptls_session_args {
 	void *(*worker_fn)(void *); /*!< the function in charge of doing the actual work */
 	const char *name;
 	struct ast_tls_config *old_tls_cfg; /*!< copy of the SSL configuration to determine whether changes have been made */
+	int suppress_connection_msgs; /*!< suppress connection messages to allow caller to manage logging */
 };
 
 /*! \brief

--- a/main/md5.c
+++ b/main/md5.c
@@ -117,7 +117,7 @@ void MD5Update(struct MD5Context *ctx, unsigned char const *buf, unsigned len)
  * Final wrapup - pad to 64-byte boundary with the bit pattern
  * 1 0* (64-bit count of bits processed, MSB-first)
  */
-void MD5Final(unsigned char digest[16], struct MD5Context *ctx)
+void MD5Final(unsigned char digest[MD5_DIGEST_LENGTH], struct MD5Context *ctx)
 {
 	unsigned count;
 	unsigned char *p;

--- a/res/res_stasis_device_state.c
+++ b/res/res_stasis_device_state.c
@@ -351,7 +351,7 @@ static int is_subscribed_device_state_lock(struct stasis_app *app, const char *n
 	int is_subscribed;
 
 	ao2_lock(device_state_subscriptions);
-	is_subscribed = is_subscribed_device_state(app, name);
+	is_subscribed = is_subscribed_device_state(app, S_OR(name, DEVICE_STATE_ALL));
 	ao2_unlock(device_state_subscriptions);
 
 	return is_subscribed;
@@ -409,7 +409,7 @@ static int unsubscribe_device_state(struct stasis_app *app, const char *name)
 	struct device_state_subscription *sub;
 
 	ao2_lock(device_state_subscriptions);
-	sub = find_device_state_subscription(app, name);
+	sub = find_device_state_subscription(app, S_OR(name, DEVICE_STATE_ALL));
 	if (sub) {
 		remove_device_state_subscription(sub);
 	}

--- a/res/stasis/control.c
+++ b/res/stasis/control.c
@@ -102,6 +102,11 @@ struct stasis_app_control {
 	 * When set, /c app_stasis should exit and continue in the dialplan.
 	 */
 	unsigned int is_done:1;
+	/*!
+	 * When set, /c app_stasis should exit indicating failure and continue
+	 * in the dialplan.
+	 */
+	unsigned int failed:1;
 };
 
 static void control_dtor(void *obj)
@@ -367,6 +372,17 @@ void control_mark_done(struct stasis_app_control *control)
 	control->is_done = 1;
 	ao2_unlock(control->command_queue);
 }
+
+void stasis_app_control_mark_failed(struct stasis_app_control *control)
+{
+	control->failed = 1;
+}
+
+int stasis_app_control_is_failed(const struct stasis_app_control *control)
+{
+	return control->failed;
+}
+
 
 struct stasis_app_control_continue_data {
 	char context[AST_MAX_CONTEXT];


### PR DESCRIPTION
stasis:
* Added stasis_app_is_registered().
* Added stasis_app_control_mark_failed().
* Added stasis_app_control_is_failed().
* Fixed res_stasis_device_state so unsubscribe all works properly.
* Modified stasis_app_unregister() to unsubscribe from all event sources.
* Modified stasis_app_exec to return -1 if stasis_app_control_is_failed()
  returns true.

http:
* Added ast_http_create_basic_auth_header().

md5:
* Added define for MD5_DIGEST_LENGTH.

tcptls:
* Added flag to ast_tcptls_session_args to suppress connection log messages
  to give callers more control over logging.

http_websocket:
* Add flag to ast_websocket_client_options to suppress connection log messages
  to give callers more control over logging.
* Added username and password to ast_websocket_client_options to support
  outbound basic authentication.
* Added ast_websocket_result_to_str().
