### PR TITLE
pbx_ael: unregister AELSub application and CLI commands on module load failure

### DIFF
--- a/pbx/pbx_ael.c
+++ b/pbx/pbx_ael.c
@@ -270,11 +270,21 @@ static int unload_module(void)
 
 static int load_module(void)
 {
+	int pbx_load_res = AST_MODULE_LOAD_SUCCESS;
+
 	ast_cli_register_multiple(cli_ael, ARRAY_LEN(cli_ael));
 #ifndef STANDALONE
 	ast_register_application_xml(aelsub, aelsub_exec);
 #endif
-	return (pbx_load_module());
+	pbx_load_res = pbx_load_module();
+	if (AST_MODULE_LOAD_SUCCESS != pbx_load_res) {
+#ifndef STANDALONE
+		ast_unregister_application(aelsub);
+#endif
+		ast_cli_unregister_multiple(cli_ael, ARRAY_LEN(cli_ael));
+	}
+
+	return pbx_load_res;
 }
 
 static int reload(void)


### PR DESCRIPTION
This fixes crashes/hangs I noticed with Asterisk 20.3.0 and 20.13.0 and quickly found out,
that the AEL module doesn't do proper cleanup when it fails to load.
This happens for example when there are syntax errors and AEL fails to compile in which case pbx_load_module()
returns an error but load_module() doesn't then unregister CLI cmds and the application.
