### PR TITLE
file.c: Increment the channel reference count when it is added as owner to a ast_filestream

### DIFF
--- a/include/asterisk/file.h
+++ b/include/asterisk/file.h
@@ -356,7 +356,7 @@ struct ast_filestream *ast_openstream_full(struct ast_channel *chan, const char 
 struct ast_filestream *ast_openvstream(struct ast_channel *chan, const char *filename, const char *preflang);
 
 /*!
- * \brief Applies a open stream to a channel.
+ * \brief Applies a open stream to a channel. And bumps the reference count of the channel.
  * \param chan channel to work
  * \param s ast_filestream to apply
  * \retval 0 on success.


### PR DESCRIPTION
SEGFAULTS and memory corruption has been reported at locations where the ast_filestream->owner is assumed to point to a vaild channel, sometimes it does not (and appears to have been freed).

Fixes: #829

UserNote: Ensure we increment the channel reference count when it is added as the owner of a ast_filestream and decrement it when the ast_filestream is destroyed