### PR TITLE
Avoid prepare in cdr_adaptive_odbc for direct INSERT

### DIFF
--- a/cdr/cdr_adaptive_odbc.c
+++ b/cdr/cdr_adaptive_odbc.c
@@ -388,7 +388,8 @@ static int odbc_log(struct ast_cdr *cdr)
 	SQLLEN rows = 0;
 	char *separator;
 	int quoted = 0;
-
+	int res;
+	
 	if (!sql || !sql2) {
 		if (sql)
 			ast_free(sql);


### PR DESCRIPTION
Avoids unnecessary prepare for simple INSERT statements that caused issues with ProxySQL (prepared statement counter overflow).