### PR TITLE
build_system: Process MAKEOPTS blocks in main source files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 *.exports
 *.moduleinfo
 *.makeopts
+*.main-makeopts
 *.makedeps
 .lastclean
 /.pc

--- a/Makefile
+++ b/Makefile
@@ -1090,12 +1090,13 @@ menuselect/nmenuselect: menuselect/makeopts .lastclean
 menuselect/makeopts: makeopts .lastclean
 	+$(MAKE_MENUSELECT) makeopts
 
-menuselect-tree: $(foreach dir,$(filter-out main,$(MOD_SUBDIRS)),$(wildcard $(dir)/*.c) $(wildcard $(dir)/*.cc) $(wildcard $(dir)/*.xml)) build_tools/cflags.xml build_tools/cflags-devmode.xml sounds/sounds.xml utils/utils.xml agi/agi.xml configure makeopts
+menuselect-tree: $(foreach dir,$(MOD_SUBDIRS),$(wildcard $(dir)/*.c) $(wildcard $(dir)/*.cc) $(wildcard $(dir)/*.xml)) build_tools/cflags.xml build_tools/cflags-devmode.xml sounds/sounds.xml utils/utils.xml agi/agi.xml configure makeopts
 	@echo "Generating input for menuselect ..."
 	@echo "<?xml version=\"1.0\"?>" > $@
 	@echo >> $@
 	@echo "<menu name=\"Asterisk Module and Build Option Selection\">" >> $@
 	+@for dir in $(sort $(filter-out main,$(MOD_SUBDIRS))); do $(SILENTMAKE) -C $${dir} SUBDIR=$${dir} moduleinfo >> $@; done
+	@$(SILENTMAKE) -C main SUBDIR=main main-makeopts >> $@
 	@cat build_tools/cflags.xml >> $@
 	+@for dir in $(sort $(filter-out main,$(MOD_SUBDIRS))); do $(SILENTMAKE) -C $${dir} SUBDIR=$${dir} makeopts >> $@; done
 	@if [ "${AST_DEVMODE}" = "yes" ]; then \

--- a/main/Makefile
+++ b/main/Makefile
@@ -32,6 +32,14 @@ SRC:=$(filter-out libasteriskpj.c,$(SRC))
 endif
 OBJSFILTER:=$(MOD_OBJS) fskmodem_int.o fskmodem_float.o cygload.o buildinfo.o
 SRC_CC:=$(wildcard *.cc)
+
+SRC_MAKEOPTS:=$(sort $(basename $(SRC) $(SRC_CC)))
+.main-makeopts: $(addsuffix .makeopts,$(addprefix .,$(SRC_MAKEOPTS)))
+	@cat $^ > $@
+
+main-makeopts: .main-makeopts
+	@cat $<
+
 OBJS=$(filter-out $(OBJSFILTER),$(SRC:.c=.o) $(SRC_CC:.cc=.oo))
 
 # we need to link in the objects statically, not as a library, because
@@ -368,3 +376,7 @@ endif
 	@$(MAKE) -C stdtime clean
 	rm -f libresample/src/*.o
 	rm -f *.tmp
+
+dist-clean::
+	rm -f .main-makeopts
+	


### PR DESCRIPTION
The source files in the module directories are scanned for blocks
beginning with `/*** MAKEOPTS` which contain XML fragments that control
menuselect.  The source files in the main directory however weren't scanned.
This commit adds rules to the top-level Makefile and main/Makefile to
do the scanning.  The rules are a bit different for main because the directory
list that controls the MAKEOPTS scanning also controls compiler options for
modules and they're not appropriate for source files in main that will be
linked into the `asterisk` executable.
