### PR TITLE
app_meetme: Remove inaccurate removal version from xmldocs.

### DIFF
--- a/apps/app_meetme.c
+++ b/apps/app_meetme.c
@@ -40,7 +40,6 @@
 	<support_level>deprecated</support_level>
 	<replacement>app_confbridge</replacement>
 	<deprecated_in>19</deprecated_in>
-	<removed_in>21</removed_in>
  ***/
 
 #include "asterisk.h"


### PR DESCRIPTION
app_meetme is deprecated but wasn't removed as planned in 21, so remove the inaccurate removal version.

Resolves: #1224