### PR TITLE
Build system: Disable rebuilding the yacc-based parsers.

### DIFF
--- a/main/Makefile
+++ b/main/Makefile
@@ -120,14 +120,20 @@ endif
 .PHONY: CHECK_SUBDIR
 CHECK_SUBDIR:	# do nothing, just make sure that we recurse in the subdir/
 
-ifneq ($(findstring REBUILD_PARSERS,$(MENUSELECT_CFLAGS)),)
-ast_expr2.c ast_expr2.h: ast_expr2.y
-else
-ast_expr2.c ast_expr2.h:
-endif
-	$(ECHO_PREFIX) echo "   [BISON] $< -> $@"
-	$(CMD_PREFIX) $(BISON) -o $@ -d --name-prefix=ast_yy ast_expr2.y
-
+#
+# Rebuilding ast_expr2.c and ast_expr2.h is disabled pending further
+# investigation as they fail to rebuild in any current distro.  Those
+# files are checked into the source tree anyway and haven't been changed,
+# other than for typos, in a long time.
+#
+#ifneq ($(findstring REBUILD_PARSERS,$(MENUSELECT_CFLAGS)),)
+#ast_expr2.c ast_expr2.h: ast_expr2.y
+#else
+#ast_expr2.c ast_expr2.h:
+#endif
+#	$(ECHO_PREFIX) echo "   [BISON] $< -> $@"
+#	$(CMD_PREFIX) $(BISON) -o $@ -d --name-prefix=ast_yy ast_expr2.y
+#
 ifneq ($(findstring REBUILD_PARSERS,$(MENUSELECT_CFLAGS)),)
 ast_expr2f.c: ast_expr2.fl
 else

--- a/res/Makefile
+++ b/res/Makefile
@@ -45,13 +45,20 @@ endif
 	$(CMD_PREFIX) echo >> $@
 	$(CMD_PREFIX) $(FLEX) -t ael/ael.flex >> $@
 
-ifneq ($(findstring REBUILD_PARSERS,$(MENUSELECT_CFLAGS)),)
-ael/ael.tab.c ael/ael.tab.h: ael/ael.y
-else
-ael/ael.tab.c ael/ael.tab.h:
-endif
-	$(ECHO_PREFIX) echo "   [BISON] $< -> $@"
-	$(CMD_PREFIX) (cd ael; $(BISON) -v -d ael.y)
+#
+# Rebuilding ael/ael.tab.c and ael/ael.tab.h is
+# disabled pending further investigation because they fail to
+# rebuild in any current distro.  Those files are checked into
+# the source tree anyway and haven't been changed, other than
+# for typos, in a long time.
+#
+#ifneq ($(findstring REBUILD_PARSERS,$(MENUSELECT_CFLAGS)),)
+#ael/ael.tab.c ael/ael.tab.h: ael/ael.y
+#else
+#ael/ael.tab.c ael/ael.tab.h:
+#endif
+#	$(ECHO_PREFIX) echo "   [BISON] $< -> $@"
+#	$(CMD_PREFIX) (cd ael; $(BISON) -v -d ael.y)
 
 ael/pval.o: ael/pval.c
 


### PR DESCRIPTION
Rebuilding main/ast_expr2.[ch] and res/ael/ael.tab.[ch] from their
respective .y files now fails on any recent distro.  Unfortunately,
for some reason, the GitHub CI runners occasionally attempt to rebuild
them for some unknown reason.  Since those files are checked into the
source tree anyway and haven't been changed, other than for typos, in
a long time, rebuilding them is being disabled pending further investigation.
