### PR TITLE
lock.h: Add include for string.h when DEBUG_THREADS is defined.

### DIFF
--- a/include/asterisk/lock.h
+++ b/include/asterisk/lock.h
@@ -54,6 +54,9 @@
 #ifdef HAVE_BKTR
 #include <execinfo.h>
 #endif
+#ifdef DEBUG_THREADS
+#include <string.h>
+#endif
 
 #ifndef HAVE_PTHREAD_RWLOCK_TIMEDWRLOCK
 #include "asterisk/time.h"


### PR DESCRIPTION
When DEBUG_THREADS is defined, lock.h uses strerror(), which is defined
in the libc string.h file, to print warning messages. If the including
source file doesn't include string.h then strerror() won't be found and
and compile errors will be thrown. Since lock.h depends on this, string.h
is now included from there if DEBUG_THREADS is defined.  This way, including
source files don't have to worry about it.
