### PR TITLE
res_audiosocket.c: Add retry mechanism for reading data from AudioSocket

### DIFF
--- a/res/res_audiosocket.c
+++ b/res/res_audiosocket.c
@@ -307,6 +307,18 @@ struct ast_frame *ast_audiosocket_receive_frame_with_hangup(const int svc,
 	while (i < *length) {
 		n = read(svc, data + i, *length - i);
 		if (n == -1) {
+			if (errno == EAGAIN || errno == EWOULDBLOCK) {
+				int poll_result = ast_wait_for_input(svc, 5);
+
+				if (poll_result == 1) {
+					continue;
+				} else if (poll_result == 0) {
+					ast_log(LOG_WARNING, "Poll timed out while waiting for data\n");
+				} else {
+					ast_log(LOG_WARNING, "Poll error: %s\n", strerror(errno));
+				}
+			}
+
 			ast_log(LOG_ERROR, "Failed to read payload from AudioSocket: %s\n", strerror(errno));
 			ret = -1;
 			break;


### PR DESCRIPTION
The added retry mechanism addresses an issue that arises when fragmented TCP packets are received, each containing only a portion of an AudioSocket packet. This situation can occur if the external service sending the AudioSocket data has Nagle's algorithm enabled.