### PR TITLE
asterisk.c: Add option to restrict shell access from remote consoles.

### DIFF
--- a/configs/samples/asterisk.conf.sample
+++ b/configs/samples/asterisk.conf.sample
@@ -138,6 +138,9 @@ documentation_language = en_US	; Set the language you want documentation
                 ;   cpp_map_name_id: Use C++ Maps to index both
                 ;                    channel name and channel uniqueid.
                 ; See http://s.asterisk.net/dc679ec3 for more information.
+;disable_remote_console_shell = no; Prevent remote console CLI sessions
+                ; from executing shell commands with the '!' prefix.
+                ; Default: no
 
 ; Changing the following lines may compromise your security.
 ;[files]

--- a/configs/samples/cli_permissions.conf.sample
+++ b/configs/samples/cli_permissions.conf.sample
@@ -19,6 +19,11 @@
 ; deny = <command name> | all		; disallow the user to run 'command' |
 ;					; disallow the user to run 'all' commands.
 ;
+; NOTE: This file can't be used to restict the use of the '!' prefix
+; for running shell commands from the CLI. You can however disable the
+; use of the shell commands in remote consoles altogether by setting
+; the 'disable_remote_console_shell' parameter in asterisk.conf to 'yes'.
+;
 
 [general]
 

--- a/include/asterisk/options.h
+++ b/include/asterisk/options.h
@@ -209,6 +209,8 @@ extern int ast_language_is_prefix;
 extern int ast_option_rtpusedynamic;
 extern unsigned int ast_option_rtpptdynamic;
 
+extern int ast_option_disable_remote_console_shell;
+
 #if defined(__cplusplus) || defined(c_plusplus)
 }
 #endif

--- a/main/asterisk.c
+++ b/main/asterisk.c
@@ -581,6 +581,8 @@ static char *handle_show_settings(struct ast_cli_entry *e, int cmd, struct ast_c
 	}
 	ast_cli(a->fd, "  Channel storage backend:     %s\n",
 		ast_channel_get_current_storage_driver_name());
+	ast_cli(a->fd, "  Shell on remote consoles:    %s\n",
+		ast_option_disable_remote_console_shell ? "Disabled" : "Enabled");
 
 	ast_cli(a->fd, "\n* Subsystems\n");
 	ast_cli(a->fd, "  -------------\n");
@@ -2337,6 +2339,10 @@ static int remoteconsolehandler(const char *s)
 
 	/* The real handler for bang */
 	if (s[0] == '!') {
+		if (ast_option_disable_remote_console_shell) {
+			printf("Shell access is disabled on remote consoles\n");
+			return 1;
+		}
 		if (s[1])
 			ast_safe_system(s+1);
 		else

--- a/main/options.c
+++ b/main/options.c
@@ -88,7 +88,7 @@ long option_minmemfree;
 #endif
 int ast_option_rtpusedynamic = 1;
 unsigned int ast_option_rtpptdynamic = 35;
-
+int ast_option_disable_remote_console_shell = 0;
 /*! @} */
 
 struct ast_eid ast_eid_default;
@@ -223,6 +223,7 @@ void load_asterisk_conf(void)
 	int option_debug_new = 0;
 	int option_trace_new = 0;
 	int option_verbose_new = 0;
+
 
 	/* init with buildtime config */
 #ifdef REF_DEBUG
@@ -477,6 +478,8 @@ void load_asterisk_conf(void)
 			ast_set2_flag(&ast_options, ast_true(v->value), AST_OPT_FLAG_SOUNDS_SEARCH_CUSTOM);
 		} else if (!strcasecmp(v->name, "channel_storage_backend")) {
 			internal_channel_set_current_storage_driver(v->value);
+		} else if (!strcasecmp(v->name, "disable_remote_console_shell")) {
+			ast_option_disable_remote_console_shell = ast_true(v->value);
 		}
 	}
 	if (!ast_opt_remote) {


### PR DESCRIPTION
UserNote: A new asterisk.conf option 'disable_remote_console_shell' has
been added that, when set, will prevent remote consoles from executing
shell commands using the '!' prefix.

Resolves: #GHSA-c7p6-7mvq-8jq2
