### PR TITLE
app_queue: queue rules – Add support for QUEUE_RAISE_PENALTY=rN to raise penalties only for members within min/max range

### DIFF
--- a/configs/samples/queuerules.conf.sample
+++ b/configs/samples/queuerules.conf.sample
@@ -37,11 +37,14 @@
 ; made during the caller's stay in the queue, these will not be reflected for that caller.
 ;
 ; The syntax for these rules is
-; penaltychange => <number of seconds into the call>,<absolute or relative change to QUEUE_MAX_PENALTY>[,absolute or relative change to QUEUE_MIN_PENALTY][,absolute or relative change to QUEUE_RAISE_PENALTY]
+; penaltychange => <number of seconds into the call>,<absolute or relative change to QUEUE_MAX_PENALTY>[,absolute or relative change to QUEUE_MIN_PENALTY][,absolute or relative change to QUEUE_RAISE_PENALTY or rN>]
 ;
+; - If QUEUE_RAISE_PENALTY is set to rN (e.g., r20), only agents with penalty between QUEUE_MIN_PENALTY and QUEUE_MAX_PENALTY (inclusive)
+;  will have their penalty raised to N. Others remain unchanged.
 ; Example:
 ; [myrule]
 ; penaltychange => 30,+3   ; 30 seconds into the call increase the QUEUE_MAX_PENALTY by 3, no change to QUEUE_MIN_PENALTY
 ; penaltychange => 60,10,5 ; 60 seconds into the call increase the QUEUE_MAX_PENALTY to 10 and increase the QUEUE_MIN_PENALTY to 5
 ; penaltychange => 75,,7   ; 75 seconds into the call keep the QUEUE_MAX_PENALTY the same and increase the QUEUE_MIN_PENALTY to 7
 ; penaltychange => 90,,,20 ; 90 seconds into the call leave QUEUE_MAX_PENALTY and QUEUE_MIN_PENALTY untouched and set QUEUE_RAISE_PENALTY to 20
+; penaltychange => 120,5,3,r20 ; After 120 seconds, set max=5, min=3, and raise only agents with penalty 3–5 to 20


### PR DESCRIPTION
This update adds support for a new QUEUE_RAISE_PENALTY format: rN

When QUEUE_RAISE_PENALTY is set to rN (e.g., r4), only members whose current penalty
is greater than or equal to the defined min_penalty and less than or equal to max_penalty
will have their penalty raised to N.

Members with penalties outside the min/max range remain unchanged.

Example behaviors:

QUEUE_RAISE_PENALTY=4     → Raise all members with penalty < 4 (existing behavior)
QUEUE_RAISE_PENALTY=r4    → Raise only members with penalty in [min_penalty, max_penalty] to 4

Implementation details:

Adds parsing logic to detect the r prefix and sets the raise_respect_min flag

Modifies the raise logic to skip members outside the defined penalty range when the flag is active

UserNote: This change introduces QUEUE_RAISE_PENALTY=rN, allowing selective penalty raises
only for members whose current penalty is within the [min_penalty, max_penalty] range.
Members with lower or higher penalties are unaffected.
This behavior is backward-compatible with existing queue rule configurations.