### PR TITLE
pbx.c: when set flag AST_SOFTHANGUP_ASYNCGOTO, ast_explicit_goto should return -1.

### DIFF
--- a/include/asterisk/pbx.h
+++ b/include/asterisk/pbx.h
@@ -1128,6 +1128,8 @@ int ast_unlock_context(struct ast_context *con);
  * \brief Set the channel to next execute the specified dialplan location.
  * \see ast_async_parseable_goto, ast_async_goto_if_exists
  *
+ * \note If the AST_SOFTHANGUP_ASYNCGOTO flag is set,
+ * it can prevent the dialplan location from being overwritten by ast_explicit_goto.
  * \note Do _NOT_ hold any channel locks when calling this function.
  */
 int ast_async_goto(struct ast_channel *chan, const char *context, const char *exten, int priority);
@@ -1509,6 +1511,7 @@ int ast_async_parseable_goto(struct ast_channel *chan, const char *goto_string);
 
 /*!
  * \note This function will handle locking the channel as needed.
+ * \note If the AST_SOFTHANGUP_ASYNCGOTO flag is set on the channel, this function will fail and return -1.
  */
 int ast_explicit_goto(struct ast_channel *chan, const char *context, const char *exten, int priority);
 

--- a/main/pbx.c
+++ b/main/pbx.c
@@ -6964,6 +6964,10 @@ int ast_explicit_goto(struct ast_channel *chan, const char *context, const char 
 
 	ast_channel_lock(chan);
 
+	if (ast_channel_softhangup_internal_flag(chan) & AST_SOFTHANGUP_ASYNCGOTO) {
+		ast_channel_unlock(chan);
+		return -1;
+	}
 	if (!ast_strlen_zero(context))
 		ast_channel_context_set(chan, context);
 	if (!ast_strlen_zero(exten))


### PR DESCRIPTION
Under certain circumstances the context/extens/prio are set in the ast_async_goto, for example action Redirect.
In the situation that action Redirect is broken by GotoIf this info is changed.
that will causes confusion in dialplan execution.
    
Resolves: #1273