### PR TITLE
sorcery: Prevent duplicate objects and ensure missing objects are created on update

### DIFF
--- a/configs/samples/sorcery.conf.sample
+++ b/configs/samples/sorcery.conf.sample
@@ -1,5 +1,16 @@
 ; Sample configuration file for Sorcery Data Access Layer
 
+[general]
+
+; When true, writable Sorcery backends may attempt to insert the object
+; if the object is missing.
+; This helps re-populate missing backends when using multiple writable mappings
+; (e.g., AstDB + Realtime) if a backend was temporarily unavailable.
+; NOTE: This is best-effort and does not guarantee atomicity across backends.
+; Default: no (preserves legacy behavior).
+;
+;update_or_create_on_update_miss = no
+
 ;
 ; Wizards
 ;

--- a/include/asterisk/sorcery.h
+++ b/include/asterisk/sorcery.h
@@ -1623,6 +1623,24 @@ int ast_sorcery_is_object_field_registered(const struct ast_sorcery_object_type 
  */
 const char *ast_sorcery_get_module(const struct ast_sorcery *sorcery);
 
+/**
+ * \brief Global control for optional update->create fallback in backends.
+ *
+ * When non-zero, writable Sorcery backends may attempt to call create()
+ * if update() indicates the object is missing (e.g., 0 rows affected or
+ * NOT_FOUND). This helps re-populate backends that temporarily missed an
+ * insert.
+ *
+ * Default is 0 (off) to maintain legacy behavior.
+ *
+ * Configured via sorcery.conf:
+ *   [general]
+ *   update_or_create_on_update_miss = yes|no
+ *
+ * NOTE: Backends MUST gate their fallback logic on this variable.
+ */
+extern int ast_sorcery_update_or_create_on_update_miss;
+
 /*!
  * \section AstSorceryConvenienceMacros Simple Sorcery Convenience Macros
  *

--- a/res/res_sorcery_astdb.c
+++ b/res/res_sorcery_astdb.c
@@ -373,7 +373,7 @@ static int sorcery_astdb_update(const struct ast_sorcery *sorcery, void *data, v
 	snprintf(family, sizeof(family), "%s/%s", prefix, ast_sorcery_object_get_type(object));
 
 	/* It is okay for the value to be truncated, we are only checking that it exists */
-	if (ast_db_get(family, ast_sorcery_object_get_id(object), value, sizeof(value))) {
+	if (ast_db_get(family, ast_sorcery_object_get_id(object), value, sizeof(value)) && !ast_sorcery_update_or_create_on_update_miss) {
 		return -1;
 	}
 

--- a/res/res_sorcery_memory.c
+++ b/res/res_sorcery_memory.c
@@ -229,12 +229,17 @@ static int sorcery_memory_update(const struct ast_sorcery *sorcery, void *data, 
 
 	ao2_lock(data);
 
-	if (!(existing = ao2_find(data, ast_sorcery_object_get_id(object), OBJ_KEY | OBJ_UNLINK))) {
+	if (!(existing = ao2_find(data, ast_sorcery_object_get_id(object), OBJ_KEY | OBJ_UNLINK)) && !ast_sorcery_update_or_create_on_update_miss) {
 		ao2_unlock(data);
 		return -1;
 	}
 
-	ao2_link(data, object);
+	if (existing) {
+		ao2_link(data, object);
+	} else {
+		/* Not found: only create if the global flag is enabled */
+		ao2_link_flags(data, object, OBJ_NOLOCK);
+	}
 
 	ao2_unlock(data);
 

--- a/tests/test_sorcery.c
+++ b/tests/test_sorcery.c
@@ -2141,8 +2141,15 @@ AST_TEST_DEFINE(object_update_uncreated)
 		return AST_TEST_FAIL;
 	}
 
+	ast_sorcery_update_or_create_on_update_miss = 0;
 	if (!ast_sorcery_update(sorcery, obj)) {
 		ast_test_status_update(test, "Successfully updated an object which has not been created yet\n");
+		return AST_TEST_FAIL;
+	}
+
+	ast_sorcery_update_or_create_on_update_miss = 1;
+	if (ast_sorcery_update(sorcery, obj)) {
+		ast_test_status_update(test, "Failed to create object when update() finds no object in a backend\n");
 		return AST_TEST_FAIL;
 	}
 

--- a/tests/test_sorcery_astdb.c
+++ b/tests/test_sorcery_astdb.c
@@ -511,8 +511,15 @@ AST_TEST_DEFINE(object_update_uncreated)
 		return AST_TEST_FAIL;
 	}
 
+	ast_sorcery_update_or_create_on_update_miss = 0;
 	if (!ast_sorcery_update(sorcery, obj)) {
 		ast_test_status_update(test, "Successfully updated an object which has not been created yet\n");
+		return AST_TEST_FAIL;
+	}
+
+	ast_sorcery_update_or_create_on_update_miss = 1;
+	if (ast_sorcery_update(sorcery, obj)) {
+		ast_test_status_update(test, "Failed to create object when update() finds no object in a backend\n");
 		return AST_TEST_FAIL;
 	}
 


### PR DESCRIPTION
This patch resolves two issues in Sorcery objectset handling with multiple
backends:

1. Prevent duplicate objects:
   When an object exists in more than one backend (e.g., a contact in both
   'astdb' and 'realtime'), the objectset previously returned multiple instances
   of the same logical object. This caused logic failures in components like the
   PJSIP registrar, where duplicate contact entries led to overcounting and
   incorrect deletions, when max_contacts=1 and remove_existing=yes.

   This patch ensures only one instance of an object with a given key is added
   to the objectset, avoiding these duplicate-related side effects.

2. Ensure missing objects are created:
   When using multiple writable backends, a temporary backend failure can lead
   to objects missing permanently from that backend.
   Currently, .update() silently fails if the object is not present,
   and no .create() is attempted.
   This results in inconsistent state across backends (e.g. astdb vs. realtime).

   This patch introduces a new global option in sorcery.conf:
     [general]
     update_or_create_on_update_miss = yes|no

   Default: no (preserves existing behavior).

   When enabled: if .update() fails with no data found, .create() is attempted
   in that backend. This ensures that objects missing due to temporary backend
   outages are re-synchronized once the backend is available again.

   Added a new CLI command:
     sorcery show settings
   Displays global Sorcery settings, including the current value of
   update_or_create_on_update_miss.

   Updated tests to validate both flag enabled/disabled behavior.

Fixes: #1289

UserNote: Users relying on Sorcery multiple writable backends configurations
(e.g., astdb + realtime) may now enable update_or_create_on_update_miss = yes
in sorcery.conf to ensure missing objects are recreated after temporary backend
failures. Default behavior remains unchanged unless explicitly enabled.
