### PR TITLE
channelstorage_cpp_map_name_id: Fix callback returning non-matching channels.

### DIFF
--- a/main/channelstorage_cpp_map_name_id.cc
+++ b/main/channelstorage_cpp_map_name_id.cc
@@ -151,12 +151,13 @@ static struct ast_channel *callback(struct ast_channelstorage_instance *driver,
 		chan = it->second;
 		if (cb_fn(chan, arg, data, ao2_flags) == (CMP_MATCH | CMP_STOP)) {
 			ao2_bump(chan);
-			break;
+			unlock(driver);
+			return chan;
 		}
 	}
 	unlock(driver);
 
-	return chan;
+	return NULL;
 }
 
 enum cpp_map_iterator_type {


### PR DESCRIPTION
When the callback() API was invoked but no channel passed the test, callback
would return the last channel tested instead of NULL.  It now correctly
returns NULL when no channel matches.

Resolves: #1288
