### PR TITLE
res_config_odbc: Prevent Realtime fallback on record-not-found (SQL_NO_DATA)

### DIFF
--- a/include/asterisk/config.h
+++ b/include/asterisk/config.h
@@ -126,6 +126,12 @@ typedef int realtime_require(const char *database, const char *table, va_list ap
  */
 typedef int realtime_unload(const char *database, const char *table);
 
+/*! Special return value indicating a successful query that returned no data.
+ * Used by realtime backends to signal "not found" vs an actual backend failure.
+ * This allows the core engine to differentiate and avoid unnecessary failover.
+ */
+#define CONFIG_RT_NOT_FOUND	(void *)-1
+
 /*! \brief Configuration engine structure, used to define realtime drivers */
 struct ast_config_engine {
 	char *name;

--- a/main/config.c
+++ b/main/config.c
@@ -3660,8 +3660,20 @@ struct ast_variable *ast_load_realtime_all_fields(const char *family, const stru
 
 	for (i = 1; ; i++) {
 		if ((eng = find_engine(family, i, db, sizeof(db), table, sizeof(table)))) {
-			if (eng->realtime_func && (res = eng->realtime_func(db, table, fields))) {
-				return res;
+			if (eng->realtime_func) {
+				res = eng->realtime_func(db, table, fields);
+
+				/* If a backend returns CONFIG_RT_NOT_FOUND, stop iteration and return NULL,
+				 * indicating that the requested record does not exist and no failover should occur.
+				 * Only continue iteration if the result is NULL and not CONFIG_RT_NOT_FOUND,
+				 * which signals a backend failure.
+				 */
+				if (res == CONFIG_RT_NOT_FOUND) {
+					return NULL;
+				}
+				if (res) {
+					return res;
+				}
 			}
 		} else {
 			return NULL;


### PR DESCRIPTION
This patch fixes an issue in the ODBC Realtime engine where Asterisk incorrectly
falls back to the next configured backend when the current one returns
SQL_NO_DATA (i.e., no record found).
This is a logical error and performance risk in multi-backend configurations.

Solution:
Introduced CONFIG_RT_NOT_FOUND ((void *)-1) as a special return marker.
ODBC Realtime backend now return CONFIG_RT_NOT_FOUND when no data is found.
Core engine stops iterating on this marker, avoiding unnecessary fallback.

Notes:
Other Realtime backends (PostgreSQL, LDAP, etc.) can be updated similarly.
This patch only covers ODBC.

Fixes: #1305
