### PR TITLE
app_mixmonitor:  Update the documentation concerning the "D" option.

### DIFF
--- a/apps/app_mixmonitor.c
+++ b/apps/app_mixmonitor.c
@@ -131,9 +131,11 @@
 						the file in the configured monitoring directory.</para>
 					</option>
 					<option name="D">
-						<para>Interleave the audio coming from the channel and the audio coming to the channel in
-						the output audio as a dual channel stream, rather than mix it.</para>
-						<note><para>Use .raw as the extension.</para></note>
+						<para>Interleave the audio coming from the channel and the audio
+						going to the channel and output it as a 2 channel (stereo)
+						raw stream rather than mixing it. You must use the
+						<literal>.raw</literal> file extension. Any other extension
+						will produce a corrupted file.</para>
 					</option>
 					<option name="n">
 						<para>When the <replaceable>r</replaceable> or <replaceable>t</replaceable> option is
@@ -189,6 +191,9 @@
 			parameters.  You risk a command injection attack executing arbitrary commands
 			if the untrusted strings aren't filtered to remove dangerous characters.  See
 			function <variable>FILTER()</variable>.</para></warning>
+			<warning><para>When using the <literal>D</literal> option to save
+			interleaved audio, you MUST use <literal>.raw</literal> as the
+			file extension.  Any other extension will produce a corrupted file.</para></warning>
 		</description>
 		<see-also>
 			<ref type="application">StopMixMonitor</ref>


### PR DESCRIPTION
When using the "D" option to output interleaved audio, the file extension
must be ".raw".  That info wasn't being properly rendered in the markdown
and HTML on the documentation site.  The XML was updated to move the
note in the option section to a warning in the description.

Resolves: #1269
