### PR TITLE
pbx.c: When the AST_SOFTHANGUP_ASYNCGOTO flag is set, pbx_extension_helper should return directly.

### DIFF
--- a/main/pbx.c
+++ b/main/pbx.c
@@ -2942,11 +2942,17 @@ static int pbx_extension_helper(struct ast_channel *c, struct ast_context *con,
 				ast_log(LOG_WARNING, "No application '%s' for extension (%s, %s, %d)\n", e->app, context, exten, priority);
 				return -1;
 			}
+			ast_channel_lock(c);
+			if (ast_channel_softhangup_internal_flag(c) & AST_SOFTHANGUP_ASYNCGOTO) {
+				ast_channel_unlock(c);
+				return 0;
+			}
 			if (ast_channel_context(c) != context)
 				ast_channel_context_set(c, context);
 			if (ast_channel_exten(c) != exten)
 				ast_channel_exten_set(c, exten);
 			ast_channel_priority_set(c, priority);
+			ast_channel_unlock(c);
 			if (substitute) {
 				pbx_substitute_variables_helper(c, substitute, passdata, sizeof(passdata)-1);
 			}


### PR DESCRIPTION
Under certain circumstances the context/extens/prio are set in the ast_async_goto, for example action Redirect.
In the situation that action Redirect is broken by pbx_extension_helper this info is changed.
This will cause the current dialplan location to be executed twice. 
In other words, the Redirect action does not take effect.

Resolves: #1315