### PR TITLE
cdr: add CANCEL dispostion in CDR

### DIFF
--- a/configs/samples/cdr.conf.sample
+++ b/configs/samples/cdr.conf.sample
@@ -96,6 +96,12 @@
 ; is "yes".
 ;safeshutdown=yes
 
+; Define if the CANCEL disposition state should be used.
+; When enabled, The NO ANSWER disposition will be split into two distinct 
+; dispositions: CANCEL and NO ANSWER.
+; The default value is "no".
+;canceldispositionenabled = no
+
 ;
 ;
 ; CHOOSING A CDR "BACKEND"  (what kind of output to generate)

--- a/include/asterisk/cdr.h
+++ b/include/asterisk/cdr.h
@@ -227,6 +227,7 @@ enum ast_cdr_settings {
 	CDR_CHANNEL_DEFAULT_ENABLED = 1 << 7, /*!< Whether CDR is enabled for each channel by default */
 	CDR_IGNORE_STATE_CHANGES = 1 << 8,	/*!< Whether to ignore bridge and other call state change events */
 	CDR_IGNORE_DIAL_CHANGES = 1 << 9,	/*!< Whether to ignore dial state changes */
+	CDR_CANCEL_DISPOSITION_ENABLED = 1 << 10, /*!< Whether to enable CANCEL disposition in CDR */
 };
 
 /*! \brief CDR Batch Mode settings */
@@ -260,6 +261,7 @@ enum ast_cdr_disposition {
 	AST_CDR_BUSY       = (1 << 2),
 	AST_CDR_ANSWERED   = (1 << 3),
 	AST_CDR_CONGESTION = (1 << 4),
+	AST_CDR_CANCEL     = (1 << 5),
 };
 
 


### PR DESCRIPTION
In the original implementation, both CANCEL and NO ANSWER states were consolidated under the NO ANSWER disposition. This patch introduces a separate CANCEL disposition, with an optional configuration switch to enable this new disposition.

Resolves: #1323

UserNote: A new CDR option "canceldispositionenabled" has been added that when set to true, the NO ANSWER disposition will be split into two dispositions: CANCEL and NO ANSWER. The default value is 'no'
