### PR TITLE
app_agent_pool: Remove documentation for removed option.

### DIFF
--- a/apps/app_agent_pool.c
+++ b/apps/app_agent_pool.c
@@ -150,9 +150,6 @@
 					<enum name="status">
 						<para>(default) The status of the agent (LOGGEDIN | LOGGEDOUT)</para>
 					</enum>
-					<enum name="password">
-						<para>Deprecated.  The dialplan handles any agent authentication.</para>
-					</enum>
 					<enum name="name">
 						<para>The name of the agent</para>
 					</enum>


### PR DESCRIPTION
The already-deprecated "password" option for the AGENT function was removed in commit d43b17a872e8227aa8a9905a21f90bd48f9d5348 for Asterisk 12, but the documentation for it wasn't removed then.

Resolves: #1321