### PR TITLE
res_stasis_device_state: Fix delete ARI Devicestates after asterisk restart.

### DIFF
--- a/res/res_stasis_device_state.c
+++ b/res/res_stasis_device_state.c
@@ -283,7 +283,7 @@ static void populate_cache(void)
 		if (!ast_strlen_zero(name)) {
 			ast_devstate_changed(
 				ast_devstate_val(entry->data),
-				AST_DEVSTATE_CACHABLE, "%s%s\n",
+				AST_DEVSTATE_CACHABLE, "%s%s",
 				DEVICE_STATE_SCHEME_STASIS, name + 1);
 		}
 	}


### PR DESCRIPTION
After an asterisk restart, the deletion of ARI Devicestates didn't
return error, but the devicestate was not deleted.
Found a typo on populate_cache function that created wrong cache for
device states.
This bug caused wrong assumption that devicestate didn't exist,
since it was not in cache, so deletion didn't returned error.

Fixes: #1327