### PR TITLE
safe_asterisk: Add ownership checks for /etc/asterisk/startup.d and its files.

### DIFF
--- a/contrib/scripts/safe_asterisk
+++ b/contrib/scripts/safe_asterisk
@@ -6,7 +6,7 @@ ASTVARRUNDIR="__ASTERISK_VARRUN_DIR__"
 ASTVARLOGDIR="__ASTERISK_LOG_DIR__"
 
 CLIARGS="$*"			# Grab any args passed to safe_asterisk
-TTY=9				# TTY (if you want one) for Asterisk to run on
+#TTY=9				# TTY (if you want one) for Asterisk to run on
 CONSOLE=yes			# Whether or not you want a console
 #NOTIFY=root@localhost		# Who to notify about crashes
 #EXEC=/path/to/somescript	# Run this command if Asterisk crashes
@@ -39,6 +39,8 @@ PRIORITY=0
 message() {
 	if test -n "$TTY" && test "$TTY" != "no"; then
 		echo "$1" >/dev/${TTY}
+	else
+		echo "$1" >&2
 	fi
 	if test -n "$SYSLOG"; then
 		logger -p "${SYSLOG}.warn" -t safe_asterisk[$$] "$1"
@@ -64,7 +66,7 @@ if test `id -u` != 0; then
 	echo "Oops. I'm not root. Falling back to standard prio and file max." >&2
 	echo "This is NOT suitable for large systems." >&2
 	PRIORITY=0
-	message "safe_asterisk was started by `id -n` (uid `id -u`)."
+	message "safe_asterisk was started by `id -un` (uid `id -u`)."
 else
 	if `uname -s | grep Linux >/dev/null 2>&1`; then
 		# maximum number of open files is set to the system maximum
@@ -160,10 +162,30 @@ trap '' PIPE
 #
 
 if test -d "${ASTETCDIR}/startup.d"; then
-	for script in "${ASTETCDIR}/startup.d/"*.sh; do
-		if test -r "${script}"; then
-			. "${script}"
+	# If this script is run by root, the startup.d directory and all scripts in it
+	# must be owned by root.
+	if test `id -u` == 0; then
+		dir_owner=$(stat -c '%u' "${ASTETCDIR}/startup.d" 2>/dev/null)
+		if test "${dir_owner}" != 0 ; then
+			message "FATAL: ${ASTETCDIR}/startup.d is not owned by root"
+			exit 1
 		fi
+
+		# Check all scripts for proper ownership before sourcing any of them.
+		for script in $(find "${ASTETCDIR}/startup.d/" -name '*.sh') ; do
+			if test -r "${script}"; then
+				script_owner=$(stat -c '%u' "${script}" 2>/dev/null)
+				if test "$script_owner" != 0 ; then
+					message "FATAL: Script $(basename "$script") is not owned by root"
+					exit 1
+				fi
+			fi
+		done
+	fi
+
+	for script in $(find "${ASTETCDIR}/startup.d/" -name '*.sh') ; do
+		echo sourceing
+		. "${script}"
 	done
 fi
 


### PR DESCRIPTION
UpgradeNote: The safe_asterisk script now checks that, if it was run by the
root user, the /etc/asterisk/startup.d directory and all the files it contains
are owned by root.  If the checks fail, safe_asterisk will exit with an error
and Asterisk will not be started.  Additionally, the default logging
destination is now stderr instead of tty "9" which probably won't exist
in modern systems.

Resolves: #GHSA-v9q8-9j8m-5xwp
