### PR TITLE
logger.c: Remove deprecated/redundant configuration option.

### DIFF
--- a/main/logger.c
+++ b/main/logger.c
@@ -840,11 +840,6 @@ static int init_logger_chain(const char *altconf)
 		} else {
 			fprintf(stderr, "Unknown rotatestrategy: %s\n", s);
 		}
-	} else {
-		if ((s = ast_variable_retrieve(cfg, "general", "rotatetimestamp"))) {
-			rotatestrategy = ast_true(s) ? TIMESTAMP : SEQUENTIAL;
-			fprintf(stderr, "rotatetimestamp option has been deprecated.  Please use rotatestrategy instead.\n");
-		}
 	}
 	if ((s = ast_variable_retrieve(cfg, "general", "logger_queue_limit"))) {
 		if (sscanf(s, "%30d", &logger_queue_limit) != 1) {


### PR DESCRIPTION
Remove the deprecated 'rotatetimestamp' config option, as this was deprecated by 'rotatestrategy' in 1.6 by commit f5a14167f3ef090f8576da3070ed5c452fa01e44.

Resolves: #1345

UpgradeNote: The deprecated rotatetimestamp option has been removed. Use rotatestrategy instead.