### PR TITLE
pbx_lua.c: segfault when pass null data to term_color function

### DIFF
--- a/pbx/pbx_lua.c
+++ b/pbx/pbx_lua.c
@@ -222,7 +222,7 @@ static int lua_pbx_exec(lua_State *L)
 			exten, context, priority,
 			term_color(tmp, app_name, COLOR_BRCYAN, 0, sizeof(tmp)),
 			term_color(tmp2, ast_channel_name(chan), COLOR_BRMAGENTA, 0, sizeof(tmp2)),
-			term_color(tmp3, data, COLOR_BRMAGENTA, 0, sizeof(tmp3)));
+			term_color(tmp3, data ? data : "", COLOR_BRMAGENTA, 0, sizeof(tmp3)));
 
 	lua_getfield(L, LUA_REGISTRYINDEX, "autoservice");
 	autoservice = lua_toboolean(L, -1);


### PR DESCRIPTION
This can be reproduced under certain curcomstences.
For example: call app.playback from lua with invalid data: app.playback({}).
pbx_lua.c will try to get data for this playback using lua_tostring function.
This function returs NULL for everything but strings and numbers.
Then, it calls term_color with NULL data.
term_color function can call(if we don't use vt100 compat term)
ast_copy_string with NULL inbuf which cause segfault. bt example:
ast_copy_string (size=8192, src=0x0, dst=0x7fe44b4be8b0)
at /usr/src/asterisk/asterisk-20.11.0/include/asterisk/strings.h:412

Resolves: https://github.com/asterisk/asterisk/issues/1363