### PR TITLE
bridge.c: Obey BRIDGE_NOANSWER variable to skip answering channel.

### DIFF
--- a/main/features.c
+++ b/main/features.c
@@ -172,6 +172,9 @@
 						<para>Additionally, to prevent a bridged channel (the target of the Bridge application)
 						from answering, the <literal>BRIDGE_NOANSWER</literal> variable can be set to inhibit
 						answering.</para>
+						<warning><para>Do not set the <literal>BRIDGE_NOANSWER</literal> variable globally,
+						as it will break normal bridging behavior in many cases. Only use this variable on
+						a per-channel basis when you really know what you are doing!</para></warning>
 					</option>
 					<option name="S(x)">
 						<para>Hang up the call after <replaceable>x</replaceable> seconds *after* the called party has answered the call.</para>


### PR DESCRIPTION
If the BRIDGE_NOANSWER variable is set on a channel, it is not supposed to answer when another channel bridges to it using Bridge(), and this is checked when ast_bridge_call* is called. However, another path exists (bridge_exec -> ast_bridge_add_channel) where this variable was not checked and channels would be answered. We now check the variable there.

Resolves: #401
Resolves: #1364