### PR TITLE
func_frame_drop: Handle allocation failure properly.

### DIFF
--- a/funcs/func_frame_drop.c
+++ b/funcs/func_frame_drop.c
@@ -234,8 +234,10 @@ static int frame_drop_helper(struct ast_channel *chan, const char *cmd, char *da
 		framedata->list_type = TX;
 	}
 
-	buffer = ast_malloc(sizeof(value) + 3); /* leading and trailing comma and null terminator */
-	snprintf(buffer, sizeof(value) + 2, ",%s,", value);
+	if (ast_asprintf(&buffer, ",%s,", value) < 0) {
+		ast_free(framedata);
+		return -1;
+	}
 	for (i = 0; i < ARRAY_LEN(frametype2str); i++) {
 		if (strcasestr(buffer, frametype2str[i].str)) {
 			framedata->values[i] = 1;


### PR DESCRIPTION
Handle allocation failure and simplify the allocation using asprintf.

Resolves: #1366