### PR TITLE
test_res_prometheus: Fix compilation failure on Debian 13.

### DIFF
--- a/tests/test_res_prometheus.c
+++ b/tests/test_res_prometheus.c
@@ -83,10 +83,10 @@ static CURL *get_curl_instance(void)
 		return NULL;
 	}
 
-	curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1);
-	curl_easy_setopt(curl, CURLOPT_TIMEOUT, 180);
+	curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+	curl_easy_setopt(curl, CURLOPT_TIMEOUT, 180L);
 	curl_easy_setopt(curl, CURLOPT_USERAGENT, AST_CURL_USER_AGENT);
-	curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1);
+	curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
 	curl_easy_setopt(curl, CURLOPT_URL, server_uri);
 
 	return curl;


### PR DESCRIPTION
curl_easy_setopt expects long types, so be explicit.

Resolves: #1369