### PR TITLE
chan_dahdi: Fix erroneously persistent dialmode.

### DIFF
--- a/channels/chan_dahdi.h
+++ b/channels/chan_dahdi.h
@@ -146,7 +146,7 @@ struct dahdi_pvt {
 	 * \note Set to a couple of nonzero values but it is only tested like a boolean.
 	 */
 	int radio;
-	int dialmode;					/*!< Dialing Modes Allowed (Pulse/Tone) */
+	enum analog_dialmode permdialmode;	/*!< Dialing Modes Allowed (Pulse/Tone). Used for reading in chan_dahdi.conf only, the perm setting pair is in sig_analog */
 	int outsigmod;					/*!< Outbound Signalling style (modifier) */
 	int oprmode;					/*!< "Operator Services" mode */
 	struct dahdi_pvt *oprpeer;				/*!< "Operator Services" peer tech_pvt ptr */

--- a/channels/sig_analog.h
+++ b/channels/sig_analog.h
@@ -301,6 +301,7 @@ struct analog_pvt {
 	unsigned int permcallwaiting:1;			/*!< TRUE if call waiting is enabled. (Configured option) */
 	unsigned int callwaitingdeluxe:1;		/*!< TRUE if Call Waiting Deluxe options are available */
 	unsigned int permhidecallerid:1;		/*!< Whether to hide our outgoing caller ID or not */
+	enum analog_dialmode permdialmode;		/*!< Which of pulse and/or tone dialing to support */
 	unsigned int pulse:1;
 	unsigned int threewaycalling:1;
 	unsigned int threewaysilenthold:1;		/*!< Whether to time out a three-way dial tone to silence */


### PR DESCRIPTION
It is possible to modify the dialmode setting in the chan_dahdi/sig_analog private using the CHANNEL function, to modify it during calls. However, it was not being reset between calls, meaning that if, for example, tone dialing was disabled, it would never work again unless explicitly enabled.

This fixes the setting by pairing it with a "perm" version of the setting, as a few other features have, so that it can be reset to the permanent setting between calls. The documentation is also clarified to explain the interaction of this setting and the digitdetect setting more clearly.

Resolves: #1378