### PR TITLE
app_queue: fix comparison for announce-position-only-up

### DIFF
--- a/apps/app_queue.c
+++ b/apps/app_queue.c
@@ -4370,7 +4370,7 @@ static int say_position(struct queue_ent *qe, int ringing)
 	}
 
 	/* Only announce if the caller's queue position has improved since last time */
-	if (qe->parent->announceposition_only_up && qe->last_pos_said <= qe->pos) {
+	if (qe->parent->announceposition_only_up && qe->last_pos_said > 0 && qe->last_pos_said <= qe->pos) {
 		return 0;
 	}
 


### PR DESCRIPTION
Numerically comparing that the current queue position is less than last_pos_said can only be done after at least one announcement has been made, otherwise last_pos_said is at the default (0).

Fixes: #1386 