### PR TITLE
sig_analog: Skip Caller ID spill if usecallerid=no.

### DIFF
--- a/channels/sig_analog.c
+++ b/channels/sig_analog.c
@@ -390,6 +390,12 @@ static int analog_unalloc_sub(struct analog_pvt *p, enum analog_sub x)
 
 static int analog_send_callerid(struct analog_pvt *p, int cwcid, struct ast_party_caller *caller)
 {
+	/* If Caller ID is disabled for the line, that means we do not send ANY spill whatsoever. */
+	if (!p->use_callerid) {
+		ast_debug(1, "Caller ID is disabled for channel %d, skipping spill\n", p->channel);
+		return 0;
+	}
+
 	ast_debug(1, "Sending callerid.  CID_NAME: '%s' CID_NUM: '%s'\n",
 		caller->id.name.str,
 		caller->id.number.str);

--- a/configs/samples/chan_dahdi.conf.sample
+++ b/configs/samples/chan_dahdi.conf.sample
@@ -570,6 +570,9 @@ context=public
 ;
 ; Whether or not to use caller ID:
 ;
+; On FXO ports, this enables detecting Caller ID on the incoming phone call.
+; On FXS ports, this enables sending a Caller ID spill to CPE.
+;
 usecallerid=yes
 ;
 ; NOTE: If the CALL_QUALIFIER variable on the channel is set to 1,


### PR DESCRIPTION
If Caller ID is disabled for an FXS port, then we should not send any Caller ID spill on the line, as we have no Caller ID information that we can/should be sending.

Resolves: #1394