### PR TITLE
app_queue.c: Add new global 'log_unpause_on_reason_change'

### DIFF
--- a/configs/samples/queues.conf.sample
+++ b/configs/samples/queues.conf.sample
@@ -75,6 +75,11 @@ monitor-type = MixMonitor
 ;
 ;force_longest_waiting_caller = no
 ;
+; Add unpause event to queue log in case of pause send twice with different reason code.
+;
+;log_unpause_on_reason_change = no
+;
+;
 ;[markq]
 ;
 ; A sample call queue


### PR DESCRIPTION
In many asterisk-based systems, the pause reason is used to separate
pauses by type,and logically, changing the reason defines two intervals
that should be accounted for separately. The introduction of a new
option allows me to separate the intervals of operator inactivity in
the log by the event of unpausing.

UserNote: Add new global option 'log_unpause_on_reason_change' that
is default disabled. When enabled cause addition of UNPAUSE event on
every re-PAUSE with reason changed.