### PR TITLE
func_hangupcause.c: Add access to Reason headers via HANGUPCAUSE()

### DIFF
--- a/funcs/func_hangupcause.c
+++ b/funcs/func_hangupcause.c
@@ -55,6 +55,7 @@
 				<para>Parameter describing which type of information is requested. Types are:</para>
 				<enumlist>
 					<enum name="tech"><para>Technology-specific cause information</para></enum>
+					<enum name="tech_extended"><para>Technology-specific extended list of cause information</para></enum>
 					<enum name="ast"><para>Translated Asterisk cause code</para></enum>
 				</enumlist>
 			</parameter>
@@ -119,9 +120,10 @@ static int hangupcause_read(struct ast_channel *chan, const char *cmd, char *dat
 	char *parms;
 	struct ast_control_pvt_cause_code *cause_code;
 	int res = 0;
+	struct ast_str *causelist;
 	AST_DECLARE_APP_ARGS(args,
 		AST_APP_ARG(channel);	/*!< Channel name */
-		AST_APP_ARG(type);	/*!< Type of information requested (ast or tech) */
+		AST_APP_ARG(type);	/*!< Type of information requested (ast, tech or tech_extended) */
 		);
 
 	/* Ensure that the buffer is empty */
@@ -139,25 +141,49 @@ static int hangupcause_read(struct ast_channel *chan, const char *cmd, char *dat
 		return -1;
 	}
 
-	ast_channel_lock(chan);
-	cause_code = ast_channel_dialed_causes_find(chan, args.channel);
-	ast_channel_unlock(chan);
-
-	if (!cause_code) {
-		ast_log(LOG_WARNING, "Unable to find information for channel %s\n", args.channel);
+	causelist = ast_str_create(128);
+	if (!causelist) {
+		ast_log(LOG_ERROR, "Unable to allocate buffer, cause information will be unavailable!\n");
 		return -1;
 	}
+
+	ast_channel_lock(chan);
+	if (!strcmp(args.type, "tech_extended")) {
+		struct ao2_iterator *cause_codes;
+		cause_codes = ast_channel_dialed_causes_find_multiple(chan, args.channel);
+		while ((cause_code = ao2_iterator_next(cause_codes))) {
+			if (!cause_code->cause_extended) {
+				ao2_ref(cause_code, -1);
+				continue;
+			}
+			ast_str_append(&causelist, 0, "%s%s", (ast_str_strlen(causelist) ? "," : ""), cause_code->code);
+			ao2_ref(cause_code, -1);
+		}
+		ao2_iterator_destroy(cause_codes);
+	} else {
+		cause_code = ast_channel_dialed_causes_find(chan, args.channel);
+		if (!cause_code) {
+			ast_log(LOG_WARNING, "Unable to find information for channel '%s'\n", args.channel);
+			ast_channel_unlock(chan);
+			return -1;
+		}
+	}
+	ast_channel_unlock(chan);
 
 	if (!strcmp(args.type, "ast")) {
 		ast_copy_string(buf, ast_cause2str(cause_code->ast_cause), len);
 	} else if (!strcmp(args.type, "tech")) {
 		ast_copy_string(buf, cause_code->code, len);
+	} else if (!strcmp(args.type, "tech_extended")) {
+		ast_copy_string(buf, ast_str_buffer(causelist), len);
 	} else {
 		ast_log(LOG_WARNING, "Information type not recognized (%s)\n", args.type);
 		res = -1;
 	}
 
-	ao2_ref(cause_code, -1);
+	if (cause_code) {
+		ao2_cleanup(cause_code);
+	}
 
 	return res;
 }

--- a/include/asterisk/channel.h
+++ b/include/asterisk/channel.h
@@ -4447,6 +4447,24 @@ struct ast_str *ast_channel_dialed_causes_channels(const struct ast_channel *cha
 struct ast_control_pvt_cause_code *ast_channel_dialed_causes_find(const struct ast_channel *chan, const char *chan_name);
 
 /*!
+ * \since 20.17.0, 22.8.0, 23.1.0
+ * \brief Retrieve a ref-counted cause code information structure iterator
+ *
+ * \details
+ * This function makes use of datastore operations on the channel, so
+ * it is important to lock the channel before calling this function.
+ * This function increases the ref count of the returned object, so the
+ * calling function must decrease the reference count when it is finished
+ * with the object.
+ *
+ * \param chan The channel from which to retrieve information
+ * \param chan_name The name of the channel about which to retrieve information
+ * \retval NULL on search failure
+ * \retval Pointer to a ao2_iterator object containing the desired information
+ */
+struct ao2_iterator *ast_channel_dialed_causes_find_multiple(const struct ast_channel *chan, const char *chan_name);
+
+/*!
  * \since 11
  * \brief Add cause code information to the channel
  *

--- a/include/asterisk/frame.h
+++ b/include/asterisk/frame.h
@@ -417,6 +417,7 @@ enum ast_control_transfer {
 struct ast_control_pvt_cause_code {
 	char chan_name[AST_CHANNEL_NAME];	/*!< Name of the channel that originated the cause information */
 	unsigned int emulate_sip_cause:1;	/*!< Indicates whether this should be used to emulate SIP_CAUSE support */
+	unsigned int cause_extended:1;		/*!< Indicates whether this cause code was retrieved from supplementary sources */
 	int ast_cause;				/*!< Asterisk cause code associated with this message */
 	char code[1];				/*!< Tech-specific cause code information, beginning with the name of the tech */
 };

--- a/main/channel_internal_api.c
+++ b/main/channel_internal_api.c
@@ -1145,23 +1145,68 @@ struct ast_str *ast_channel_dialed_causes_channels(const struct ast_channel *cha
 
 struct ast_control_pvt_cause_code *ast_channel_dialed_causes_find(const struct ast_channel *chan, const char *chan_name)
 {
-	return ao2_find(chan->dialed_causes, chan_name, OBJ_KEY);
+	struct ao2_iterator causes;
+	struct ast_control_pvt_cause_code *cause_code;
+
+	causes = ao2_iterator_init(chan->dialed_causes, 0);
+	while ((cause_code = ao2_iterator_next(&causes))) {
+		if (strcmp(cause_code->chan_name, chan_name)) {
+			ao2_ref(cause_code, -1);
+			continue;
+		}
+		if (!cause_code->cause_extended) {
+			ao2_iterator_destroy(&causes);
+			return cause_code;
+		}
+		ao2_ref(cause_code, -1);
+	}
+	ao2_iterator_destroy(&causes);
+
+	return NULL;
+}
+
+struct ao2_iterator *ast_channel_dialed_causes_find_multiple(const struct ast_channel *chan, const char *chan_name)
+{
+	struct ao2_iterator *causes;
+	struct ast_control_pvt_cause_code *cause_code;
+
+	causes = ao2_find(chan->dialed_causes, chan_name, OBJ_SEARCH_KEY | OBJ_MULTIPLE);
+	while ((cause_code = ao2_iterator_next(causes))) {
+		ao2_ref(cause_code, -1);
+	}
+	ao2_iterator_destroy(causes);
+
+	return ao2_find(chan->dialed_causes, chan_name, OBJ_SEARCH_KEY | OBJ_MULTIPLE);
+}
+
+static int remove_dialstatus_cb(void *obj, void *arg, int flags)
+{
+	struct ast_control_pvt_cause_code *cause_code = obj;
+	char *str = ast_tech_to_upper(ast_strdupa(arg));
+	char *pc_str = ast_tech_to_upper(ast_strdupa(cause_code->chan_name));
+
+	if (cause_code->cause_extended) {
+		return 0;
+	}
+	return !strcmp(pc_str, str) ? CMP_MATCH | CMP_STOP : 0;
 }
 
 int ast_channel_dialed_causes_add(const struct ast_channel *chan, const struct ast_control_pvt_cause_code *cause_code, int datalen)
 {
 	struct ast_control_pvt_cause_code *ao2_cause_code;
-	ao2_find(chan->dialed_causes, cause_code->chan_name, OBJ_KEY | OBJ_UNLINK | OBJ_NODATA);
-	ao2_cause_code = ao2_alloc(datalen, NULL);
+	char *arg = ast_strdupa(cause_code->chan_name);
 
+	ao2_callback(chan->dialed_causes, OBJ_MULTIPLE | OBJ_NODATA | OBJ_UNLINK, remove_dialstatus_cb, arg);
+
+	ao2_cause_code = ao2_alloc(datalen, NULL);
 	if (ao2_cause_code) {
 		memcpy(ao2_cause_code, cause_code, datalen);
 		ao2_link(chan->dialed_causes, ao2_cause_code);
 		ao2_ref(ao2_cause_code, -1);
 		return 0;
-	} else {
-		return -1;
 	}
+
+	return -1;
 }
 
 void ast_channel_dialed_causes_clear(const struct ast_channel *chan)


### PR DESCRIPTION
As soon as SIP call may end with several Reason headers, we want to make all of them available through the HAGUPCAUSE() function. This implementation uses the same ao2 hash for cause codes storage and adds a flag to make difference between last processed sip message and content of reason headers.

UserNote: Added a new option to HANGUPCAUSE to access additional information about hangup reason. Reason headers from pjsip could be read using 'tech_extended' cause type.