### PR TITLE
manager.c: Fix presencestate object leak

### DIFF
--- a/main/manager.c
+++ b/main/manager.c
@@ -5524,6 +5524,9 @@ static int action_presencestate(struct mansession *s, const struct message *m)
 	}
 	astman_append(s, "\r\n");
 
+	ast_free(subtype);
+	ast_free(message);
+
 	return 0;
 }
 


### PR DESCRIPTION
ast_presence_state allocates subtype and message. We straightforwardly need to clean those up.