### PR TITLE
app_adsiprog: Fix possible NULL dereference.

### DIFF
--- a/apps/app_adsiprog.c
+++ b/apps/app_adsiprog.c
@@ -848,7 +848,10 @@ static int onevent(char *buf, char *name, int id, char *args, struct adsi_script
 			return 0;
 		}
 		/* Process 'in' things */
-		tok = get_token(&args, script, lineno);
+		if (!(tok = get_token(&args, script, lineno))) {
+			ast_log(LOG_WARNING, "Missing state name at line %d of %s\n", lineno, script);
+			return 0;
+		}
 		if (process_token(sname, tok, sizeof(sname), ARG_STRING)) {
 			ast_log(LOG_WARNING, "'%s' is not a valid state name at line %d of %s\n", tok, lineno, script);
 			return 0;


### PR DESCRIPTION
get_token can return NULL, but process_token uses this result without checking for NULL; as elsewhere, check for a NULL result to avoid possible NULL dereference.

Resolves: #1419