### PR TITLE
stasis_channels.c: Add null check for referred_by in ast_ari_transfer_message_create

### DIFF
--- a/main/stasis_channels.c
+++ b/main/stasis_channels.c
@@ -1797,11 +1797,14 @@ struct ast_ari_transfer_message *ast_ari_transfer_message_create(struct ast_chan
 		}
 	}
 
-	msg->referred_by = ast_strdup(referred_by);
-	if (!msg->referred_by) {
-		ao2_cleanup(msg);
-		return NULL;
+	if (referred_by) {
+		msg->referred_by = ast_strdup(referred_by);
+		if (!msg->referred_by) {
+			ao2_cleanup(msg);
+			return NULL;
+		}
 	}
+
 	ast_copy_string(msg->destination, exten, sizeof(msg->destination));
 	msg->protocol_id = ast_strdup(protocol_id);
 	if (!msg->protocol_id) {


### PR DESCRIPTION
When handling SIP transfers via ARI, the `referred_by` field in `transfer_ari_state` may be null, since SIP REFER requests are not required to include a `Referred-By` header. Without this check, a null value caused the transfer to fail and triggered a NOTIFY with a 500 Internal Server Error.