### PR TITLE
stasis_channels.c: Make protocol_id optional to enable blind transfer via ari

### DIFF
--- a/main/stasis_channels.c
+++ b/main/stasis_channels.c
@@ -1666,11 +1666,14 @@ static struct ast_json *ari_transfer_to_json(struct stasis_message *msg,
 	const struct timeval *tv = stasis_message_timestamp(msg);
 	struct ast_ari_transfer_message *transfer_msg = stasis_message_data(msg);
 
-	dest_json = ast_json_pack("{s: s, s: s}",
-		"protocol_id", transfer_msg->protocol_id,
-		"destination", transfer_msg->destination);
+	dest_json = ast_json_pack("{s: s}", "destination", transfer_msg->destination);
 	if (!dest_json) {
 		return NULL;
+	}
+
+	if (transfer_msg->protocol_id) {
+		ast_json_object_set(dest_json, "protocol_id",
+			ast_json_string_create(transfer_msg->protocol_id));
 	}
 
 	if (AST_VECTOR_SIZE(transfer_msg->refer_params) > 0) {
@@ -1803,10 +1806,13 @@ struct ast_ari_transfer_message *ast_ari_transfer_message_create(struct ast_chan
 		return NULL;
 	}
 	ast_copy_string(msg->destination, exten, sizeof(msg->destination));
-	msg->protocol_id = ast_strdup(protocol_id);
-	if (!msg->protocol_id) {
-		ao2_cleanup(msg);
-		return NULL;
+
+	if (protocol_id) {
+		msg->protocol_id = ast_strdup(protocol_id);
+		if (!msg->protocol_id) {
+			ao2_cleanup(msg);
+			return NULL;
+		}
 	}
 
 	return msg;


### PR DESCRIPTION
When handling SIP transfers via ARI, there is no protocol_id in case of a blind transfer.

Resolves: #1467