### PR TITLE
res_rtp_asterisk.c: Use rtp->dtls in __rtp_sendto when rtcp mux is used.

### DIFF
--- a/res/res_rtp_asterisk.c
+++ b/res/res_rtp_asterisk.c
@@ -3453,7 +3453,7 @@ static int __rtp_sendto(struct ast_rtp_instance *instance, void *buf, size_t siz
 	int res;
 #if defined(HAVE_OPENSSL) && (OPENSSL_VERSION_NUMBER >= 0x10001000L) && !defined(OPENSSL_NO_SRTP)
 	char *out = buf;
-	struct dtls_details *dtls = !rtcp ? &rtp->dtls : &rtp->rtcp->dtls;
+	struct dtls_details *dtls = (!rtcp || rtp->rtcp->type == AST_RTP_INSTANCE_RTCP_MUX) ? &rtp->dtls : &rtp->rtcp->dtls;
 
 	/* Don't send RTP if DTLS hasn't finished yet */
 	if (dtls->ssl && ((*out < 20) || (*out > 63)) && dtls->connection == AST_RTP_DTLS_CONNECTION_NEW) {


### PR DESCRIPTION
In __rtp_sendto(), the check for DTLS negotiation completion for rtcp packets
needs to use the rtp->dtls structure instead of rtp->rtcp->dtls when
AST_RTP_INSTANCE_RTCP_MUX is set.

Resolves: #1474
