### PR TITLE
ARI: The bridges play and record APIs now handle sample rates > 8K correctly.

### DIFF
--- a/res/ari/resource_bridges.h
+++ b/res/ari/resource_bridges.h
@@ -285,6 +285,8 @@ struct ast_ari_bridges_play_args {
 	size_t media_count;
 	/*! Parsing context for media. */
 	char *media_parse;
+	/*! Format of the 'Anouncer' channel attached to the bridge. Defaults to the format of the channel in the bridge with the highest sampe rate. */
+	const char *announcer_format;
 	/*! For sounds, selects language for sound. */
 	const char *lang;
 	/*! Number of milliseconds to skip before playing. Only applies to the first URI if multiple media URIs are specified. */
@@ -327,6 +329,8 @@ struct ast_ari_bridges_play_with_id_args {
 	size_t media_count;
 	/*! Parsing context for media. */
 	char *media_parse;
+	/*! Format of the 'Anouncer' channel attached to the bridge. Defaults to the format of the channel in the bridge with the highest sampe rate. */
+	const char *announcer_format;
 	/*! For sounds, selects language for sound. */
 	const char *lang;
 	/*! Number of milliseconds to skip before playing. Only applies to the first URI if multiple media URIs are specified. */
@@ -363,6 +367,8 @@ struct ast_ari_bridges_record_args {
 	const char *name;
 	/*! Format to encode audio in */
 	const char *format;
+	/*! Format of the 'Recorder' channel attached to the bridge. Defaults to the same format as the 'format' parameter. */
+	const char *recorder_format;
 	/*! Maximum duration of the recording, in seconds. 0 for no limit. */
 	int max_duration_seconds;
 	/*! Maximum duration of silence, in seconds. 0 for no limit. */

--- a/res/res_ari_bridges.c
+++ b/res/res_ari_bridges.c
@@ -1044,6 +1044,10 @@ int ast_ari_bridges_play_parse_body(
 			args->media[0] = ast_json_string_get(field);
 		}
 	}
+	field = ast_json_object_get(body, "announcer_format");
+	if (field) {
+		args->announcer_format = ast_json_string_get(field);
+	}
 	field = ast_json_object_get(body, "lang");
 	if (field) {
 		args->lang = ast_json_string_get(field);
@@ -1128,6 +1132,9 @@ static void ast_ari_bridges_play_cb(
 				args.media[j] = (vals[j]);
 			}
 		} else
+		if (strcmp(i->name, "announcer_format") == 0) {
+			args.announcer_format = (i->value);
+		} else
 		if (strcmp(i->name, "lang") == 0) {
 			args.lang = (i->value);
 		} else
@@ -1164,6 +1171,7 @@ static void ast_ari_bridges_play_cb(
 	case 501: /* Not Implemented */
 	case 404: /* Bridge not found */
 	case 409: /* Bridge not in a Stasis application */
+	case 422: /* The format specified is unknown on this system */
 		is_valid = 1;
 		break;
 	default:
@@ -1222,6 +1230,10 @@ int ast_ari_bridges_play_with_id_parse_body(
 			}
 			args->media[0] = ast_json_string_get(field);
 		}
+	}
+	field = ast_json_object_get(body, "announcer_format");
+	if (field) {
+		args->announcer_format = ast_json_string_get(field);
 	}
 	field = ast_json_object_get(body, "lang");
 	if (field) {
@@ -1303,6 +1315,9 @@ static void ast_ari_bridges_play_with_id_cb(
 				args.media[j] = (vals[j]);
 			}
 		} else
+		if (strcmp(i->name, "announcer_format") == 0) {
+			args.announcer_format = (i->value);
+		} else
 		if (strcmp(i->name, "lang") == 0) {
 			args.lang = (i->value);
 		} else
@@ -1339,6 +1354,7 @@ static void ast_ari_bridges_play_with_id_cb(
 	case 501: /* Not Implemented */
 	case 404: /* Bridge not found */
 	case 409: /* Bridge not in a Stasis application */
+	case 422: /* The format specified is unknown on this system */
 		is_valid = 1;
 		break;
 	default:
@@ -1376,6 +1392,10 @@ int ast_ari_bridges_record_parse_body(
 	field = ast_json_object_get(body, "format");
 	if (field) {
 		args->format = ast_json_string_get(field);
+	}
+	field = ast_json_object_get(body, "recorder_format");
+	if (field) {
+		args->recorder_format = ast_json_string_get(field);
 	}
 	field = ast_json_object_get(body, "maxDurationSeconds");
 	if (field) {
@@ -1427,6 +1447,9 @@ static void ast_ari_bridges_record_cb(
 		} else
 		if (strcmp(i->name, "format") == 0) {
 			args.format = (i->value);
+		} else
+		if (strcmp(i->name, "recorder_format") == 0) {
+			args.recorder_format = (i->value);
 		} else
 		if (strcmp(i->name, "maxDurationSeconds") == 0) {
 			args.max_duration_seconds = atoi(i->value);

--- a/rest-api/api-docs/bridges.json
+++ b/rest-api/api-docs/bridges.json
@@ -491,6 +491,14 @@
 							"dataType": "string"
 						},
 						{
+							"name": "announcer_format",
+							"description": "Format of the 'Anouncer' channel attached to the bridge. Defaults to the format of the channel in the bridge with the highest sampe rate.",
+							"paramType": "query",
+							"required": false,
+							"allowMultiple": false,
+							"dataType": "string"
+						},
+						{
 							"name": "lang",
 							"description": "For sounds, selects language for sound.",
 							"paramType": "query",
@@ -510,7 +518,6 @@
 								"valueType": "RANGE",
 								"min": 0
 							}
-
 						},
 						{
 							"name": "skipms",
@@ -542,6 +549,10 @@
 						{
 							"code": 409,
 							"reason": "Bridge not in a Stasis application"
+						},
+						{
+							"code": 422,
+							"reason": "The format specified is unknown on this system"
 						}
 					]
 				}
@@ -586,6 +597,14 @@
 							"dataType": "string"
 						},
 						{
+							"name": "announcer_format",
+							"description": "Format of the 'Anouncer' channel attached to the bridge. Defaults to the format of the channel in the bridge with the highest sampe rate.",
+							"paramType": "query",
+							"required": false,
+							"allowMultiple": false,
+							"dataType": "string"
+						},
+						{
 							"name": "lang",
 							"description": "For sounds, selects language for sound.",
 							"paramType": "query",
@@ -628,6 +647,10 @@
 						{
 							"code": 409,
 							"reason": "Bridge not in a Stasis application"
+						},
+						{
+							"code": 422,
+							"reason": "The format specified is unknown on this system"
 						}
 					]
 
@@ -669,6 +692,14 @@
 							"description": "Format to encode audio in",
 							"paramType": "query",
 							"required": true,
+							"allowMultiple": false,
+							"dataType": "string"
+						},
+						{
+							"name": "recorder_format",
+							"description": "Format of the 'Recorder' channel attached to the bridge. Defaults to the same format as the 'format' parameter.",
+							"paramType": "query",
+							"required": false,
 							"allowMultiple": false,
 							"dataType": "string"
 						},


### PR DESCRIPTION
The bridge play and record APIs were forcing the Announcer/Recorder channel
to slin8 which meant that if you played or recorded audio with a sample
rate > 8K, it was downsampled to 8K limiting the bandwidth.

* The /bridges/play REST APIs have a new "announcer_format" parameter that
  allows the caller to explicitly set the format on the "Announcer" channel
  through which the audio is played into the bridge.  If not specified, the
  default depends on how many channels are currently in the bridge.  If
  a single channel is in the bridge, then the Announcer channel's format
  will be set to the same as that channel's.  If multiple channels are in the
  bridge, the channels will be scanned to find the one with the highest
  sample rate and the Announcer channel's format will be set to the slin
  format that has an equal to or greater than sample rate.

* The /bridges/record REST API has a new "recorder_format" parameter that
  allows the caller to explicitly set the format on the "Recorder" channel
  from which audio is retrieved to write to the file.  If not specified,
  the Recorder channel's format will be set to the format that was requested
  to save the audio in.

Resolves: #1479

DeveloperNote: The ARI /bridges/play and /bridges/record REST APIs have new
parameters that allow the caller to specify the format to be used on the
"Announcer" and "Recorder" channels respecitvely.
