### PR TITLE
func_scramble: Add example to XML documentation.

### DIFF
--- a/funcs/func_scramble.c
+++ b/funcs/func_scramble.c
@@ -52,6 +52,9 @@
 			This is not intended to be used for securely scrambling
 			audio. It merely renders obfuscates audio on a channel
 			to render it unintelligible, as a privacy enhancement.</para>
+			<example title="Scramble speech in both directions">
+			same => n,Set(SCRAMBLE()=both)
+			</example>
 		</description>
 		<see-also>
 			<ref type="application">ChanSpy</ref>


### PR DESCRIPTION
The previous lack of an example made it ambiguous if the arguments went inside the function arguments or were part of the right-hand value.

Resolves: #1485