### PR TITLE
app_dial: Allow fractional seconds for dial timeouts.

### DIFF
--- a/apps/app_dial.c
+++ b/apps/app_dial.c
@@ -97,6 +97,7 @@
 				<para>If a second argument is specified, this controls the number of seconds we attempt to dial the specified devices
 				without receiving early media or ringing. If neither progress, ringing, nor voice frames have been received when this
 				timeout expires, the call will be treated as a CHANUNAVAIL. This can be used to skip destinations that may not be responsive.</para>
+				<para>The timeouts need not be whole numbers; both arguments accept fractional seconds.</para>
 			</parameter>
 			<parameter name="options" required="false">
 				<optionlist>
@@ -2934,22 +2935,23 @@ static int dial_exec_full(struct ast_channel *chan, const char *data, struct ast
 		to_answer = -1;
 		to_progress = -1;
 	} else {
+		double tmp;
 		char *anstimeout = strsep(&args.timeout, "^");
 		if (!ast_strlen_zero(anstimeout)) {
-			to_answer = atoi(anstimeout);
-			if (to_answer > 0) {
-				to_answer *= 1000;
+			if (sscanf(anstimeout, "%30lf", &tmp) == 1 && tmp > 0) {
+				to_answer = tmp * 1000;
+				ast_debug(3, "Dial timeout set to %d ms\n", to_answer);
 			} else {
-				ast_log(LOG_WARNING, "Invalid answer timeout specified: '%s'. Setting timeout to infinite\n", args.timeout);
+				ast_log(LOG_WARNING, "Invalid answer timeout specified: '%s'. Setting timeout to infinite\n", anstimeout);
 				to_answer = -1;
 			}
 		} else {
 			to_answer = -1;
 		}
 		if (!ast_strlen_zero(args.timeout)) {
-			to_progress = atoi(args.timeout);
-			if (to_progress > 0) {
-				to_progress *= 1000;
+			if (sscanf(args.timeout, "%30lf", &tmp) == 1 && tmp > 0) {
+				to_progress = tmp * 1000;
+				ast_debug(3, "Dial progress timeout set to %d ms\n", to_progress);
 			} else {
 				ast_log(LOG_WARNING, "Invalid progress timeout specified: '%s'. Setting timeout to infinite\n", args.timeout);
 				to_progress = -1;


### PR DESCRIPTION
Even though Dial() internally uses milliseconds for its dial timeouts, this capability has been mostly obscured from users as the argument is only parsed as an integer, thus forcing the use of whole seconds for timeouts.

Parse it as a decimal instead so that timeouts can now truly have millisecond precision.

Resolves: #1487

UserNote: The answer and progress dial timeouts now have millisecond precision, instead of having to be whole numbers.