### PR TITLE
config_options.c: Improve misleading warning.

### DIFF
--- a/main/config_options.c
+++ b/main/config_options.c
@@ -1239,7 +1239,7 @@ static void cli_show_module_types(struct ast_cli_args *a)
 	ast_assert(a->argc == 4);
 
 	if (!(item = ao2_find(xmldocs, a->argv[3], OBJ_KEY))) {
-		ast_cli(a->fd, "Module %s not found.\n", a->argv[3]);
+		ast_cli(a->fd, "Module %s not found or has no config XML documentation.\n", a->argv[3]);
 		return;
 	}
 


### PR DESCRIPTION
When running "config show help <module>", if no XML documentation exists for the specified module, "Module <module> not found." is returned, which is misleading if the module is loaded but simply has no XML documentation for its config. Improve the message to clarify that the module may simply have no config documentation.

Resolves: #1489