### PR TITLE
res_audiosocket: add message types for all slin sample rates

### DIFF
--- a/include/asterisk/res_audiosocket.h
+++ b/include/asterisk/res_audiosocket.h
@@ -39,19 +39,43 @@ extern "C" {
 
 enum ast_audiosocket_msg_kind {
 	/*! \brief Message indicates the channel should be hung up, direction: Sent only. */
-	AST_AUDIOSOCKET_KIND_HANGUP = 0x00,
+	AST_AUDIOSOCKET_KIND_HANGUP         = 0x00,
 
 	/*! \brief Message contains the connection's UUID, direction: Received only. */
-	AST_AUDIOSOCKET_KIND_UUID   = 0x01,
+	AST_AUDIOSOCKET_KIND_UUID           = 0x01,
 
 	/*! \brief Message contains a DTMF digit, direction: Received only. */
-	AST_AUDIOSOCKET_KIND_DTMF   = 0x03,
+	AST_AUDIOSOCKET_KIND_DTMF           = 0x03,
 
-	/*! \brief Messages contains audio data, direction: Sent and received. */
-	AST_AUDIOSOCKET_KIND_AUDIO  = 0x10,
+	/*! \brief Messages contains audio data, format: slin, direction: Sent and received. */
+	AST_AUDIOSOCKET_KIND_AUDIO          = 0x10,
+
+	/*! \brief Messages contains audio data, format: slin12, direction: Sent and received. */
+	AST_AUDIOSOCKET_KIND_AUDIO_SLIN12   = 0x11,
+
+	/*! \brief Messages contains audio data, format: slin16, direction: Sent and received. */
+	AST_AUDIOSOCKET_KIND_AUDIO_SLIN16   = 0x12,
+
+	/*! \brief Messages contains audio data, format: slin24, direction: Sent and received. */
+	AST_AUDIOSOCKET_KIND_AUDIO_SLIN24   = 0x13,
+
+	/*! \brief Messages contains audio data, format: slin32, direction: Sent and received. */
+	AST_AUDIOSOCKET_KIND_AUDIO_SLIN32   = 0x14,
+
+	/*! \brief Messages contains audio data, format: slin44, direction: Sent and received. */
+	AST_AUDIOSOCKET_KIND_AUDIO_SLIN44   = 0x15,
+
+	/*! \brief Messages contains audio data, format: slin48, direction: Sent and received. */
+	AST_AUDIOSOCKET_KIND_AUDIO_SLIN48   = 0x16,
+
+	/*! \brief Messages contains audio data, format: slin96, direction: Sent and received. */
+	AST_AUDIOSOCKET_KIND_AUDIO_SLIN96   = 0x17,
+
+	/*! \brief Messages contains audio data, format: slin192, direction: Sent and received. */
+	AST_AUDIOSOCKET_KIND_AUDIO_SLIN192  = 0x18,
 
 	/*! \brief An Asterisk-side error occurred, direction: Received only. */
-	AST_AUDIOSOCKET_KIND_ERROR  = 0xFF,
+	AST_AUDIOSOCKET_KIND_ERROR          = 0xFF,
 };
 
 

--- a/res/res_audiosocket.c
+++ b/res/res_audiosocket.c
@@ -230,7 +230,28 @@ const int ast_audiosocket_send_frame(const int svc, const struct ast_frame *f)
 			depends on agreed upon audio codec for channel driver interface. */
 		switch (f->frametype) {
 			case AST_FRAME_VOICE:
-				buf[0] = AST_AUDIOSOCKET_KIND_AUDIO;
+				if (ast_format_cmp(f->subclass.format, ast_format_slin) == AST_FORMAT_CMP_EQUAL) {
+					buf[0] = AST_AUDIOSOCKET_KIND_AUDIO;
+				} else if (ast_format_cmp(f->subclass.format, ast_format_slin12) == AST_FORMAT_CMP_EQUAL) {
+					buf[0] = AST_AUDIOSOCKET_KIND_AUDIO_SLIN12;
+				} else if (ast_format_cmp(f->subclass.format, ast_format_slin16) == AST_FORMAT_CMP_EQUAL) {
+					buf[0] = AST_AUDIOSOCKET_KIND_AUDIO_SLIN16;
+				} else if (ast_format_cmp(f->subclass.format, ast_format_slin24) == AST_FORMAT_CMP_EQUAL) {
+					buf[0] = AST_AUDIOSOCKET_KIND_AUDIO_SLIN24;
+				} else if (ast_format_cmp(f->subclass.format, ast_format_slin32) == AST_FORMAT_CMP_EQUAL) {
+					buf[0] = AST_AUDIOSOCKET_KIND_AUDIO_SLIN32;
+				} else if (ast_format_cmp(f->subclass.format, ast_format_slin44) == AST_FORMAT_CMP_EQUAL) {
+					buf[0] = AST_AUDIOSOCKET_KIND_AUDIO_SLIN44;
+				} else if (ast_format_cmp(f->subclass.format, ast_format_slin48) == AST_FORMAT_CMP_EQUAL) {
+					buf[0] = AST_AUDIOSOCKET_KIND_AUDIO_SLIN48;
+				} else if (ast_format_cmp(f->subclass.format, ast_format_slin96) == AST_FORMAT_CMP_EQUAL) {
+					buf[0] = AST_AUDIOSOCKET_KIND_AUDIO_SLIN96;
+				} else if (ast_format_cmp(f->subclass.format, ast_format_slin192) == AST_FORMAT_CMP_EQUAL) {
+					buf[0] = AST_AUDIOSOCKET_KIND_AUDIO_SLIN192;
+				} else {
+					buf[0] = AST_AUDIOSOCKET_KIND_AUDIO;
+				}
+
 				*length = htons(datalen);
 				memcpy(&buf[3], f->data.ptr, datalen);
 				break;
@@ -264,7 +285,6 @@ struct ast_frame *ast_audiosocket_receive_frame_with_hangup(const int svc,
 	int i = 0, n = 0, ret = 0;
 	struct ast_frame f = {
 		.frametype = AST_FRAME_VOICE,
-		.subclass.format = ast_format_slin,
 		.src = "AudioSocket",
 		.mallocd = AST_MALLOCD_DATA,
 	};
@@ -291,9 +311,37 @@ struct ast_frame *ast_audiosocket_receive_frame_with_hangup(const int svc,
 		return NULL;
 	}
 
-	if (*kind != AST_AUDIOSOCKET_KIND_AUDIO) {
-		ast_log(LOG_ERROR, "Received AudioSocket message other than hangup or audio, refer to protocol specification for valid message types\n");
-		return NULL;
+	switch (*kind) {
+		case AST_AUDIOSOCKET_KIND_AUDIO:
+			f.subclass.format = ast_format_slin;
+			break;
+		case AST_AUDIOSOCKET_KIND_AUDIO_SLIN12:
+			f.subclass.format = ast_format_slin12;
+			break;
+		case AST_AUDIOSOCKET_KIND_AUDIO_SLIN16:
+			f.subclass.format = ast_format_slin16;
+			break;
+		case AST_AUDIOSOCKET_KIND_AUDIO_SLIN24:
+			f.subclass.format = ast_format_slin24;
+			break;
+		case AST_AUDIOSOCKET_KIND_AUDIO_SLIN32:
+			f.subclass.format = ast_format_slin32;
+			break;
+		case AST_AUDIOSOCKET_KIND_AUDIO_SLIN44:
+			f.subclass.format = ast_format_slin44;
+			break;
+		case AST_AUDIOSOCKET_KIND_AUDIO_SLIN48:
+			f.subclass.format = ast_format_slin48;
+			break;
+		case AST_AUDIOSOCKET_KIND_AUDIO_SLIN96:
+			f.subclass.format = ast_format_slin96;
+			break;
+		case AST_AUDIOSOCKET_KIND_AUDIO_SLIN192:
+			f.subclass.format = ast_format_slin192;
+			break;
+		default:
+			ast_log(LOG_ERROR, "Received AudioSocket message other than hangup or audio, refer to protocol specification for valid message types\n");
+			return NULL;
 	}
 
 	/* Swap endianess of length if needed. */


### PR DESCRIPTION
Extend audiosocket messages with types 0x11 - 0x18 to create asterisk
frames in slin12, slin16, slin24, slin32, slin44, slin48, slin96, and
slin192 format, enabling the transmission of audio at a higher sample
rates. For audiosocket messages sent by Asterisk, the message kind is
determined by the format of the originating asterisk frame.

UpgradeNote: New audiosocket message types 0x11 - 0x18 has been added
for slin12, slin16, slin24, slin32, slin44, slin48, slin96, and
slin192 audio. External applications using audiosocket may need to be
updated to support these message types if the audiosocket channel is
created with one of these audio formats.
