### PR TITLE
codec_builtin.c: Adjust some of the quality scores to reflect reality.

### DIFF
--- a/main/codec_builtin.c
+++ b/main/codec_builtin.c
@@ -216,7 +216,7 @@ static struct ast_codec gsm = {
 	.samples_count = gsm_samples,
 	.get_length = gsm_length,
 	.smooth = 1,
-	.quality = 60,
+	.quality = 40,
 };
 
 static int g726_samples(struct ast_frame *frame)
@@ -449,7 +449,7 @@ static struct ast_codec lpc10 = {
 	.minimum_bytes = 7,
 	.samples_count = lpc10_samples,
 	.smooth = 1,
-	.quality = 25,
+	.quality = 8,
 };
 
 static int g729_samples(struct ast_frame *frame)
@@ -475,7 +475,7 @@ static struct ast_codec g729a = {
 	.get_length = g729_length,
 	.smooth = 1,
 	.smoother_flags = AST_SMOOTHER_FLAG_G729,
-	.quality = 20,
+	.quality = 45,
 };
 
 static unsigned char get_n_bits_at(unsigned char *data, int n, int bit)
@@ -662,7 +662,7 @@ static struct ast_codec ilbc = {
 	.minimum_bytes = 38,
 	.samples_count = ilbc_samples,
 	.smooth = 0,
-	.quality = 45,
+	.quality = 35,
 };
 
 static struct ast_codec g722 = {
@@ -777,7 +777,7 @@ static struct ast_codec opus = {
 	.default_ms = 20,
 	.samples_count = opus_samples,
 	.minimum_bytes = 10,
-	.quality = 50,
+	.quality = 75,
 };
 
 static struct ast_codec jpeg = {


### PR DESCRIPTION
Among the lower-quality voice codecs, some of the quality scores did not make sense relative to each other.

For instance, quality-wise, G.729 > G.723 > PLC10. However, current scores do not uphold these relationships.

Tweak the scores slightly to reflect more accurate relationships.

Resolves: #1501