### PR TITLE
core_unreal: Preserve ADSI capability when dialing Local channels.

### DIFF
--- a/main/core_unreal.c
+++ b/main/core_unreal.c
@@ -887,6 +887,7 @@ void ast_unreal_call_setup(struct ast_channel *semi1, struct ast_channel *semi2)
 	ast_connected_line_copy_to_caller(ast_channel_caller(semi2), ast_channel_connected(semi1));
 	ast_connected_line_copy_from_caller(ast_channel_connected(semi2), ast_channel_caller(semi1));
 
+	ast_channel_adsicpe_set(semi2, ast_channel_adsicpe(semi1));
 	ast_channel_language_set(semi2, ast_channel_language(semi1));
 	ast_channel_musicclass_set(semi2, ast_channel_musicclass(semi1));
 	ast_channel_parkinglot_set(semi2, ast_channel_parkinglot(semi1));


### PR DESCRIPTION
Dial() already preserves the ADSI capability by copying it to the new channel, but since Local channel pairs consist of two channels, we also need to copy the capability to the second channel.

Resolves: #1517