### PR TITLE
func_callerid: Document limitation of DNID fields.

### DIFF
--- a/funcs/func_callerid.c
+++ b/funcs/func_callerid.c
@@ -127,6 +127,9 @@
 					<enum name = "dnid-subaddr-type" />
 					<enum name = "dnid-subaddr-odd" />
 				</enumlist>
+				<para>Note that unlike other Caller ID fields, DNID information is not propagated
+				by the <literal>Dial</literal> application, with the exception of
+				Transmit Network Select (which is not currently used for anything).</para>
 			</parameter>
 			<parameter name="CID">
 				<para>Optional Caller*ID to parse instead of using the Caller*ID from the


### PR DESCRIPTION
The Dial() application does not propagate DNID fields, which is counter to the behavior of the other Caller ID fields. This behavior is likely intentional since the use of Dial theoretically suggests a new dialed number, but document this caveat to inform users of it.

Resolves: #1519