### PR TITLE
app_queue: Allow stasis message filtering to work.

### DIFF
--- a/apps/app_queue.c
+++ b/apps/app_queue.c
@@ -6950,7 +6950,7 @@ static int setup_stasis_subs(struct queue_ent *qe, struct ast_channel *peer, str
 			handle_blind_transfer, queue_data);
 	stasis_message_router_add(queue_data->bridge_router, ast_attended_transfer_type(),
 			handle_attended_transfer, queue_data);
-	stasis_message_router_set_default(queue_data->bridge_router,
+	stasis_message_router_add(queue_data->bridge_router, stasis_subscription_change_type(),
 			queue_bridge_cb, queue_data);
 
 	queue_data->channel_router = stasis_message_router_create_pool(ast_channel_topic_all());
@@ -6972,7 +6972,7 @@ static int setup_stasis_subs(struct queue_ent *qe, struct ast_channel *peer, str
 			handle_hangup, queue_data);
 	stasis_message_router_add(queue_data->channel_router, ast_channel_masquerade_type(),
 			handle_masquerade, queue_data);
-	stasis_message_router_set_default(queue_data->channel_router,
+	stasis_message_router_add(queue_data->channel_router, stasis_subscription_change_type(),
 			queue_channel_cb, queue_data);
 
 	return 0;


### PR DESCRIPTION
The app_queue module subscribes on a per-dialed agent basis to both the bridge all and channel all topics to keep apprised of things going on involving them. This subscription has associated state that must be cleaned up when the subscription ends. This was done by setting a default router callback that only had logic to handle the case where the subscription ends. By using the default router callback all filtering for the subscription was disabled, causing unrelated messages to get published and handled by it.

This change makes it so that an explicit route is added for the message type used for the message indicating the subscription has ended and removes the default router callback. This allows message filtering to occur on publishing reducing the messages to app_queue to only those it is interested in.