### PR TITLE
chan_pjsip: Add technology-specific off-nominal hangup cause to events.

### DIFF
--- a/channels/chan_pjsip.c
+++ b/channels/chan_pjsip.c
@@ -2577,16 +2577,23 @@ static int chan_pjsip_hangup(struct ast_channel *ast)
 {
 	struct ast_sip_channel_pvt *channel = ast_channel_tech_pvt(ast);
 	int cause;
+	int tech_cause;
+	int original_tech_cause;
 	struct hangup_data *h_data;
 	SCOPE_ENTER(1, "%s\n", ast_channel_name(ast));
 
 	if (!channel || !channel->session) {
-		SCOPE_EXIT_RTN_VALUE(-1, "No channel or session\n");
+		SCOPE_EXIT_RTN_VALUE(-1, "%s: No channel or session\n", ast_channel_name(ast));
 	}
 
-	cause = hangup_cause2sip(ast_channel_hangupcause(channel->session->channel));
-	h_data = hangup_data_alloc(cause, ast);
+	cause = ast_channel_hangupcause(channel->session->channel);
+	tech_cause = hangup_cause2sip(cause);
+	original_tech_cause = ast_channel_tech_hangupcause(channel->session->channel);
+	if (!original_tech_cause) {
+		ast_channel_tech_hangupcause_set(channel->session->channel, tech_cause);
+	}
 
+	h_data = hangup_data_alloc(tech_cause, ast);
 	if (!h_data) {
 		goto failure;
 	}
@@ -2596,7 +2603,8 @@ static int chan_pjsip_hangup(struct ast_channel *ast)
 		goto failure;
 	}
 
-	SCOPE_EXIT_RTN_VALUE(0, "Cause: %d\n", cause);
+	SCOPE_EXIT_RTN_VALUE(0, "%s: Cause: %d  Tech Cause: %d\n", ast_channel_name(ast),
+		cause, tech_cause);
 
 failure:
 	/* Go ahead and do our cleanup of the session and channel even if we're not going
@@ -2606,7 +2614,7 @@ failure:
 	ao2_cleanup(channel);
 	ao2_cleanup(h_data);
 
-	SCOPE_EXIT_RTN_VALUE(-1, "Cause: %d\n", cause);
+	SCOPE_EXIT_RTN_VALUE(-1, "%s: Cause: %d\n", ast_channel_name(ast), cause);
 }
 
 struct request_data {
@@ -2943,7 +2951,7 @@ static void chan_pjsip_session_end(struct ast_sip_session *session)
 	SCOPE_ENTER(1, "%s\n", ast_sip_session_get_name(session));
 
 	if (!session->channel) {
-		SCOPE_EXIT_RTN("No channel\n");
+		SCOPE_EXIT_RTN("%s: No channel\n", ast_sip_session_get_name(session));
 	}
 
 
@@ -2959,6 +2967,24 @@ static void chan_pjsip_session_end(struct ast_sip_session *session)
 	chan_pjsip_remove_hold(ast_channel_uniqueid(session->channel));
 
 	ast_set_hangupsource(session->channel, ast_channel_name(session->channel), 0);
+
+	ast_trace(-1, "%s: channel cause: %d\n", ast_sip_session_get_name(session),
+		ast_channel_hangupcause(session->channel));
+
+	if (session->inv_session) {
+		/*
+		 * tech_hangupcause should only be set if off-nominal.
+		 */
+		if (session->inv_session->cause / 100 > 2) {
+			ast_trace(-1, "%s: inv_session cause: %d\n", ast_sip_session_get_name(session),
+				session->inv_session->cause);
+			ast_channel_tech_hangupcause_set(session->channel, session->inv_session->cause);
+		} else {
+			ast_trace(-1, "%s: inv_session cause: %d suppressed\n", ast_sip_session_get_name(session),
+				session->inv_session->cause);
+		}
+	}
+
 	if (!ast_channel_hangupcause(session->channel) && session->inv_session) {
 		int cause = ast_sip_hangup_sip2cause(session->inv_session->cause);
 
@@ -2967,7 +2993,7 @@ static void chan_pjsip_session_end(struct ast_sip_session *session)
 		ast_queue_hangup(session->channel);
 	}
 
-	SCOPE_EXIT_RTN();
+	SCOPE_EXIT_RTN("%s\n", ast_sip_session_get_name(session));
 }
 
 static void set_sipdomain_variable(struct ast_sip_session *session)

--- a/include/asterisk/channel.h
+++ b/include/asterisk/channel.h
@@ -4281,6 +4281,8 @@ int ast_channel_hangupcause(const struct ast_channel *chan);
 void ast_channel_hangupcause_set(struct ast_channel *chan, int value);
 int ast_channel_macropriority(const struct ast_channel *chan);
 void ast_channel_macropriority_set(struct ast_channel *chan, int value);
+int ast_channel_tech_hangupcause(const struct ast_channel *chan);
+void ast_channel_tech_hangupcause_set(struct ast_channel *chan, int value);
 int ast_channel_priority(const struct ast_channel *chan);
 void ast_channel_priority_set(struct ast_channel *chan, int value);
 int ast_channel_rings(const struct ast_channel *chan);

--- a/include/asterisk/stasis_channels.h
+++ b/include/asterisk/stasis_channels.h
@@ -132,7 +132,9 @@ struct ast_channel_snapshot_peer {
  */
 struct ast_channel_snapshot_hangup {
 	int cause;      /*!< Why is the channel hanged up. See causes.h */
-	char source[0]; /*!< Who is responsible for hanging up this channel */
+	char *source;   /*!< Who is responsible for hanging up this channel */
+	int tech_cause; /*!< Technology-specific hangup cause */
+	char buffer[0]; /*!< \private Buffer to store source in */
 };
 
 /*!

--- a/main/channel_internal_api.c
+++ b/main/channel_internal_api.c
@@ -328,6 +328,15 @@ void ast_channel_macropriority_set(struct ast_channel *chan, int value)
 {
 	chan->macropriority = value;
 }
+int ast_channel_tech_hangupcause(const struct ast_channel *chan)
+{
+	return chan->tech_hangupcause;
+}
+void ast_channel_tech_hangupcause_set(struct ast_channel *chan, int value)
+{
+	chan->tech_hangupcause = value;
+	ast_channel_snapshot_invalidate_segment(chan, AST_CHANNEL_SNAPSHOT_INVALIDATE_HANGUP);
+}
 int ast_channel_priority(const struct ast_channel *chan)
 {
 	return chan->priority;

--- a/main/channel_private.h
+++ b/main/channel_private.h
@@ -160,7 +160,10 @@ struct ast_channel {
 							 *   the counter is only in the remaining bits */
 	unsigned int fout;				/*!< Frames out counters. The high bit is a debug mask, so
 							 *   the counter is only in the remaining bits */
-	int hangupcause;				/*!< Why is the channel hanged up. See causes.h */
+	int hangupcause;                /*!< Why is the channel hanged up. See causes.h */
+	int tech_hangupcause;           /*!< Technology-specific off-nominal hangup cause.
+                                     * Leave set to 0 for nominal call termination.
+                                     */
 	unsigned int finalized:1;       /*!< Whether or not the channel has been successfully allocated */
 	struct ast_flags flags;				/*!< channel flags of AST_FLAG_ type */
 	int alertpipe[2];

--- a/main/stasis_channels.c
+++ b/main/stasis_channels.c
@@ -469,6 +469,8 @@ static struct ast_channel_snapshot_hangup *channel_snapshot_hangup_create(struct
 	}
 
 	snapshot->cause = ast_channel_hangupcause(chan);
+	snapshot->tech_cause = ast_channel_tech_hangupcause(chan);
+	snapshot->source = snapshot->buffer;
 	strcpy(snapshot->source, hangupsource); /* Safe */
 
 	return snapshot;

--- a/res/ari/ari_model_validators.c
+++ b/res/ari/ari_model_validators.c
@@ -4094,6 +4094,15 @@ int ast_ari_validate_channel_destroyed(struct ast_json *json)
 				res = 0;
 			}
 		} else
+		if (strcmp("tech_cause", ast_json_object_iter_key(iter)) == 0) {
+			int prop_is_valid;
+			prop_is_valid = ast_ari_validate_int(
+				ast_json_object_iter_value(iter));
+			if (!prop_is_valid) {
+				ast_log(LOG_ERROR, "ARI ChannelDestroyed field tech_cause failed validation\n");
+				res = 0;
+			}
+		} else
 		{
 			ast_log(LOG_ERROR,
 				"ARI ChannelDestroyed has undocumented field %s\n",
@@ -4572,6 +4581,15 @@ int ast_ari_validate_channel_hangup_request(struct ast_json *json)
 				ast_json_object_iter_value(iter));
 			if (!prop_is_valid) {
 				ast_log(LOG_ERROR, "ARI ChannelHangupRequest field soft failed validation\n");
+				res = 0;
+			}
+		} else
+		if (strcmp("tech_cause", ast_json_object_iter_key(iter)) == 0) {
+			int prop_is_valid;
+			prop_is_valid = ast_ari_validate_int(
+				ast_json_object_iter_value(iter));
+			if (!prop_is_valid) {
+				ast_log(LOG_ERROR, "ARI ChannelHangupRequest field tech_cause failed validation\n");
 				res = 0;
 			}
 		} else

--- a/res/ari/ari_model_validators.h
+++ b/res/ari/ari_model_validators.h
@@ -1731,6 +1731,7 @@ ari_validator ast_ari_validate_application_fn(void);
  * - cause: int (required)
  * - cause_txt: string (required)
  * - channel: Channel (required)
+ * - tech_cause: int
  * ChannelDialplan
  * - asterisk_id: string
  * - type: string (required)
@@ -1762,6 +1763,7 @@ ari_validator ast_ari_validate_application_fn(void);
  * - cause: int
  * - channel: Channel (required)
  * - soft: boolean
+ * - tech_cause: int
  * ChannelHold
  * - asterisk_id: string
  * - type: string (required)

--- a/rest-api/api-docs/events.json
+++ b/rest-api/api-docs/events.json
@@ -578,6 +578,10 @@
 					"description": "Text representation of the cause of the hangup",
 					"type": "string"
 				},
+				"tech_cause": {
+					"type": "int",
+					"description": "Integer representation of the technology-specific off-nominal cause of the hangup."
+				},
 				"channel": {
 					"required": true,
 					"type": "Channel"
@@ -722,6 +726,10 @@
 				"cause": {
 					"type": "int",
 					"description": "Integer representation of the cause of the hangup."
+				},
+				"tech_cause": {
+					"type": "int",
+					"description": "Integer representation of the technology-specific off-nominal cause of the hangup."
 				},
 				"soft": {
 					"type": "boolean",


### PR DESCRIPTION
Although the ISDN/Q.850/Q.931 hangup cause code is already part of the ARI
and AMI hangup and channel destroyed events, it can be helpful to know what
the actual channel technology code was if the call was unsuccessful.
For PJSIP, it's the SIP response code.

* A new "tech_hangupcause" field was added to the ast_channel structure along
with ast_channel_tech_hangupcause() and ast_channel_tech_hangupcause_set()
functions.  It should only be set for off-nominal terminations.

* chan_pjsip was modified to set the tech hangup cause in the
chan_pjsip_hangup() and chan_pjsip_session_end() functions.  This is a bit
tricky because these two functions aren't always called in the same order.
The channel that hangs up first will get chan_pjsip_session_end() called
first which will trigger the core to call chan_pjsip_hangup() on itself,
then call chan_pjsip_hangup() on the other channel.  The other channel's
chan_pjsip_session_end() function will get called last.  Unfortunately,
the other channel's HangupRequest events are sent before chan_pjsip has had a
chance to set the tech hangupcause code so the HangupRequest events for that
channel won't have the cause code set.  The ChannelDestroyed and Hangup
events however will have the code set for both channels.

* A new "tech_cause" field was added to the ast_channel_snapshot_hangup
structure. This is a public structure so a bit of refactoring was needed to
preserve ABI compatibility.

* The ARI ChannelHangupRequest and ChannelDestroyed events were modified to
include the "tech_cause" parameter in the JSON for off-nominal terminations.
The parameter is suppressed for nominal termination.

* The AMI SoftHangupRequest, HangupRequest and Hangup events were modified to
include the "TechCause" parameter for off-nominal terminations. Like their ARI
counterparts, the parameter is suppressed for nominal termination.

DeveloperNote: A "tech_cause" parameter has been added to the
ChannelHangupRequest and ChannelDestroyed ARI event messages and a "TechCause"
parameter has been added to the HangupRequest, SoftHangupRequest and Hangup
AMI event messages.  For chan_pjsip, these will be set to the last SIP
response status code for off-nominally terminated calls.  The parameter is
suppressed for nominal termination.
