### PR TITLE
Fix Endianness detection in utils.h for non-Linux

### DIFF
--- a/include/asterisk/utils.h
+++ b/include/asterisk/utils.h
@@ -28,6 +28,7 @@
 #include <time.h>	/* we want to override localtime_r */
 #include <unistd.h>
 #include <string.h>
+#include <endian.h>
 
 #include "asterisk/lock.h"
 #include "asterisk/time.h"
@@ -126,10 +127,12 @@ extern unsigned int __unsigned_int_flags_dummy;
  * \param flags The 64-bit flags to swap
  * \retval The flags with the upper and lower 32 bits swapped if the system is big-endian,
  */
-#if __BYTE_ORDER == __BIG_ENDIAN
+#if defined(BYTE_ORDER) && (BYTE_ORDER == BIG_ENDIAN)
 #define SWAP64_32(flags) (((uint64_t)flags << 32) | ((uint64_t)flags >> 32))
-#else
+#elif defined(BYTE_ORDER) && (BYTE_ORDER == LITTLE_ENDIAN)
 #define SWAP64_32(flags) (flags)
+#else
+#error "Endianness not known - endian.h broken?"
 #endif
 
 extern uint64_t __unsigned_int_flags_dummy64;


### PR DESCRIPTION
Commit 43bf8a4ded7a65203b766b91eaf8331a600e9d8d introduced endian dependend byte-swapping code in include/asterisk/utils.h, where the endianness was detected using the __BYTE_ORDER macro. This macro lives in endian.h, which on Linux is included implicitely (by the network-related headers, I think), but on FreeBSD the headers are laid out differently and we do not get __BYTE_ORDER the implicit way.

Instead, this makes the usage of endian.h explicit by including it where we need it, and switches the BYTE_ORDER/*ENDIAN macros to the POSIX-defined ones (see
https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/endian.h.html for standard compliance). Additionally, this adds a compile-time check for the endianness-logic: compilation will fail if neither big nor little endian can be detected.

Fixes: #1536
