### PR TITLE
chan_pjsip: Disable SSRC change for WebRTC endpoints.

### DIFF
--- a/channels/chan_pjsip.c
+++ b/channels/chan_pjsip.c
@@ -1820,12 +1820,14 @@ static int chan_pjsip_indicate(struct ast_channel *ast, int condition, const voi
 	case AST_CONTROL_SRCUPDATE:
 		break;
 	case AST_CONTROL_SRCCHANGE:
-		/* Generate a new SSRC due to media source change and RTP timestamp reset.
-		   Ensures RFC 3550 compliance and avoids SBC interoperability issues (Sonus/Ribbon)*/
-		for (i = 0; i < AST_VECTOR_SIZE(&channel->session->active_media_state->sessions); ++i) {
-			media = AST_VECTOR_GET(&channel->session->active_media_state->sessions, i);
-			if (media && media->rtp) {
-				ast_rtp_instance_change_source(media->rtp);
+		if (!channel->session->endpoint->media.bundle) {
+			/* Generate a new SSRC due to media source change and RTP timestamp reset.
+			   Ensures RFC 3550 compliance and avoids SBC interoperability issues (Sonus/Ribbon)*/
+			for (i = 0; i < AST_VECTOR_SIZE(&channel->session->active_media_state->sessions); ++i) {
+				media = AST_VECTOR_GET(&channel->session->active_media_state->sessions, i);
+				if (media && media->rtp) {
+					ast_rtp_instance_change_source(media->rtp);
+				}
 			}
 		}
 		break;


### PR DESCRIPTION
Commit b333ee3b introduced a fix to chan_pjsip that addressed RTP issues with
blind transfers and some SBCs.  Unfortunately, the fix broke some WebRTC
clients that are sensitive to SSRC changes and non-monotonic timestamps so
the fix is now disabled for endpoints with the "bundle" parameter set to true.

Resolves: #1535
