### PR TITLE
chan_dahdi.conf.sample: Avoid warnings with default configs.

### DIFF
--- a/configs/samples/chan_dahdi.conf.sample
+++ b/configs/samples/chan_dahdi.conf.sample
@@ -980,8 +980,8 @@ group=1
 ; If you need to pick up an FXS signalled channel directly, you can have it
 ; dial a Local channel and pick up the ;1 side of the Local channel instead.
 ;
-callgroup=1
-pickupgroup=1
+;callgroup=1
+;pickupgroup=1
 ;
 ; Named ring groups (a.k.a. named call groups) and named pickup groups.
 ; If a phone is ringing and it is a member of a group which is one of your


### PR DESCRIPTION
callgroup and pickupgroup may only be specified for FXO-signaled channels; however, the chan_dahdi sample config had these options uncommented in the [channels] section, thus applying these settings to all channels, resulting in warnings. Comment these out so there are no warnings with an unmodified sample config.

Resolves: #1552