### PR TITLE
res_stir_shaken: Add STIR_SHAKEN_ATTESTATION dialplan function.

### DIFF
--- a/res/res_stir_shaken/stir_shaken.h
+++ b/res/res_stir_shaken/stir_shaken.h
@@ -29,6 +29,25 @@
 #define STIR_SHAKEN_PPT "shaken"
 #define STIR_SHAKEN_TYPE "passport"
 
+#define STIR_SHAKEN_VERIFICATION_DS "STIR/SHAKEN/VERIFICATION"
+struct stir_shaken_verification_ds {
+	/*! The identitifier for the STIR/SHAKEN verification */
+	char *identity;
+	/*! The attestation value */
+	char *attestation;
+	/*! The actual verification result */
+	enum ast_stir_shaken_vs_response_code verify_result;
+};
+
+#define STIR_SHAKEN_ATTESTATION_DS "STIR/SHAKEN/ATTESTATION"
+struct stir_shaken_attestation_ds {
+	/*! Whether to suppress attestation on outgoing call */
+	int suppress;
+};
+
+struct stir_shaken_attestation_ds *ast_stir_shaken_get_attestation_datastore(
+	struct ast_channel *chan);
+
 /*!
  * \brief Retrieve the stir/shaken sorcery context
  *

--- a/res/res_stir_shaken/stir_shaken_doc.xml
+++ b/res/res_stir_shaken/stir_shaken_doc.xml
@@ -507,4 +507,38 @@
 			</example>
 		</description>
 	</function>
+	<function name="STIR_SHAKEN_ATTESTATION" language="en_US">
+		<since>
+			<version>20.17.0</version>
+			<version>22.7.0</version>
+			<version>23.1.0</version>
+		</since>
+		<synopsis>
+			Sets STIR/SHAKEN Attestation parameters on an outgoing channel.
+		</synopsis>
+		<syntax>
+			<parameter name="field" required="true">
+				<para>The attestation field to set. Allowable values:</para>
+				<enumlist>
+					<enum name = "suppress">
+					<para>
+					When set to <literal>true</literal>, attestation is suppressed
+					on the channel regardless of the profile on the endpoint.
+					</para>
+					</enum>
+				</enumlist>
+			</parameter>
+		</syntax>
+		<description>
+			<para>When used on an outgoing channel, this function can override the
+			profile on an endpoint.  Currently, only the ability to suppress
+			attestation is supported.
+			</para>
+			<para>
+			</para>
+			<example title="Suppress attestation on an outgoing channel">
+			same => n,Set(STIR_SHAKEN_ATTESTATION(suppress)=yes)
+			</example>
+		</description>
+	</function>
 </docs>


### PR DESCRIPTION
Also...

* Refactored the verification datastore process so instead of having
a separate channel datastore for each verification result, there's only
one channel datastore with a vector of results.

* Refactored some log messages to include channel name and removed
some that would be redundant if a memory allocation failed. 

Resolves: #781

UserNote: The STIR_SHAKEN_ATTESTATION dialplan function has been added
which will allow suppressing attestation on a call-by-call basis
regardless of the profile attached to the outgoing endpoint.
