### PR TITLE
pjsip_transport_management.c: Auto-cleanup of long-idle transport connections

### DIFF
--- a/configs/samples/pjsip.conf.sample
+++ b/configs/samples/pjsip.conf.sample
@@ -1350,6 +1350,14 @@
                         ; keep-alives on all active connection-oriented transports;
                         ; for connection-less like UDP see qualify_frequency.
                         ; (default: "90")
+;incoming_transport_idle_timeout=0
+                        ; Timeout in seconds for incoming connection-oriented transports with no new SIP requests.
+                        ; After this timeout, the transport will be shut down if no new
+                        ; SIP requests are received.
+                        ; This applies to all connection-oriented transports (TCP, TLS, WebSocket, etc.).
+                        ; Note that only SIP requests reset the timeout timer - SIP responses do not reset it.
+                        ; Zero disables the timeout.
+                        ; (default: "0")
 ;contact_expiration_check_interval=30
                         ; The interval (in seconds) to check for expired contacts.
 ;disable_multi_domain=no

--- a/include/asterisk/res_pjsip.h
+++ b/include/asterisk/res_pjsip.h
@@ -3595,6 +3595,13 @@ void ast_sip_get_default_from_user(char *from_user, size_t size);
 unsigned int ast_sip_get_keep_alive_interval(void);
 
 /*!
+ * \brief Retrieve the incoming transport idle timeout setting.
+ *
+ * \retval the incoming transport idle timeout in seconds.
+ */
+unsigned int ast_sip_get_incoming_transport_idle_timeout(void);
+
+/*!
  * \brief Retrieve the system contact expiration check interval setting.
  *
  * \retval the contact expiration check interval.

--- a/res/res_pjsip/config_global.c
+++ b/res/res_pjsip/config_global.c
@@ -128,6 +128,8 @@ struct global_config {
 	unsigned int norefersub;
 	/*! Nonzero if we should return all codecs on empty re-INVITE */
 	unsigned int all_codecs_on_empty_reinvite;
+	/*! Timeout in seconds for incoming transports with no new SIP requests */
+	unsigned int incoming_transport_idle_timeout;
 };
 
 static void global_destructor(void *obj)
@@ -608,6 +610,21 @@ unsigned int ast_sip_get_all_codecs_on_empty_reinvite(void)
 	return all_codecs_on_empty_reinvite;
 }
 
+unsigned int ast_sip_get_incoming_transport_idle_timeout(void)
+{
+	unsigned int incoming_transport_idle_timeout;
+	struct global_config *cfg;
+
+	cfg = get_global_cfg();
+	if (!cfg) {
+		return 0;
+	}
+
+	incoming_transport_idle_timeout = cfg->incoming_transport_idle_timeout;
+	ao2_ref(cfg, -1);
+	return incoming_transport_idle_timeout;
+}
+
 static int overload_trigger_handler(const struct aco_option *opt,
 	struct ast_variable *var, void *obj)
 {
@@ -824,6 +841,9 @@ int ast_sip_initialize_sorcery_global(void)
 	ast_sorcery_object_field_register(sorcery, "global", "default_auth_algorithms_uac",
 		DEFAULT_AUTH_ALGORITHMS_UAC, OPT_STRINGFIELD_T, 0,
 		STRFLDSET(struct global_config, default_auth_algorithms_uac));
+	ast_sorcery_object_field_register(sorcery, "global", "incoming_transport_idle_timeout",
+		__stringify(0),
+		OPT_UINT_T, 0, FLDSET(struct global_config, incoming_transport_idle_timeout));
 
 	if (ast_sorcery_instance_observer_add(sorcery, &observer_callbacks_global)) {
 		return -1;

--- a/res/res_pjsip/pjsip_config.xml
+++ b/res/res_pjsip/pjsip_config.xml
@@ -3164,6 +3164,21 @@
 					</since>
 					<synopsis>The interval (in seconds) to send keepalives to active connection-oriented transports.</synopsis>
 				</configOption>
+				<configOption name="incoming_transport_idle_timeout" default="0">
+					<since>
+						<version>20.16.0</version>
+						<version>22.6.0</version>
+						<version>23.0.0</version>
+					</since>
+					<synopsis>Timeout in seconds for incoming connection-oriented transports with no new SIP requests.</synopsis>
+					<description><para>
+						After this timeout, the transport will be shut down if no new SIP requests are received.
+						This applies to all connection-oriented transports (TCP, TLS, WebSocket, etc.).
+						Note that only SIP requests reset the timeout timer - SIP responses do not reset it.
+						This is useful for cleaning up idle incoming connections and preventing resource exhaustion.
+						A value of zero disables the timeout.
+					</para></description>
+				</configOption>
 				<configOption name="contact_expiration_check_interval" default="30">
 					<since>
 						<version>13.9.0</version>


### PR DESCRIPTION
The client establishes dozens of WebSocket connections within a short period, but only actually uses one of them. A large number of idle WebSocket connections consume CPU resources and cause the number of HTTP sessions to appear inflated. Although the client should follow proper behavior, the WebRTC server should still implement mechanisms to restrict or handle invalid connections.

Resolves: #1564