### PR TITLE
app_queue.c: Only announce to head caller if announce_to_first_user

### DIFF
--- a/apps/app_queue.c
+++ b/apps/app_queue.c
@@ -8972,13 +8972,12 @@ check_turns:
 					goto stop;
 				}
 			}
-		}
-		makeannouncement = 1;
 
-		/* Make a periodic announcement, if enabled */
-		if (qe.parent->periodicannouncefrequency) {
-			if ((res = say_periodic_announcement(&qe, ringing))) {
-				goto stop;
+			/* Make a periodic announcement, if enabled */
+			if (qe.parent->periodicannouncefrequency) {
+				if ((res = say_periodic_announcement(&qe, ringing))) {
+					goto stop;
+				}
 			}
 		}
 


### PR DESCRIPTION
Only make announcements to head caller if announce_to_first_user is true

Fixes: #1568

UserNote: When announce_to_first_user is false, no announcements are played to the head caller