### PR TITLE
build: Add menuselect options to facilitate code tracing and coverage

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -82,17 +82,21 @@ ifeq ($(CC),gcc)
 	endif
 endif
 
-ifeq ($(findstring DONT_OPTIMIZE,$(MENUSELECT_CFLAGS))$(AST_CODE_COVERAGE),no)
+ifeq ($(findstring DONT_OPTIMIZE,$(MENUSELECT_CFLAGS))$(findstring CODE_COVERAGE,$(MENUSELECT_CFLAGS))$(findstring CODE_PROFILE,$(MENUSELECT_CFLAGS))$(AST_CODE_COVERAGE),no)
     _ASTCFLAGS+=$(OPTIMIZE)
 else
     _ASTCFLAGS+=-O0
 endif
 
-ifeq ($(AST_CODE_COVERAGE),yes)
+ifeq ($(findstring CODE_COVERAGE,$(MENUSELECT_CFLAGS))$(AST_CODE_COVERAGE),no)
+    _ASTCFLAGS_COVERAGE=
+else
     _ASTCFLAGS_COVERAGE=-ftest-coverage -fprofile-arcs
     _ASTLDFLAGS+=-ftest-coverage -fprofile-arcs
-else
-    _ASTCFLAGS_COVERAGE=
+endif
+
+ifneq ($(findstring KEEP_FRAME_POINTERS,$(MENUSELECT_CFLAGS)),)
+    _ASTCFLAGS+=-fno-omit-frame-pointer
 endif
 
 ifeq ($(findstring $(CONFIG_CFLAGS),$(_ASTCFLAGS)),)

--- a/build_tools/cflags.xml
+++ b/build_tools/cflags.xml
@@ -5,6 +5,8 @@
 		</member>
 		<member name="COMPILE_DOUBLE" displayname="Pre-compile with optimizations to detect errors, then discard and recompile with DONT_OPTIMIZE.  Creates intermediate .i files">
 			<depend>DONT_OPTIMIZE</depend>
+			<conflict>KEEP_FRAME_POINTERS</conflict>
+			<conflict>CODE_COVERAGE</conflict>
 			<support_level>core</support_level>
 		</member>
 		<member name="DEBUG_THREADS" displayname="Enable Thread Debugging">
@@ -132,4 +134,13 @@
 			<support_level>core</support_level>
 			<defaultenabled>no</defaultenabled>
 		</member>
+		<member name="KEEP_FRAME_POINTERS" displayname="Set -fno-omit-frame-pointers to Facilitate Debugging and Tracing with 'perf'">
+			<conflict>COMPILE_DOUBLE</conflict>
+			<support_level>core</support_level>
+		</member>
+		<member name="CODE_COVERAGE" displayname="Set -ftest-coverage -fprofile-arcs to Enable gcov Code Coverage">
+			<support_level>extended</support_level>
+			<depend>DONT_OPTIMIZE</depend>
+		</member>
+
 	</category>


### PR DESCRIPTION
The following options have been added to the menuselect "Compiler Flags"
section...

CODE_COVERAGE: The ability to enable code coverage via the `--enable-coverage`
configure flag has existed for many years but changing it requires
re-running ./configure which is painfully slow.  With this commit, you can
now enable and disable it via menuselect. Setting this option adds the
`-ftest-coverage` and `-fprofile-arcs` flags on the gcc and ld command lines.
It also sets DONT_OPTIMIZE. Note: If you use the `--enable-coverage` configure
flag, you can't turn it off via menuselect so choose one method and stick to
it.

KEEP_FRAME_POINTERS: This option sets `-fno-omit-frame-pointers` on the gcc
command line which can facilitate debugging with 'gdb' and tracing with 'perf'.
Unlike CODE_COVERAGE, this option doesn't depend on optimization being
disabled.  It does however conflict with COMPILE_DOUBLE.
