### PR TITLE
channelstorage:  Allow storage driver read locking to be skipped.

### DIFF
--- a/main/channelstorage.h
+++ b/main/channelstorage.h
@@ -51,13 +51,13 @@ struct ast_channelstorage_instance {
 	void (*rdlock)(struct ast_channelstorage_instance *driver);
 	void (*wrlock)(struct ast_channelstorage_instance *driver);
 	void (*unlock)(struct ast_channelstorage_instance *driver);
-	int (*active_channels)(struct ast_channelstorage_instance *driver);
+	int (*active_channels)(struct ast_channelstorage_instance *driver, int rdlock);
 	struct ast_channel *(*callback)(struct ast_channelstorage_instance *driver, ao2_callback_data_fn *cb_fn,
-		void *arg, void *data, int ao2_flags);
-	struct ast_channel *(*get_by_name_prefix)(struct ast_channelstorage_instance *driver, const char *name, size_t len);
-	struct ast_channel *(*get_by_name_prefix_or_uniqueid)(struct ast_channelstorage_instance *driver, const char *name, size_t len);
-	struct ast_channel *(*get_by_exten)(struct ast_channelstorage_instance *driver, const char *exten, const char *context);
-	struct ast_channel *(*get_by_uniqueid)(struct ast_channelstorage_instance *driver, const char *uniqueid);
+		void *arg, void *data, int ao2_flags, int rdlock);
+	struct ast_channel *(*get_by_name_prefix)(struct ast_channelstorage_instance *driver, const char *name, size_t len, int rdlock);
+	struct ast_channel *(*get_by_name_prefix_or_uniqueid)(struct ast_channelstorage_instance *driver, const char *name, size_t len, int rdlock);
+	struct ast_channel *(*get_by_exten)(struct ast_channelstorage_instance *driver, const char *exten, const char *context, int rdlock);
+	struct ast_channel *(*get_by_uniqueid)(struct ast_channelstorage_instance *driver, const char *uniqueid, int rdlock);
 	struct ast_channel_iterator *(*iterator_all_new)(struct ast_channelstorage_instance *driver);
 	struct ast_channel_iterator *(*iterator_by_exten_new)
 		(struct ast_channelstorage_instance *driver, const char *exten, const char *context);
@@ -81,15 +81,15 @@ void ast_channelstorage_close(struct ast_channelstorage_instance *storage_instan
 
 int channelstorage_exten_cb(void *obj, void *arg, void *data, int flags);
 struct ast_channel *channelstorage_by_exten(struct ast_channelstorage_instance *driver,
-	const char *exten, const char *context);
+	const char *exten, const char *context, int rdlock);
 int channelstorage_name_cb(void *obj, void *arg, void *data, int flags);
 struct ast_channel *channelstorage_by_name_or_uniqueid(struct ast_channelstorage_instance *driver,
-	const char *name);
+	const char *name, int rdlock);
 struct ast_channel *channelstorage_by_name_prefix_or_uniqueid(struct ast_channelstorage_instance *driver,
-	const char *name, size_t name_len);
+	const char *name, size_t name_len, int rdlock);
 int channelstorage_uniqueid_cb(void *obj, void *arg, void *data, int flags);
 struct ast_channel *channelstorage_by_uniqueid(struct ast_channelstorage_instance *driver,
-	const char *uniqueid);
+	const char *uniqueid, int rdlock);
 
 #if defined(__cplusplus) || defined(c_plusplus)
 }

--- a/main/channelstorage_ao2_legacy.c
+++ b/main/channelstorage_ao2_legacy.c
@@ -58,13 +58,13 @@ static int delete_channel(struct ast_channelstorage_instance *driver,
 }
 
 /*! \brief returns number of active/allocated channels */
-static int active_channels(struct ast_channelstorage_instance *driver)
+static int active_channels(struct ast_channelstorage_instance *driver, int rdlock)
 {
 	return getdb(driver) ? ao2_container_count(getdb(driver)) : 0;
 }
 
 static struct ast_channel *callback(struct ast_channelstorage_instance *driver,
-	ao2_callback_data_fn *cb_fn, void *arg, void *data, int ao2_flags)
+	ao2_callback_data_fn *cb_fn, void *arg, void *data, int ao2_flags, int rdlock)
 {
 	return ao2_callback_data(getdb(driver), ao2_flags, cb_fn, arg, data);
 }
@@ -161,7 +161,7 @@ static struct ast_channel_iterator *iterator_by_exten_new(struct ast_channelstor
 	}
 
 	i->active_iterator = (void *) callback(driver, by_exten_cb,
-		l_context, l_exten, OBJ_MULTIPLE);
+		l_context, l_exten, OBJ_MULTIPLE, 1);
 	if (!i->active_iterator) {
 		ast_free(i);
 		return NULL;
@@ -182,7 +182,7 @@ static struct ast_channel_iterator *iterator_by_name_new(struct ast_channelstora
 
 	i->active_iterator = (void *) callback(driver, by_name_cb,
 		l_name, &name_len,
-		OBJ_MULTIPLE | (name_len == 0 /* match the whole word, so optimize */ ? OBJ_KEY : 0));
+		OBJ_MULTIPLE | (name_len == 0 /* match the whole word, so optimize */ ? OBJ_KEY : 0), 1);
 	if (!i->active_iterator) {
 		ast_free(i);
 		return NULL;
@@ -212,17 +212,17 @@ static struct ast_channel *iterator_next(struct ast_channelstorage_instance *dri
 }
 
 static struct ast_channel *get_by_uniqueid(struct ast_channelstorage_instance *driver,
-	const char *uniqueid)
+	const char *uniqueid, int lock)
 {
 	char *l_name = (char *) uniqueid;
 	size_t name_len = strlen(uniqueid);
 
-	struct ast_channel *chan = callback(driver, by_uniqueid_cb, l_name, &name_len, 0);
+	struct ast_channel *chan = callback(driver, by_uniqueid_cb, l_name, &name_len, 0, lock);
 	return chan;
 }
 
 static struct ast_channel *get_by_name_prefix(struct ast_channelstorage_instance *driver,
-	const char *name, size_t name_len)
+	const char *name, size_t name_len, int lock)
 {
 	struct ast_channel *chan;
 	char *l_name = (char *) name;
@@ -233,23 +233,23 @@ static struct ast_channel *get_by_name_prefix(struct ast_channelstorage_instance
 	}
 
 	chan = callback(driver, by_name_cb, l_name, &name_len,
-		(name_len == 0) /* optimize if it is a complete name match */ ? OBJ_KEY : 0);
+		(name_len == 0) /* optimize if it is a complete name match */ ? OBJ_KEY : 0, lock);
 	if (chan) {
 		return chan;
 	}
 
 	/* Now try a search for uniqueid. */
-	chan = callback(driver, by_uniqueid_cb, l_name, &name_len, 0);
+	chan = callback(driver, by_uniqueid_cb, l_name, &name_len, 0, lock);
 	return chan;
 }
 
 static struct ast_channel *get_by_exten(struct ast_channelstorage_instance *driver,
-	const char *exten, const char *context)
+	const char *exten, const char *context, int rdlock)
 {
 	char *l_exten = (char *) exten;
 	char *l_context = (char *) context;
 
-	return callback(driver, by_exten_cb, l_context, l_exten, 0);
+	return callback(driver, by_exten_cb, l_context, l_exten, 0, rdlock);
 }
 
 static int hash_cb(const void *obj, const int flags)

--- a/main/channelstorage_cpp_map_name_id.cc
+++ b/main/channelstorage_cpp_map_name_id.cc
@@ -139,7 +139,7 @@ static int delete_channel(struct ast_channelstorage_instance *driver,
 }
 
 /*! \brief returns number of active/allocated channels */
-static int active_channels(struct ast_channelstorage_instance *driver)
+static int active_channels(struct ast_channelstorage_instance *driver, int lock)
 {
 	int count = 0;
 
@@ -147,15 +147,19 @@ static int active_channels(struct ast_channelstorage_instance *driver)
 		return 0;
 	}
 
-	rdlock(driver);
+	if (lock) {
+		rdlock(driver);
+	}
 	count = getdb(driver).size();
-	unlock(driver);
+	if (lock) {
+		unlock(driver);
+	}
 
 	return count;
 }
 
 static struct ast_channel *callback(struct ast_channelstorage_instance *driver,
-	ao2_callback_data_fn *cb_fn, void *arg, void *data, int ao2_flags)
+	ao2_callback_data_fn *cb_fn, void *arg, void *data, int ao2_flags, int lock)
 {
 	struct ast_channel *chan = NULL;
 	ChannelMap::const_iterator it;
@@ -164,18 +168,21 @@ static struct ast_channel *callback(struct ast_channelstorage_instance *driver,
 		return NULL;
 	}
 
-	rdlock(driver);
+	if (lock) {
+		rdlock(driver);
+	}
 	for (it = getdb(driver).begin(); it != getdb(driver).end(); it++) {
 		chan = it->second;
 		if (cb_fn(chan, arg, data, ao2_flags) == (CMP_MATCH | CMP_STOP)) {
 			ao2_bump(chan);
-			unlock(driver);
-			return chan;
+			break;
 		}
 	}
-	unlock(driver);
+	if (lock) {
+		unlock(driver);
+	}
 
-	return NULL;
+	return chan;
 }
 
 enum cpp_map_iterator_type {
@@ -460,7 +467,7 @@ static struct ast_channel_iterator *iterator_by_exten_new(struct ast_channelstor
 }
 
 static struct ast_channel *get_by_uniqueid(struct ast_channelstorage_instance *driver,
-	const char *uniqueid)
+	const char *uniqueid, int lock)
 {
 	struct ast_channel *chan = NULL;
 	char *search = uniqueid ? ast_str_to_lower(ast_strdupa(uniqueid)) : NULL;
@@ -469,18 +476,22 @@ static struct ast_channel *get_by_uniqueid(struct ast_channelstorage_instance *d
 		return NULL;
 	}
 
-	rdlock(driver);
+	if (lock) {
+		rdlock(driver);
+	}
 	auto rtn = map_by_id(driver).find(search);
 	if (rtn != map_by_id(driver).end()) {
 		chan = ao2_bump((struct ast_channel *)rtn->second);
 	}
-	unlock(driver);
+	if (lock) {
+		unlock(driver);
+	}
 
 	return chan;
 }
 
 static struct ast_channel *get_by_name_exact(struct ast_channelstorage_instance *driver,
-	const char *name)
+	const char *name, int lock)
 {
 	struct ast_channel *chan = NULL;
 	char *search = name ? ast_str_to_lower(ast_strdupa(name)) : NULL;
@@ -489,35 +500,43 @@ static struct ast_channel *get_by_name_exact(struct ast_channelstorage_instance 
 		return NULL;
 	}
 
-	rdlock(driver);
+	if (lock) {
+		rdlock(driver);
+	}
 	auto rtn = getdb(driver).find(search);
 	if (rtn != getdb(driver).end()) {
 		chan = ao2_bump((struct ast_channel *)rtn->second);
 	}
-	unlock(driver);
+	if (lock) {
+		unlock(driver);
+	}
 
 	return chan;
 }
 
 static struct ast_channel *get_by_name_prefix(struct ast_channelstorage_instance *driver,
-	const char *name, size_t name_len)
+	const char *name, size_t name_len, int lock)
 {
 	struct ast_channel *chan = NULL;
 	char *l_name = NULL;
 
 	if (name_len == 0) {
-		chan = get_by_name_exact(driver, name);
+		chan = get_by_name_exact(driver, name, lock);
 		return chan;
 	}
 
 	l_name = ast_str_to_lower(ast_strdupa(name));
 
-	rdlock(driver);
+	if (lock) {
+		rdlock(driver);
+	}
 	auto rtn = getdb(driver).lower_bound(l_name);
 	if (rtn != getdb(driver).end()) {
 		chan = ao2_bump((struct ast_channel *)rtn->second);
 	}
-	unlock(driver);
+	if (lock) {
+		unlock(driver);
+	}
 
 	return chan;
 }


### PR DESCRIPTION
After PR #1498 added read locking to channelstorage_cpp_map_name_id, if ARI
channels/externalMedia was called with a custom channel id AND the
cpp_map_name_id channel storage backend is in use, a deadlock can occur when
hanging up the channel. It's actually triggered in
channel.c:__ast_channel_alloc_ap() when it gets a write lock on the
channelstorage driver then subsequently does a lookup for channel uniqueid
which now does a read lock. This is an invalid operation and causes the lock
state to get "bad". When the channels try to hang up, a write lock is
attempted again which hangs and causes the deadlock.

Now instead of the cpp_map_name_id channelstorage driver "get" APIs
automatically performing a read lock, they take a "lock" parameter which
allows a caller who already has a write lock to indicate that the "get" API
must not attempt its own lock.  This prevents the state from getting mesed up.

The ao2_legacy driver uses the ao2 container's recursive mutex so doesn't
have this issue but since it also implements the common channelstorage API,
it needed its "get" implementations updated to take the lock parameter. They
just don't use it.

Resolves: #1578
