### PR TITLE
chan_websocket.c: Tolerate other frame types

### DIFF
--- a/channels/chan_websocket.c
+++ b/channels/chan_websocket.c
@@ -1099,10 +1099,14 @@ static int webchan_write(struct ast_channel *ast, struct ast_frame *f)
 		return -1;
 	}
 
+	if (f->frametype == AST_FRAME_CNG) {
+		return 0;
+	}
+
 	if (f->frametype != AST_FRAME_VOICE) {
 		ast_log(LOG_WARNING, "%s: This WebSocket channel only supports AST_FRAME_VOICE frames\n",
 			ast_channel_name(ast));
-		return -1;
+		return 0;
 	}
 
 	if (ast_format_cmp(f->subclass.format, instance->native_format) == AST_FORMAT_CMP_NOT_EQUAL) {


### PR DESCRIPTION
Currently, if chan_websocket receives an un supported frame like comfort noise it will exit the websocket. The proposed change is to tolerate the other frames by not sending them down the websocket but instead just ignoring them.

Resolves: https://github.com/asterisk/asterisk/issues/1587