### PR TITLE
core_unreal.c: Use ast instead of p->chan to get the DIALSTATUS variable

### DIFF
--- a/main/core_unreal.c
+++ b/main/core_unreal.c
@@ -1042,7 +1042,7 @@ int ast_unreal_hangup(struct ast_unreal_pvt *p, struct ast_channel *ast)
 		ast_clear_flag(p, AST_UNREAL_CARETAKER_THREAD);
 		p->chan = NULL;
 		if (p->owner) {
-			const char *status = pbx_builtin_getvar_helper(p->chan, "DIALSTATUS");
+			const char *status = pbx_builtin_getvar_helper(chan, "DIALSTATUS");
 
 			if (status) {
 				ast_channel_hangupcause_set(p->owner, cause);


### PR DESCRIPTION
After p->chan = NULL, ast still points to the valid channel object, using ast safely accesses the channel's DIALSTATUS variable before it's fully destroyed

Resolves: #1590