### PR TITLE
app_disa: Avoid use of removed ResetCDR() option.

### DIFF
--- a/apps/app_disa.c
+++ b/apps/app_disa.c
@@ -388,8 +388,11 @@ static int disa_exec(struct ast_channel *chan, const char *data)
 				ast_channel_unlock(chan);
 			}
 
-			if (ast_pbx_exec_application(chan, "ResetCDR", special_noanswer ? "" : "e")) {
-				ast_log(AST_LOG_NOTICE, "ResetCDR application not found; CDR will not be reset\n");
+			if (ast_pbx_exec_application(chan, "ResetCDR", "")) {
+				ast_log(LOG_WARNING, "ResetCDR application not found; CDR will not be reset\n");
+			}
+			if (!special_noanswer && ast_func_write(chan, "CDR_PROP(disable)", "0")) {
+				ast_log(LOG_WARNING, "CDR_PROP not found, CDR will not be re-enabled\n");
 			}
 			ast_explicit_goto(chan, args.context, exten, 1);
 			return 0;


### PR DESCRIPTION
Commit a46d5f9b760f84b9f27f594b62507c1443aa661b removed the deprecated 'e' option to ResetCDR; this now causes DISA() to emit a warning if attempting to call ResetCDR() with the deprecated option (in all cases except when the no answer option is provided). Rewrite the code to do this the current way.

Resolves: #1592