### PR TITLE
dsp.c: Avoid running digit detection twice if busydetect is enabled.

### DIFF
--- a/main/dsp.c
+++ b/main/dsp.c
@@ -1571,7 +1571,7 @@ struct ast_frame *ast_dsp_process(struct ast_channel *chan, struct ast_dsp *dsp,
 		dsp->f.frametype = AST_FRAME_CONTROL;
 		dsp->f.subclass.integer = AST_CONTROL_BUSY;
 		ast_frfree(af);
-		ast_debug(1, "Requesting Hangup because the busy tone was detected on channel %s\n", ast_channel_name(chan));
+		ast_log(LOG_NOTICE, "Requesting hangup because busy tone was detected on channel %s\n", ast_channel_name(chan));
 		return ast_frisolate(&dsp->f);
 	}
 
@@ -1591,7 +1591,7 @@ struct ast_frame *ast_dsp_process(struct ast_channel *chan, struct ast_dsp *dsp,
 		}
 	}
 
-	if (dsp->features & (DSP_FEATURE_DIGIT_DETECT | DSP_FEATURE_BUSY_DETECT)) {
+	if (dsp->features & (DSP_FEATURE_DIGIT_DETECT)) {
 		if (dsp->digitmode & DSP_DIGITMODE_MF) {
 			digit = mf_detect(dsp, &dsp->digit_state, shortdata, len, (dsp->digitmode & DSP_DIGITMODE_NOQUELCH) == 0, (dsp->digitmode & DSP_DIGITMODE_RELAXDTMF));
 		} else {


### PR DESCRIPTION
When setting busydetect=yes in chan_dahdi.conf, chan_dahdi uses a second DSP to process audio on the channel, in addition to the one that exists normally. Within ast_dsp_process, the conditional guarding digit detection (either mf_detect or dtmf_detect) was true if either DSP_FEATURE_DIGIT_DETECT or DSP_FEATURE_BUSY_DETECT was set. Because digits are normally quelched unless DSP_DIGITMODE_NOQUELCH is set, the first pass would quelch digits on the channel and the second pass would see discrete DTMF tones instead of the continuous tone that is actually present.

This second digit detection on the frame should not be happening, and DSP_FEATURE_BUSY_DETECT should not be part of this condition in the first place. While the busy detector gets reset if a digit is detected, this is done even without it being part of this conditional. This regression was introduced in commit ec0581fef4e44b029588cd1ce0539dffa36db94a.

Removing it ensures that mf_detect/dtmf_detect is only called once per frame, since busy detection doesn't need digit detection to work and digit detection shouldn't be performed twice.

Resolves: #1570