### PR TITLE
Makefile: Add module-list-* targets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,9 +108,13 @@ export XMLLINT
 export XMLSTARLET
 
 # makeopts is required unless the goal is just {dist{-}}clean
+# or module-list-{core,extended,deprecated}
 ifeq ($(MAKECMDGOALS),clean)
 else ifeq ($(MAKECMDGOALS),distclean)
 else ifeq ($(MAKECMDGOALS),dist-clean)
+else ifeq ($(MAKECMDGOALS),module-list-core)
+else ifeq ($(MAKECMDGOALS),module-list-extended)
+else ifeq ($(MAKECMDGOALS),module-list-deprecated)
 else
 include makeopts
 endif
@@ -611,6 +615,13 @@ oldmodcheck:
 		echo "" ;\
 		echo " WARNING WARNING WARNING" ;\
 	fi
+
+# The module-list-* independent targets are for evaluation of the source tree
+# to show which modules are at which support levels, without configure/compile.
+module-list-core module-list-extended module-list-deprecated:
+	@s=$(subst module-list-,,$@) ;\
+	echo "Showing all modules at support level '$$s':" ;\
+	grep -l -r --include="*.c" --include="*.cc" --exclude-dir=tests --exclude-dir=utils "<support_level>$$s</support_level>" | sort
 
 ld-cache-update:
 ifeq ($(LDCONFIG),)


### PR DESCRIPTION
Convenience wrappers for showing modules at various support levels.

* module-list-core
* module-list-extended
* module-list-deprecated

Resolves: #1572

UserNote: Try "make module-list-deprecated" to see what modules are on their way out the door.