### PR TITLE
app_reload: Fix Reload() without arguments.

### DIFF
--- a/apps/app_reload.c
+++ b/apps/app_reload.c
@@ -85,7 +85,7 @@ static int reload_exec(struct ast_channel *chan, const char *data)
 	targets = ast_strdupa(data);
 	ast_autoservice_start(chan);
 	if (ast_strlen_zero(targets)) { /* Reload everything */
-		res = ast_module_reload(targets);
+		res = ast_module_reload(NULL);
 	} else {
 		while((target = ast_strsep(&targets, ',', AST_STRSEP_ALL))) {
 			res |= ast_module_reload(target);


### PR DESCRIPTION
Calling Reload() without any arguments is supposed to reload everything (equivalent to a 'core reload'), but actually does nothing. This is because it was calling ast_module_reload with an empty string, and the argument needs to explicitly be NULL.

Resolves: #1597