### PR TITLE
pbx.c: Print new context count when reloading dialplan.

### DIFF
--- a/main/pbx.c
+++ b/main/pbx.c
@@ -6614,6 +6614,10 @@ void ast_merge_contexts_and_delete(struct ast_context **extcontexts, struct ast_
 	/* Create all applicable autohint contexts */
 	context_table_create_autohints(contexts_table);
 
+	/* ctx_count is still the number of old contexts before the merge,
+	 * use the new count when we tell the user how many contexts exist. */
+	ctx_count = ast_hashtab_size(contexts_table);
+
 	ao2_unlock(hints);
 	ast_unlock_contexts();
 


### PR DESCRIPTION
When running "dialplan reload", the number of contexts reported is initially wrong, as it is the old context count. Running "dialplan reload" a second time returns the correct number of contexts that are loaded. This can confuse users into thinking that the reload didn't work successfully the first time.

This counter is currently only incremented when iterating the old contexts prior to the context merge; at the very end, get the current number of elements in the context hash table and report that instead. This way, the count is correct immediately whenever a reload occurs.

Resolves: #1599