### PR TITLE
configure.ac: use AC_PATH_TOOL for nm

### DIFF
--- a/configure
+++ b/configure
@@ -19025,8 +19025,9 @@ printf "%s\n" "no" >&6; }
 fi
 
 
-# Extract the first word of "nm", so it can be a program name with args.
-set dummy nm; ac_word=$2
+if test -n "$ac_tool_prefix"; then
+  # Extract the first word of "${ac_tool_prefix}nm", so it can be a program name with args.
+set dummy ${ac_tool_prefix}nm; ac_word=$2
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
 printf %s "checking for $ac_word... " >&6; }
 if test ${ac_cv_path_NM+y}
@@ -19057,7 +19058,6 @@ done
   done
 IFS=$as_save_IFS
 
-  test -z "$ac_cv_path_NM" && ac_cv_path_NM=":"
   ;;
 esac ;;
 esac
@@ -19071,6 +19071,69 @@ else
 printf "%s\n" "no" >&6; }
 fi
 
+
+fi
+if test -z "$ac_cv_path_NM"; then
+  ac_pt_NM=$NM
+  # Extract the first word of "nm", so it can be a program name with args.
+set dummy nm; ac_word=$2
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+printf %s "checking for $ac_word... " >&6; }
+if test ${ac_cv_path_ac_pt_NM+y}
+then :
+  printf %s "(cached) " >&6
+else case e in #(
+  e) case $ac_pt_NM in
+  [\\/]* | ?:[\\/]*)
+  ac_cv_path_ac_pt_NM="$ac_pt_NM" # Let the user override the test with a path.
+  ;;
+  *)
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  case $as_dir in #(((
+    '') as_dir=./ ;;
+    */) ;;
+    *) as_dir=$as_dir/ ;;
+  esac
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+    ac_cv_path_ac_pt_NM="$as_dir$ac_word$ac_exec_ext"
+    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+  ;;
+esac ;;
+esac
+fi
+ac_pt_NM=$ac_cv_path_ac_pt_NM
+if test -n "$ac_pt_NM"; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_pt_NM" >&5
+printf "%s\n" "$ac_pt_NM" >&6; }
+else
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+fi
+
+  if test "x$ac_pt_NM" = x; then
+    NM=":"
+  else
+    case $cross_compiling:$ac_tool_warned in
+yes:)
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+ac_tool_warned=yes ;;
+esac
+    NM=$ac_pt_NM
+  fi
+else
+  NM="$ac_cv_path_NM"
+fi
 
 # Extract the first word of "realpath", so it can be a program name with args.
 set dummy realpath; ac_word=$2
@@ -19463,9 +19526,6 @@ printf "%s\n" "yes" >&6; }
 printf "%s\n" "no" >&6; }
 		PKG_CONFIG=""
 	fi
-fi
-if test -z "$PKG_CONFIG"; then
-	as_fn_error $? "pkg-config not found" "$LINENO" 5
 fi
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for bison that supports parse-param" >&5
@@ -27515,18 +27575,18 @@ then :
 fi
 if test "$enable_largefile,$enable_year2038" != no,no
 then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CC option to enable large file support" >&5
-printf %s "checking for $CC option to enable large file support... " >&6; }
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CPPFLAGS option for large files" >&5
+printf %s "checking for $CPPFLAGS option for large files... " >&6; }
 if test ${ac_cv_sys_largefile_opts+y}
 then :
   printf %s "(cached) " >&6
 else case e in #(
-  e) ac_save_CC="$CC"
+  e) ac_save_CPPFLAGS=$CPPFLAGS
   ac_opt_found=no
-  for ac_opt in "none needed" "-D_FILE_OFFSET_BITS=64" "-D_LARGE_FILES=1" "-n32"; do
+  for ac_opt in "none needed" "-D_FILE_OFFSET_BITS=64" "-D_LARGE_FILES=1"; do
     if test x"$ac_opt" != x"none needed"
 then :
-  CC="$ac_save_CC $ac_opt"
+  CPPFLAGS="$ac_save_CPPFLAGS $ac_opt"
 fi
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -27555,12 +27615,12 @@ then :
   if test x"$ac_opt" = x"none needed"
 then :
   # GNU/Linux s390x and alpha need _FILE_OFFSET_BITS=64 for wide ino_t.
-	 CC="$CC -DFTYPE=ino_t"
+	 CPPFLAGS="$CPPFLAGS -DFTYPE=ino_t"
 	 if ac_fn_c_try_compile "$LINENO"
 then :
 
 else case e in #(
-  e) CC="$CC -D_FILE_OFFSET_BITS=64"
+  e) CPPFLAGS="$CPPFLAGS -D_FILE_OFFSET_BITS=64"
 	    if ac_fn_c_try_compile "$LINENO"
 then :
   ac_opt='-D_FILE_OFFSET_BITS=64'
@@ -27576,7 +27636,7 @@ fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
     test $ac_opt_found = no || break
   done
-  CC="$ac_save_CC"
+  CPPFLAGS=$ac_save_CPPFLAGS
 
   test $ac_opt_found = yes || ac_cv_sys_largefile_opts="support not detected" ;;
 esac
@@ -27600,16 +27660,14 @@ printf "%s\n" "#define _FILE_OFFSET_BITS 64" >>confdefs.h
 
 printf "%s\n" "#define _LARGE_FILES 1" >>confdefs.h
  ;; #(
-  "-n32") :
-    CC="$CC -n32" ;; #(
   *) :
     as_fn_error $? "internal error: bad value for \$ac_cv_sys_largefile_opts" "$LINENO" 5 ;;
 esac
 
 if test "$enable_year2038" != no
 then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CC option for timestamps after 2038" >&5
-printf %s "checking for $CC option for timestamps after 2038... " >&6; }
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CPPFLAGS option for timestamps after 2038" >&5
+printf %s "checking for $CPPFLAGS option for timestamps after 2038... " >&6; }
 if test ${ac_cv_sys_year2038_opts+y}
 then :
   printf %s "(cached) " >&6
@@ -39740,16 +39798,22 @@ printf %s "checking for pjsip_auth_get_algorithm_by_type in -lpjsip... " >&6; }
 if test ${ac_cv_lib_pjsip_pjsip_auth_get_algorithm_by_type+y}
 then :
   printf %s "(cached) " >&6
-else $as_nop
-  ac_check_lib_save_LIBS=$LIBS
+else case e in #(
+  e) ac_check_lib_save_LIBS=$LIBS
 LIBS="-lpjsip ${pbxlibdir} $PJPROJECT_LIB $LIBS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-char pjsip_auth_get_algorithm_by_type ();
+   builtin and then its argument prototype would still apply.
+   The 'extern "C"' is for builds by C++ compilers;
+   although this is not generally supported in C code supporting it here
+   has little cost and some practical benefit (sr 110532).  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char pjsip_auth_get_algorithm_by_type (void);
 int
 main (void)
 {
@@ -39761,20 +39825,23 @@ _ACEOF
 if ac_fn_c_try_link "$LINENO"
 then :
   ac_cv_lib_pjsip_pjsip_auth_get_algorithm_by_type=yes
-else $as_nop
-  ac_cv_lib_pjsip_pjsip_auth_get_algorithm_by_type=no
+else case e in #(
+  e) ac_cv_lib_pjsip_pjsip_auth_get_algorithm_by_type=no ;;
+esac
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam \
     conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
+LIBS=$ac_check_lib_save_LIBS ;;
+esac
 fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_pjsip_pjsip_auth_get_algorithm_by_type" >&5
 printf "%s\n" "$ac_cv_lib_pjsip_pjsip_auth_get_algorithm_by_type" >&6; }
 if test "x$ac_cv_lib_pjsip_pjsip_auth_get_algorithm_by_type" = xyes
 then :
   AST_PJSIP_AUTH_NEW_DIGESTS_FOUND=yes
-else $as_nop
-  AST_PJSIP_AUTH_NEW_DIGESTS_FOUND=no
+else case e in #(
+  e) AST_PJSIP_AUTH_NEW_DIGESTS_FOUND=no ;;
+esac
 fi
 
       CFLAGS="${ast_ext_lib_check_save_CFLAGS}"
@@ -39796,8 +39863,9 @@ fi
 if test "x$ac_cv_header_pjsip_h" = xyes
 then :
   PJSIP_AUTH_NEW_DIGESTS_HEADER_FOUND=1
-else $as_nop
-  PJSIP_AUTH_NEW_DIGESTS_HEADER_FOUND=0
+else case e in #(
+  e) PJSIP_AUTH_NEW_DIGESTS_HEADER_FOUND=0 ;;
+esac
 fi
 
          CPPFLAGS="${ast_ext_lib_check_saved_CPPFLAGS}"

--- a/configure.ac
+++ b/configure.ac
@@ -303,7 +303,7 @@ AC_PATH_PROG([BZIP2], [bzip2], :)
 AC_PATH_PROG([TAR], [tar], :)
 AC_PATH_PROG([PATCH], [patch], :)
 AC_PATH_PROG([SED], [sed], :)
-AC_PATH_PROG([NM], [nm], :)
+AC_PATH_TOOL([NM], [nm], :)
 AC_PATH_PROG([REALPATH], [realpath], :)
 
 


### PR DESCRIPTION
`nm` might, especially in cross-compilation scenarios, be available but prefixed with the target triple.  So: use `AC_PATH_TOOL` rather than `AC_PATH_PROG` to find it.  (See https://www.gnu.org/software/autoconf/manual/autoconf-2.68/html_node/Generic-Programs.html .)

Found and proposed fix tested by cross-compiling Asterisk using Nixpkgs on x86_64 targeting aarch64. :)