### PR TITLE
channelstorage_cpp: Fix fallback return value in channelstorage callback

### DIFF
--- a/main/channelstorage_cpp_map_name_id.cc
+++ b/main/channelstorage_cpp_map_name_id.cc
@@ -172,9 +172,8 @@ static struct ast_channel *callback(struct ast_channelstorage_instance *driver,
 		rdlock(driver);
 	}
 	for (it = getdb(driver).begin(); it != getdb(driver).end(); it++) {
-		chan = it->second;
-		if (cb_fn(chan, arg, data, ao2_flags) == (CMP_MATCH | CMP_STOP)) {
-			ao2_bump(chan);
+		if (cb_fn(it->second, arg, data, ao2_flags) == (CMP_MATCH | CMP_STOP)) {
+			chan = ao2_bump(it->second);
 			break;
 		}
 	}


### PR DESCRIPTION
callback returned the last iterated channel when no match existed, causing invalid channel references and potential double frees. Updated to correctly return NULL when there is no match.

Resolves: #1609