### PR TITLE
abstract_jb.c: Remove redundant timer check per static analysis.

### DIFF
--- a/main/abstract_jb.c
+++ b/main/abstract_jb.c
@@ -966,7 +966,7 @@ static struct ast_frame *hook_event_cb(struct ast_channel *chan, struct ast_fram
 		return frame;
 	}
 
-	if (ast_channel_fdno(chan) == AST_JITTERBUFFER_FD && framedata->timer) {
+	if (ast_channel_fdno(chan) == AST_JITTERBUFFER_FD) {
 		if (ast_timer_ack(framedata->timer, 1) < 0) {
 			ast_log(LOG_ERROR, "Failed to acknowledge timer in jitter buffer\n");
 			return frame;


### PR DESCRIPTION
While this check is technically unnecessary, it also was not harmful.

The 2 other items mentioned in the linked issue are false positives and require no action.

Resolves: #1417