### PR TITLE
file.c: Ensure opening a stream opens at most one file

### DIFF
--- a/main/file.c
+++ b/main/file.c
@@ -678,6 +678,11 @@ static int filehelper(const char *filename, const void *arg2, const char *fmt, c
 			}
 			ast_free(fn);
 		}
+
+		/* If we have successfully opened a file, we are done. */
+		if (action == ACTION_OPEN && res == 1) {
+			break;
+		}
 	}
 	AST_RWLIST_UNLOCK(&formats);
 	return res;


### PR DESCRIPTION
The functions used to stream files eventually end up calling into `filehelper(.., ACTION_OPEN)` which takes care of iterating over supported extensions and opening the first existing file.

To do this, `filehelper` uses two nested loops:

- An outer loop over the supported file formats.
- An inner loop over the possible extensions for that format.

We need to break out of both loops as soon as a file was successfully opened. Otherwise if a file exists in multiple formats (e.g `foo.wav` and `foo.alaw`) both files will be opened successively.

Resolves: #1625