### PR TITLE
cel_manager.c: Correct manager event mask for CEL events.

### DIFF
--- a/cel/cel_manager.c
+++ b/cel/cel_manager.c
@@ -35,7 +35,7 @@
 
 /*** DOCUMENTATION
 	<managerEvent language="en_US" name="CEL">
-		<managerEventInstance class="EVENT_FLAG_CEL">
+		<managerEventInstance class="EVENT_FLAG_CALL">
 			<since>
 				<version>13.2.0</version>
 			</since>


### PR DESCRIPTION
There is no EVENT_FLAG_CEL and these events are raised with as EVENT_FLAG_CALL.