### PR TITLE
Fix false null-deref warning in channel_state

### DIFF
--- a/res/stasis/app.c
+++ b/res/stasis/app.c
@@ -435,21 +435,25 @@ static struct ast_json *channel_state_change_event(
 	return simple_channel_event("ChannelStateChange", snapshot, tv);
 }
 
-/*! \brief Handle channel state changes */
+/*!
+*\brief Handle channel state changes 
+*
+*\note For channel snapshot updates, new_snapshot is guaranteed to be
+*	   non-NULL. A channel going away is indicated by AST_FLAG_DEAD
+*	   on the new snapshot. See stasis_channels.h for the invariant.
+*/
 static struct ast_json *channel_state(
 	struct ast_channel_snapshot *old_snapshot,
 	struct ast_channel_snapshot *new_snapshot,
 	const struct timeval *tv)
 {
-	struct ast_channel_snapshot *snapshot = new_snapshot ?
-		new_snapshot : old_snapshot;
 
 	if (!old_snapshot) {
-		return channel_created_event(snapshot, tv);
+		return channel_created_event(new_snapshot, tv);
 	} else if (ast_test_flag(&new_snapshot->flags, AST_FLAG_DEAD)) {
-		return channel_destroyed_event(snapshot, tv);
+		return channel_destroyed_event(new_snapshot, tv);
 	} else if (old_snapshot->state != new_snapshot->state) {
-		return channel_state_change_event(snapshot, tv);
+		return channel_state_change_event(new_snapshot, tv);
 	}
 
 	return NULL;


### PR DESCRIPTION
Resolve analyzer warning in channel_state by checking AST_FLAG_DEAD on snapshot, which is guaranteed non-NULL.

Resolves: #1430