### PR TITLE
endpoint.c: Plug a memory leak in ast_endpoint_shutdown().

### DIFF
--- a/main/endpoints.c
+++ b/main/endpoints.c
@@ -327,6 +327,7 @@ void ast_endpoint_shutdown(struct ast_endpoint *endpoint)
 			stasis_publish(ast_endpoint_topic(endpoint), message);
 		}
 	}
+	ao2_ref(endpoint, -1);
 }
 
 const char *ast_endpoint_get_tech(const struct ast_endpoint *endpoint)


### PR DESCRIPTION
Commit 26795be introduced a memory leak of ast_endpoint when
ast_endpoint_shutdown() was called. The leak occurs only if a configuration
change removes an endpoint and isn't related to call volume or the length of
time asterisk has been running.  An ao2_ref(-1) has been added to
ast_endpoint_shutdown() to plug the leak.

Resolves: #1635
