### PR TITLE
Disable device state caching for ephemeral channels

### DIFF
--- a/channels/chan_audiosocket.c
+++ b/channels/chan_audiosocket.c
@@ -275,6 +275,8 @@ static struct ast_channel *audiosocket_request(const char *type,
 		goto failure;
 	}
 	ast_channel_set_fd(chan, 0, fd);
+	/* Prevent device state caching as this channel involves ephemeral destinations or sources */
+	ast_set_flag(ast_channel_flags(chan), AST_FLAG_DISABLE_DEVSTATE_CACHE);
 
 	ast_channel_tech_set(chan, &audiosocket_channel_tech);
 

--- a/channels/chan_rtp.c
+++ b/channels/chan_rtp.c
@@ -217,6 +217,8 @@ static struct ast_channel *multicast_rtp_request(const char *type, struct ast_fo
 		ast_rtp_instance_destroy(instance);
 		goto failure;
 	}
+	/* Prevent device state caching as this channel involves ephemeral destinations or sources */
+	ast_set_flag(ast_channel_flags(chan), AST_FLAG_DISABLE_DEVSTATE_CACHE);
 	ast_rtp_instance_set_channel_id(instance, ast_channel_uniqueid(chan));
 	ast_rtp_instance_set_remote_address(instance, &destination_address);
 
@@ -374,6 +376,8 @@ static struct ast_channel *unicast_rtp_request(const char *type, struct ast_form
 		ast_rtp_instance_destroy(instance);
 		goto failure;
 	}
+	/*Prevent device state caching as this channel involves ephemeral destinations or sources */
+	ast_set_flag(ast_channel_flags(chan), AST_FLAG_DISABLE_DEVSTATE_CACHE);
 	ast_rtp_instance_set_channel_id(instance, ast_channel_uniqueid(chan));
 	ast_rtp_instance_set_remote_address(instance, &address);
 	ast_channel_set_fd(chan, 0, ast_rtp_instance_fd(instance, 0));

--- a/channels/chan_websocket.c
+++ b/channels/chan_websocket.c
@@ -1708,6 +1708,8 @@ static struct ast_channel *webchan_request(const char *type,
 		goto failure;
 	}
 
+	/* Prevent device state caching as this channel involves ephemeral destinations or sources */
+	ast_set_flag(ast_channel_flags(chan), AST_FLAG_DISABLE_DEVSTATE_CACHE);
 	ast_debug(3, "%s: WebSocket channel %s allocated for connection %s\n",
 		ast_channel_name(chan), requestor_name,
 		instance->connection_id);

--- a/res/res_stasis_snoop.c
+++ b/res/res_stasis_snoop.c
@@ -351,6 +351,8 @@ struct ast_channel *stasis_app_control_snoop(struct ast_channel *chan,
 
 	/* To keep the channel valid on the Snoop structure until it is destroyed we bump the ref up here */
 	ast_channel_ref(snoop->chan);
+	/* Prevent device state caching as this channel involves ephemeral destinations or sources */
+	ast_set_flag(ast_channel_flags(snoop->chan), AST_FLAG_DISABLE_DEVSTATE_CACHE);
 
 	ast_channel_tech_set(snoop->chan, &snoop_tech);
 	ao2_ref(snoop, +1);


### PR DESCRIPTION
chan_audiosocket/chan_rtp/res_stasis_snoop: Disable device state caching for ephemeral channels

Resolves: #1638