### PR TITLE
app_queue: Add 'prio' setting to the 'force_longest_waiting_caller' option

### DIFF
--- a/configs/samples/queues.conf.sample
+++ b/configs/samples/queues.conf.sample
@@ -73,6 +73,8 @@ monitor-type = MixMonitor
 ; is a member of another queue with a call that's been waiting longer. If so, the current
 ; call is not offered to the agent. The default value is 'no'.
 ;
+; Setting this to 'prio' performs the same check but also accounts for call priority.
+;
 ;force_longest_waiting_caller = no
 ;
 ; Add unpause event to queue log in case of pause send twice with different reason code.


### PR DESCRIPTION
This adds a 'prio' setting to ensure that call priority is respected across multiple queues.
Using 'yes' could cause high-priority callers to be skipped if a caller
in another queue had a longer wait time, regardless of priority.

Resolves: #1637

UserNote: The 'force_longest_waiting_caller' option now supports a 'prio' setting.
When set to 'prio', calls are offered by priority first, then by wait time.