### PR TITLE
res_pjsip_config_wizard: Force endpoint reload when Named ACL changes

### DIFF
--- a/include/asterisk/acl.h
+++ b/include/asterisk/acl.h
@@ -487,6 +487,8 @@ void ast_ha_output(int fd, const struct ast_ha *ha, const char *prefix);
  */
 void ast_acl_output(int fd, struct ast_acl_list *acl, const char *prefix);
 
+int ast_named_acl_get_generation(void);
+
 #if defined(__cplusplus) || defined(c_plusplus)
 }
 #endif

--- a/main/named_acl.c
+++ b/main/named_acl.c
@@ -90,6 +90,8 @@ static void *named_acl_config_alloc(void);
 static void *named_acl_alloc(const char *cat);
 static void *named_acl_find(struct ao2_container *container, const char *cat);
 
+static int acl_generation = 0;
+
 /* Config type for named ACL profiles (must not be named general) */
 static struct aco_type named_acl_type = {
 	.type = ACO_ITEM,                  /*!< named_acls are items stored in containers, not individual global objects */
@@ -531,6 +533,11 @@ static char *handle_show_named_acl_cmd(struct ast_cli_entry *e, int cmd, struct 
 	return CLI_SHOWUSAGE;
 }
 
+int ast_named_acl_get_generation(void)
+{
+	return acl_generation;
+}
+
 static struct ast_cli_entry cli_named_acl[] = {
 	AST_CLI_DEFINE(handle_show_named_acl_cmd, "Show a named ACL or list all named ACLs"),
 };
@@ -552,6 +559,9 @@ static int reload_module(void)
 		 */
 		return 0;
 	}
+
+	acl_generation++;
+	ast_log(LOG_NOTICE, "Named ACL reloaded. New generation: %d\n", acl_generation);
 
 	/* We need to push an ACL change event with no ACL name so that all subscribers update with all ACLs */
 	publish_acl_change("");


### PR DESCRIPTION
When using res_pjsip_config_wizard, endpoints fail to update their ACL rules if the underlying Named ACL (in acl.conf) changes, even after reloading both ACL and PJSIP. This happens because the wizard optimizes reloads by checking file timestamps or content changes in pjsip_wizard.conf, ignoring external ACL changes.

This patch introduces a generation counter for Named ACLs.
- main/named_acl.c: Exposes a generation counter incremented on reload.
- res_pjsip_config_wizard.c: Checks if the global ACL generation changed. If an ACL change is detected during a reload, the wizard forces a rebuild of endpoints that use 'acl' or 'contact_acl', bypassing standard optimization checks.

Fixes: #1641
Signed-off-by: Michal Hajek michal.hajek@daktela.com

cherry-pick-to: 23
cherry-pick-to: 22