### PR TITLE
cel: Add missing manager documentation.

### DIFF
--- a/cel/cel_manager.c
+++ b/cel/cel_manager.c
@@ -97,8 +97,23 @@
 						<enum name="LINKEDID_END">
 							<para>The linked ID associated with this channel is being retired.</para>
 						</enum>
+						<enum name="LOCAL_OPTIMIZE_BEGIN">
+							<para>A Local channel optimization has begun.</para>
+						</enum>
 						<enum name="LOCAL_OPTIMIZE">
 							<para>A Local channel optimization has occurred.</para>
+						</enum>
+						<enum name="STREAM_BEGIN">
+							<para>A stream started playing: it can be a standalone sound
+							file playing back, or a music-on-hold class started.</para>
+						</enum>
+						<enum name="STREAM_END">
+							<para>A playing stream ended.</para>
+						</enum>
+						<enum name="DTMF">
+							<para>A DTMF digit was processed: these events are dispatched
+							at the end, when the button is released and the duration is
+							present in the extra field</para>
 						</enum>
 						<enum name="USER_DEFINED">
 							<para>A user defined type.</para>

--- a/configs/samples/cel.conf.sample
+++ b/configs/samples/cel.conf.sample
@@ -45,8 +45,8 @@ apps=dial,park
 ;  CHAN_END         -- The time a channel was terminated
 ;  ANSWER           -- The time a channel was answered (ie, phone taken off-hook)
 ;  HANGUP           -- The time at which a hangup occurred
-;  BRIDGE_ENTER       -- The time a channel was connected into a conference room
-;  BRIDGE_EXIT        -- The time a channel was removed from a conference room
+;  BRIDGE_ENTER     -- The time a channel was connected into a conference room
+;  BRIDGE_EXIT      -- The time a channel was removed from a conference room
 ;  APP_START        -- The time a tracked application was started
 ;  APP_END          -- the time a tracked application ended
 ;  PARK_START       -- The time a call was parked
@@ -58,7 +58,9 @@ apps=dial,park
 ;  LINKEDID_END     -- The last channel with the given linkedid is retired
 ;  USER_DEFINED     -- Triggered from the dialplan, and has a name given by the
 ;                      user
-;  LOCAL_OPTIMIZE   -- A local channel pair is optimizing away.
+;  LOCAL_OPTIMIZE_BEGIN
+;                   -- A local channel pair optimization has begun.
+;  LOCAL_OPTIMIZE   -- A local channel pair has been optimized away.
 ;  STREAM_BEGIN     -- A stream started playing: it can be a standalone sound file
 ;                      playing back, or a music-on-hold class started
 ;  STREAM_END       -- A playing stream ended


### PR DESCRIPTION
The LOCAL_OPTIMIZE_BEGIN, STREAM_BEGIN, STREAM_END, and DTMF CEL events were not all documented in the CEL configuration file or the manager documentation for the CEL event.