### PR TITLE
sorcery: Fix crash when registering object types pre-created by sorcery.conf

### DIFF
--- a/include/asterisk/sorcery.h
+++ b/include/asterisk/sorcery.h
@@ -808,6 +808,7 @@ int ast_sorcery_object_unregister(struct ast_sorcery *sorcery, const char *type)
  *
  * \param sorcery Pointer to a sorcery structure
  * \param type Type of object
+ * \param module The module name for XML documentation lookup (typically AST_MODULE)
  * \param hidden All objects of this type are internal and should not be manipulated by users
  * \param reloadable All objects of this type are reloadable
  * \param alloc Required object allocation callback
@@ -817,10 +818,15 @@ int ast_sorcery_object_unregister(struct ast_sorcery *sorcery, const char *type)
  * \note In general, this function should not be used directly. One of the various
  * macro'd versions should be used instead.
  *
+ * \note The module parameter is used for XML documentation lookup. When an object type
+ * is created via sorcery.conf, it may initially have a different module name than the
+ * module that provides the XML documentation. This parameter ensures the correct module
+ * is used for documentation lookup.
+ *
  * \retval 0 success
  * \retval -1 failure
  */
-int __ast_sorcery_object_register(struct ast_sorcery *sorcery, const char *type, unsigned int hidden, unsigned int reloadable, aco_type_item_alloc alloc, sorcery_transform_handler transform, sorcery_apply_handler apply);
+int __ast_sorcery_object_register(struct ast_sorcery *sorcery, const char *type, const char *module, unsigned int hidden, unsigned int reloadable, aco_type_item_alloc alloc, sorcery_transform_handler transform, sorcery_apply_handler apply);
 
 /*!
  * \brief Register an object type
@@ -835,7 +841,7 @@ int __ast_sorcery_object_register(struct ast_sorcery *sorcery, const char *type,
  * \retval -1 failure
  */
 #define ast_sorcery_object_register(sorcery, type, alloc, transform, apply) \
-	__ast_sorcery_object_register((sorcery), (type), 0, 1, (alloc), (transform), (apply))
+	__ast_sorcery_object_register((sorcery), (type), AST_MODULE, 0, 1, (alloc), (transform), (apply))
 
 /*!
  * \brief Register an object type that is not reloadable
@@ -850,7 +856,7 @@ int __ast_sorcery_object_register(struct ast_sorcery *sorcery, const char *type,
  * \retval -1 failure
  */
 #define ast_sorcery_object_register_no_reload(sorcery, type, alloc, transform, apply) \
-	__ast_sorcery_object_register((sorcery), (type), 0, 0, (alloc), (transform), (apply))
+	__ast_sorcery_object_register((sorcery), (type), AST_MODULE, 0, 0, (alloc), (transform), (apply))
 
 /*!
  * \brief Register an internal, hidden object type
@@ -865,7 +871,7 @@ int __ast_sorcery_object_register(struct ast_sorcery *sorcery, const char *type,
  * \retval -1 failure
  */
 #define ast_sorcery_internal_object_register(sorcery, type, alloc, transform, apply) \
-	__ast_sorcery_object_register((sorcery), (type), 1, 1, (alloc), (transform), (apply))
+	__ast_sorcery_object_register((sorcery), (type), AST_MODULE, 1, 1, (alloc), (transform), (apply))
 
 /*!
  * \brief Set the high and low alert water marks of the sorcery object type.

--- a/main/sorcery.c
+++ b/main/sorcery.c
@@ -1141,13 +1141,22 @@ int ast_sorcery_object_unregister(struct ast_sorcery *sorcery, const char *type)
 	return res;
 }
 
-int __ast_sorcery_object_register(struct ast_sorcery *sorcery, const char *type, unsigned int hidden, unsigned int reloadable, aco_type_item_alloc alloc, sorcery_transform_handler transform, sorcery_apply_handler apply)
+int __ast_sorcery_object_register(struct ast_sorcery *sorcery, const char *type, const char *module, unsigned int hidden, unsigned int reloadable, aco_type_item_alloc alloc, sorcery_transform_handler transform, sorcery_apply_handler apply)
 {
 	RAII_VAR(struct ast_sorcery_object_type *, object_type, ao2_find(sorcery->types, type, OBJ_KEY), ao2_cleanup);
 
 	if (!object_type || object_type->type.item_alloc) {
 		return -1;
 	}
+
+	/*
+	 * Update the module name for XML documentation lookup.
+	 * The object type may have been created earlier by sorcery.conf processing
+	 * with a different module name (e.g., "res_pjsip"), but the registering
+	 * module (e.g., "res_pjsip_outbound_registration") provides the actual
+	 * XML documentation. Use the registering module's name for xmldoc lookups.
+	 */
+	object_type->info->module = module;
 
 	object_type->type.name = object_type->name;
 	object_type->type.type = ACO_ITEM;


### PR DESCRIPTION
When sorcery.conf maps an object type (e.g., registration) to a realtime
backend under a section like [res_pjsip], the sorcery system creates the
object type early with the section name as the module. When the actual
module (res_pjsip_outbound_registration) later registers the same type,
the xmldoc system attempts to look up documentation using the wrong
module name, causing a crash with "munmap_chunk(): invalid pointer".

Fix by adding a module parameter to __ast_sorcery_object_register() that
updates the object type's module name to match the registering module.
This ensures XML documentation lookups use the correct module name.

The macros ast_sorcery_object_register(), ast_sorcery_object_register_no_reload(),
and ast_sorcery_internal_object_register() now pass AST_MODULE automatically.

Fixes: #1651