### PR TITLE
res_odbc: Use SQL_SUCCEEDED() macro where applicable.

### DIFF
--- a/cdr/cdr_adaptive_odbc.c
+++ b/cdr/cdr_adaptive_odbc.c
@@ -161,14 +161,14 @@ static int load_config(void)
 		}
 
 		res = SQLAllocHandle(SQL_HANDLE_STMT, obj->con, &stmt);
-		if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+		if (!SQL_SUCCEEDED(res)) {
 			ast_log(LOG_WARNING, "SQL Alloc Handle failed on connection '%s'!\n", connection);
 			ast_odbc_release_obj(obj);
 			continue;
 		}
 
 		res = SQLColumns(stmt, NULL, 0, lenschema == 0 ? NULL : (unsigned char *)schema, SQL_NTS, (unsigned char *)table, SQL_NTS, (unsigned char *)"%", SQL_NTS);
-		if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+		if (!SQL_SUCCEEDED(res)) {
 			ast_log(LOG_ERROR, "Unable to query database columns on connection '%s'.  Skipping.\n", connection);
 			SQLFreeHandle(SQL_HANDLE_STMT, stmt);
 			ast_odbc_release_obj(obj);
@@ -333,13 +333,13 @@ static SQLHSTMT generic_prepare(struct odbc_obj *obj, void *data)
 	unsigned char state[10], diagnostic[256];
 
 	res = SQLAllocHandle (SQL_HANDLE_STMT, obj->con, &stmt);
-	if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+	if (!SQL_SUCCEEDED(res)) {
 		ast_log(LOG_WARNING, "SQL Alloc Handle failed!\n");
 		return NULL;
 	}
 
 	res = ast_odbc_prepare(obj, stmt, data);
-	if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+	if (!SQL_SUCCEEDED(res)) {
 		ast_log(LOG_WARNING, "SQL Prepare failed![%s]\n", (char *) data);
 		SQLGetDiagField(SQL_HANDLE_STMT, stmt, 1, SQL_DIAG_NUMBER, &numfields, SQL_IS_INTEGER, &diagbytes);
 		for (i = 0; i < numfields; i++) {

--- a/cdr/cdr_odbc.c
+++ b/cdr/cdr_odbc.c
@@ -96,7 +96,7 @@ static SQLHSTMT execute_cb(struct odbc_obj *obj, void *data)
 
 	ODBC_res = SQLAllocHandle(SQL_HANDLE_STMT, obj->con, &stmt);
 
-	if ((ODBC_res != SQL_SUCCESS) && (ODBC_res != SQL_SUCCESS_WITH_INFO)) {
+	if (!SQL_SUCCEEDED(ODBC_res)) {
 		ast_log(LOG_WARNING, "cdr_odbc: Failure in AllocStatement %d\n", ODBC_res);
 		SQLFreeHandle(SQL_HANDLE_STMT, stmt);
 		return NULL;
@@ -152,7 +152,7 @@ static SQLHSTMT execute_cb(struct odbc_obj *obj, void *data)
 
 	ODBC_res = ast_odbc_execute_sql(obj, stmt, sqlcmd);
 
-	if ((ODBC_res != SQL_SUCCESS) && (ODBC_res != SQL_SUCCESS_WITH_INFO)) {
+	if (!SQL_SUCCEEDED(ODBC_res)) {
 		ast_log(LOG_WARNING, "cdr_odbc: Error in ExecDirect: %d, query is: %s\n", ODBC_res, sqlcmd);
 		SQLFreeHandle(SQL_HANDLE_STMT, stmt);
 		return NULL;

--- a/cel/cel_odbc.c
+++ b/cel/cel_odbc.c
@@ -151,14 +151,14 @@ static int load_config(void)
 		lentable = strlen(table);
 
 		res = SQLAllocHandle(SQL_HANDLE_STMT, obj->con, &stmt);
-		if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+		if (!SQL_SUCCEEDED(res)) {
 			ast_log(LOG_WARNING, "SQL Alloc Handle failed on connection '%s'!\n", connection);
 			ast_odbc_release_obj(obj);
 			continue;
 		}
 
 		res = SQLColumns(stmt, NULL, 0, NULL, 0, (unsigned char *)table, SQL_NTS, (unsigned char *)"%", SQL_NTS);
-		if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+		if (!SQL_SUCCEEDED(res)) {
 			ast_log(LOG_ERROR, "Unable to query database columns on connection '%s'.  Skipping.\n", connection);
 			ast_odbc_release_obj(obj);
 			continue;
@@ -318,13 +318,13 @@ static SQLHSTMT generic_prepare(struct odbc_obj *obj, void *data)
 	unsigned char state[10], diagnostic[256];
 
 	res = SQLAllocHandle (SQL_HANDLE_STMT, obj->con, &stmt);
-	if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+	if (!SQL_SUCCEEDED(res)) {
 		ast_log(LOG_WARNING, "SQL Alloc Handle failed!\n");
 		return NULL;
 	}
 
 	res = ast_odbc_prepare(obj, stmt, sql);
-	if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+	if (!SQL_SUCCEEDED(res)) {
 		ast_log(LOG_WARNING, "SQL Prepare failed![%s]\n", sql);
 		SQLGetDiagField(SQL_HANDLE_STMT, stmt, 1, SQL_DIAG_NUMBER, &numfields, SQL_IS_INTEGER, &diagbytes);
 		for (i = 0; i < numfields; i++) {

--- a/funcs/func_odbc.c
+++ b/funcs/func_odbc.c
@@ -489,13 +489,13 @@ static SQLHSTMT execute(struct odbc_obj *obj, void *data, int silent)
 	SQLHSTMT stmt;
 
 	res = SQLAllocHandle (SQL_HANDLE_STMT, obj->con, &stmt);
-	if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+	if (!SQL_SUCCEEDED(res)) {
 		ast_log(LOG_WARNING, "SQL Alloc Handle failed (%d)!\n", res);
 		return NULL;
 	}
 
 	res = ast_odbc_execute_sql(obj, stmt, sql);
-	if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO) && (res != SQL_NO_DATA)) {
+	if (!SQL_SUCCEEDED(res) && (res != SQL_NO_DATA)) {
 		if (res == SQL_ERROR && !silent) {
 			int i;
 			SQLINTEGER nativeerror=0, numfields=0;
@@ -898,7 +898,7 @@ static int acf_odbc_read(struct ast_channel *chan, const char *cmd, char *s, cha
 	}
 
 	res = SQLNumResultCols(stmt, &colcount);
-	if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+	if (!SQL_SUCCEEDED(res)) {
 		ast_log(LOG_WARNING, "SQL Column Count error!\n[%s]\n\n", ast_str_buffer(sql));
 		SQLCloseCursor(stmt);
 		SQLFreeHandle (SQL_HANDLE_STMT, stmt);
@@ -927,7 +927,7 @@ static int acf_odbc_read(struct ast_channel *chan, const char *cmd, char *s, cha
 	}
 
 	res = SQLFetch(stmt);
-	if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+	if (!SQL_SUCCEEDED(res)) {
 		int res1 = -1;
 		if (res == SQL_NO_DATA) {
 			ast_verb(4, "Found no rows [%s]\n", ast_str_buffer(sql));
@@ -978,7 +978,7 @@ static int acf_odbc_read(struct ast_channel *chan, const char *cmd, char *s, cha
 
 				res = SQLDescribeCol(stmt, x + 1, (unsigned char *)colname, sizeof(colname), &collength, NULL, NULL, NULL, NULL);
 				ast_debug(3, "Got collength of %d for column '%s' (offset %d)\n", (int)collength, colname, x);
-				if (((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) || collength == 0) {
+				if (!SQL_SUCCEEDED(res) || collength == 0) {
 					snprintf(colname, sizeof(colname), "field%d", x);
 				}
 
@@ -1019,7 +1019,7 @@ static int acf_odbc_read(struct ast_channel *chan, const char *cmd, char *s, cha
 				res = SQL_SUCCESS;
 			}
 
-			if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+			if (!SQL_SUCCEEDED(res)) {
 				ast_log(LOG_WARNING, "SQL Get Data error!\n[%s]\n\n", ast_str_buffer(sql));
 				y = -1;
 				buf[0] = '\0';
@@ -1066,7 +1066,7 @@ static int acf_odbc_read(struct ast_channel *chan, const char *cmd, char *s, cha
 
 			/* Get next row */
 			res = SQLFetch(stmt);
-			if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+			if (!SQL_SUCCEEDED(res)) {
 				if (res != SQL_NO_DATA) {
 					ast_log(LOG_WARNING, "Error %d in FETCH [%s]\n", res, ast_str_buffer(sql));
 				}
@@ -1601,7 +1601,7 @@ static char *cli_odbc_read(struct ast_cli_entry *e, int cmd, struct ast_cli_args
 			executed = 1;
 
 			res = SQLNumResultCols(stmt, &colcount);
-			if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+			if (!SQL_SUCCEEDED(res)) {
 				ast_cli(a->fd, "SQL Column Count error!\n[%s]\n\n", ast_str_buffer(sql));
 				SQLCloseCursor(stmt);
 				SQLFreeHandle (SQL_HANDLE_STMT, stmt);
@@ -1620,7 +1620,7 @@ static char *cli_odbc_read(struct ast_cli_entry *e, int cmd, struct ast_cli_args
 			}
 
 			res = SQLFetch(stmt);
-			if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+			if (!SQL_SUCCEEDED(res)) {
 				SQLCloseCursor(stmt);
 				SQLFreeHandle(SQL_HANDLE_STMT, stmt);
 				release_obj_or_dsn (&obj, &dsn);
@@ -1636,7 +1636,7 @@ static char *cli_odbc_read(struct ast_cli_entry *e, int cmd, struct ast_cli_args
 			for (;;) {
 				for (x = 0; x < colcount; x++) {
 					res = SQLDescribeCol(stmt, x + 1, (unsigned char *)colname, sizeof(colname), &collength, NULL, NULL, NULL, NULL);
-					if (((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) || collength == 0) {
+					if (!SQL_SUCCEEDED(res) || collength == 0) {
 						snprintf(colname, sizeof(colname), "field%d", x);
 					}
 
@@ -1649,7 +1649,7 @@ static char *cli_odbc_read(struct ast_cli_entry *e, int cmd, struct ast_cli_args
 						res = SQL_SUCCESS;
 					}
 
-					if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+					if (!SQL_SUCCEEDED(res)) {
 						ast_cli(a->fd, "SQL Get Data error %d!\n[%s]\n\n", res, ast_str_buffer(sql));
 						SQLCloseCursor(stmt);
 						SQLFreeHandle(SQL_HANDLE_STMT, stmt);
@@ -1664,7 +1664,7 @@ static char *cli_odbc_read(struct ast_cli_entry *e, int cmd, struct ast_cli_args
 
 				/* Get next row */
 				res = SQLFetch(stmt);
-				if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+				if (!SQL_SUCCEEDED(res)) {
 					break;
 				}
 				ast_cli(a->fd, "%-20.20s  %s\n", "----------", "----------");

--- a/res/res_config_odbc.c
+++ b/res/res_config_odbc.c
@@ -110,7 +110,7 @@ static SQLHSTMT custom_prepare(struct odbc_obj *obj, void *data)
 	SQLHSTMT stmt;
 
 	res = SQLAllocHandle(SQL_HANDLE_STMT, obj->con, &stmt);
-	if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+	if (!SQL_SUCCEEDED(res)) {
 		ast_log(LOG_WARNING, "SQL Alloc Handle failed!\n");
 		return NULL;
 	}
@@ -118,7 +118,7 @@ static SQLHSTMT custom_prepare(struct odbc_obj *obj, void *data)
 	ast_debug(1, "Skip: %llu; SQL: %s\n", cps->skip, cps->sql);
 
 	res = ast_odbc_prepare(obj, stmt, cps->sql);
-	if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+	if (!SQL_SUCCEEDED(res)) {
 		if (res == SQL_ERROR) {
 			ast_odbc_print_errors(SQL_HANDLE_STMT, stmt, "SQL Prepare");
 		}
@@ -229,7 +229,7 @@ static struct ast_variable *realtime_odbc(const char *database, const char *tabl
 	}
 
 	res = SQLNumResultCols(stmt, &colcount);
-	if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+	if (!SQL_SUCCEEDED(res)) {
 		ast_log(LOG_WARNING, "SQL Column Count error! [%s]\n", ast_str_buffer(sql));
 		SQLFreeHandle (SQL_HANDLE_STMT, stmt);
 		ast_odbc_release_obj(obj);
@@ -246,7 +246,7 @@ static struct ast_variable *realtime_odbc(const char *database, const char *tabl
 		ast_odbc_release_obj(obj);
 		return CONFIG_RT_NOT_FOUND;
 	}
-	if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+	if (!SQL_SUCCEEDED(res)) {
 		ast_log(LOG_WARNING, "SQL Fetch error! [%s]\n", ast_str_buffer(sql));
 		SQLFreeHandle (SQL_HANDLE_STMT, stmt);
 		ast_odbc_release_obj(obj);
@@ -257,7 +257,7 @@ static struct ast_variable *realtime_odbc(const char *database, const char *tabl
 		collen = sizeof(coltitle);
 		res = SQLDescribeCol(stmt, x + 1, (unsigned char *)coltitle, sizeof(coltitle), &collen,
 					&datatype, &colsize, &decimaldigits, &nullable);
-		if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+		if (!SQL_SUCCEEDED(res)) {
 			ast_log(LOG_WARNING, "SQL Describe Column error! [%s]\n", ast_str_buffer(sql));
 			if (var)
 				ast_variables_destroy(var);
@@ -276,7 +276,7 @@ static struct ast_variable *realtime_odbc(const char *database, const char *tabl
 			/* Because we encode the empty string for a NULL, we will encode
 			 * actual empty strings as a string containing a single whitespace. */
 			ast_str_set(&rowdata, -1, "%s", " ");
-		} else if ((res == SQL_SUCCESS) || (res == SQL_SUCCESS_WITH_INFO)) {
+		} else if (SQL_SUCCEEDED(res)) {
 			if (indicator != ast_str_strlen(rowdata)) {
 				/* If the available space was not enough to contain the row data enlarge and read in the rest */
 				ast_str_make_space(&rowdata, indicator + 1);
@@ -286,7 +286,7 @@ static struct ast_variable *realtime_odbc(const char *database, const char *tabl
 			}
 		}
 
-		if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+		if (!SQL_SUCCEEDED(res)) {
 			ast_log(LOG_WARNING, "SQL Get Data error! [%s]\n", ast_str_buffer(sql));
 			if (var)
 				ast_variables_destroy(var);
@@ -416,7 +416,7 @@ static struct ast_config *realtime_multi_odbc(const char *database, const char *
 	}
 
 	res = SQLNumResultCols(stmt, &colcount);
-	if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+	if (!SQL_SUCCEEDED(res)) {
 		ast_log(LOG_WARNING, "SQL Column Count error! [%s]\n", ast_str_buffer(sql));
 		SQLFreeHandle(SQL_HANDLE_STMT, stmt);
 		ast_odbc_release_obj(obj);
@@ -433,7 +433,7 @@ static struct ast_config *realtime_multi_odbc(const char *database, const char *
 
 	while ((res=SQLFetch(stmt)) != SQL_NO_DATA) {
 		var = NULL;
-		if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+		if (!SQL_SUCCEEDED(res)) {
 			ast_log(LOG_WARNING, "SQL Fetch error! [%s]\n", ast_str_buffer(sql));
 			continue;
 		}
@@ -446,7 +446,7 @@ static struct ast_config *realtime_multi_odbc(const char *database, const char *
 			collen = sizeof(coltitle);
 			res = SQLDescribeCol(stmt, x + 1, (unsigned char *)coltitle, sizeof(coltitle), &collen,
 						&datatype, &colsize, &decimaldigits, &nullable);
-			if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+			if (!SQL_SUCCEEDED(res)) {
 				ast_log(LOG_WARNING, "SQL Describe Column error! [%s]\n", ast_str_buffer(sql));
 				ast_category_destroy(cat);
 				goto next_sql_fetch;
@@ -461,7 +461,7 @@ static struct ast_config *realtime_multi_odbc(const char *database, const char *
 				continue;
 			}
 
-			if ((res == SQL_SUCCESS) || (res == SQL_SUCCESS_WITH_INFO)) {
+			if (SQL_SUCCEEDED(res)) {
 				if (indicator != ast_str_strlen(rowdata)) {
 					/* If the available space was not enough to contain the row data enlarge and read in the rest */
 					ast_str_make_space(&rowdata, indicator + 1);
@@ -471,7 +471,7 @@ static struct ast_config *realtime_multi_odbc(const char *database, const char *
 				}
 			}
 
-			if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+			if (!SQL_SUCCEEDED(res)) {
 				ast_log(LOG_WARNING, "SQL Get Data error! [%s]\n", ast_str_buffer(sql));
 				ast_category_destroy(cat);
 				goto next_sql_fetch;
@@ -592,7 +592,7 @@ static int update_odbc(const char *database, const char *table, const char *keyf
 	SQLFreeHandle (SQL_HANDLE_STMT, stmt);
 	ast_odbc_release_obj(obj);
 
-	if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+	if (!SQL_SUCCEEDED(res)) {
 		ast_log(LOG_WARNING, "SQL Row Count error! [%s]\n", ast_str_buffer(sql));
 		return -1;
 	}
@@ -625,7 +625,7 @@ static SQLHSTMT update2_prepare(struct odbc_obj *obj, void *data)
 	}
 
 	res = SQLAllocHandle(SQL_HANDLE_STMT, obj->con, &stmt);
-	if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+	if (!SQL_SUCCEEDED(res)) {
 		ast_log(LOG_WARNING, "SQL Alloc Handle failed!\n");
 		return NULL;
 	}
@@ -657,7 +657,7 @@ static SQLHSTMT update2_prepare(struct odbc_obj *obj, void *data)
 	}
 
 	res = ast_odbc_prepare(obj, stmt, ast_str_buffer(sql));
-	if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+	if (!SQL_SUCCEEDED(res)) {
 		if (res == SQL_ERROR) {
 			ast_odbc_print_errors(SQL_HANDLE_STMT, stmt, "SQL Prepare");
 		}
@@ -720,7 +720,7 @@ static int update2_odbc(const char *database, const char *table, const struct as
 	SQLFreeHandle(SQL_HANDLE_STMT, stmt);
 	ast_odbc_release_obj(obj);
 
-	if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+	if (!SQL_SUCCEEDED(res)) {
 		/* Since only a single thread can access this memory, we can retrieve what would otherwise be lost. */
 		sql = ast_str_thread_get(&sql_buf, SQL_BUF_SIZE);
 		ast_assert(sql != NULL);
@@ -805,7 +805,7 @@ static int store_odbc(const char *database, const char *table, const struct ast_
 	SQLFreeHandle (SQL_HANDLE_STMT, stmt);
 	ast_odbc_release_obj(obj);
 
-	if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+	if (!SQL_SUCCEEDED(res)) {
 		ast_log(LOG_WARNING, "SQL Row Count error! [%s]\n", ast_str_buffer(sql));
 		return -1;
 	}
@@ -875,7 +875,7 @@ static int destroy_odbc(const char *database, const char *table, const char *key
 	SQLFreeHandle (SQL_HANDLE_STMT, stmt);
 	ast_odbc_release_obj(obj);
 
-	if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+	if (!SQL_SUCCEEDED(res)) {
 		ast_log(LOG_WARNING, "SQL Row Count error! [%s]\n", ast_str_buffer(sql));
 		return -1;
 	}
@@ -904,13 +904,13 @@ static SQLHSTMT length_determination_odbc_prepare(struct odbc_obj *obj, void *da
 	int res;
 
 	res = SQLAllocHandle(SQL_HANDLE_STMT, obj->con, &sth);
-	if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+	if (!SQL_SUCCEEDED(res)) {
 		ast_verb(4, "Failure in AllocStatement %d\n", res);
 		return NULL;
 	}
 
 	res = ast_odbc_prepare(obj, sth, q->sql);
-	if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+	if (!SQL_SUCCEEDED(res)) {
 		ast_verb(4, "Error in PREPARE %d\n", res);
 		SQLFreeHandle(SQL_HANDLE_STMT, sth);
 		return NULL;
@@ -928,13 +928,13 @@ static SQLHSTMT config_odbc_prepare(struct odbc_obj *obj, void *data)
 	int res;
 
 	res = SQLAllocHandle(SQL_HANDLE_STMT, obj->con, &sth);
-	if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+	if (!SQL_SUCCEEDED(res)) {
 		ast_verb(4, "Failure in AllocStatement %d\n", res);
 		return NULL;
 	}
 
 	res = ast_odbc_prepare(obj, sth, q->sql);
-	if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+	if (!SQL_SUCCEEDED(res)) {
 		ast_verb(4, "Error in PREPARE %d\n", res);
 		SQLFreeHandle(SQL_HANDLE_STMT, sth);
 		return NULL;
@@ -986,7 +986,7 @@ static struct ast_config *config_odbc(const char *database, const char *table, c
 
 	res = SQLNumResultCols(stmt, &rowcount);
 
-	if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+	if (!SQL_SUCCEEDED(res)) {
 		ast_log(LOG_WARNING, "SQL NumResultCols error! [%s]\n", ast_str_buffer(sql));
 		SQLFreeHandle(SQL_HANDLE_STMT, stmt);
 		ast_odbc_release_obj(obj);
@@ -1033,7 +1033,7 @@ static struct ast_config *config_odbc(const char *database, const char *table, c
 
 	res = SQLNumResultCols(stmt, &rowcount);
 
-	if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+	if (!SQL_SUCCEEDED(res)) {
 		ast_log(LOG_WARNING, "SQL NumResultCols error! [%s]\n", ast_str_buffer(sql));
 		SQLFreeHandle(SQL_HANDLE_STMT, stmt);
 		ast_odbc_release_obj(obj);

--- a/res/res_odbc.c
+++ b/res/res_odbc.c
@@ -265,13 +265,13 @@ struct odbc_cache_tables *ast_odbc_find_table(const char *database, const char *
 	/* Table structure not already cached; build it now. */
 	do {
 		res = SQLAllocHandle(SQL_HANDLE_STMT, obj->con, &stmt);
-		if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+		if (!SQL_SUCCEEDED(res)) {
 			ast_log(LOG_WARNING, "SQL Alloc Handle failed on connection '%s'!\n", database);
 			break;
 		}
 
 		res = SQLColumns(stmt, NULL, 0, NULL, 0, (unsigned char *)tablename, SQL_NTS, (unsigned char *)"%", SQL_NTS);
-		if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+		if (!SQL_SUCCEEDED(res)) {
 			SQLFreeHandle(SQL_HANDLE_STMT, stmt);
 			ast_log(LOG_ERROR, "Unable to query database columns on connection '%s'.\n", database);
 			break;
@@ -421,7 +421,7 @@ SQLHSTMT ast_odbc_prepare_and_execute(struct odbc_obj *obj, SQLHSTMT (*prepare_c
 	}
 
 	res = SQLExecute(stmt);
-	if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO) && (res != SQL_NO_DATA)) {
+	if (!SQL_SUCCEEDED(res) && (res != SQL_NO_DATA)) {
 		if (res == SQL_ERROR) {
 			ast_odbc_print_errors(SQL_HANDLE_STMT, stmt, "SQL Execute");
 		}
@@ -487,7 +487,7 @@ int ast_odbc_smart_execute(struct odbc_obj *obj, SQLHSTMT stmt)
 	int res = 0;
 
 	res = SQLExecute(stmt);
-	if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO) && (res != SQL_NO_DATA)) {
+	if (!SQL_SUCCEEDED(res) && (res != SQL_NO_DATA)) {
 		if (res == SQL_ERROR) {
 			ast_odbc_print_errors(SQL_HANDLE_STMT, stmt, "SQL Execute");
 		}
@@ -676,7 +676,7 @@ static int load_odbc_config(void)
 				SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &new->env);
 				res = SQLSetEnvAttr(new->env, SQL_ATTR_ODBC_VERSION, (void *) SQL_OV_ODBC3, 0);
 
-				if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+				if (!SQL_SUCCEEDED(res)) {
 					ast_log(LOG_WARNING, "res_odbc: Error SetEnv\n");
 					ao2_ref(new, -1);
 					return res;
@@ -1116,7 +1116,7 @@ static odbc_status odbc_obj_connect(struct odbc_obj *obj)
 
 	res = SQLAllocHandle(SQL_HANDLE_DBC, obj->parent->env, &con);
 
-	if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+	if (!SQL_SUCCEEDED(res)) {
 		ast_log(LOG_WARNING, "res_odbc: Error AllocHDB %d\n", res);
 		obj->parent->last_negative_connect = ast_tvnow();
 		return ODBC_FAIL;
@@ -1133,7 +1133,7 @@ static odbc_status odbc_obj_connect(struct odbc_obj *obj)
 		   (SQLCHAR *) obj->parent->username, SQL_NTS,
 		   (SQLCHAR *) obj->parent->password, SQL_NTS);
 
-	if ((res != SQL_SUCCESS) && (res != SQL_SUCCESS_WITH_INFO)) {
+	if (!SQL_SUCCEEDED(res)) {
 		SQLGetDiagRec(SQL_HANDLE_DBC, con, 1, state, &err, msg, 100, &mlen);
 		obj->parent->last_negative_connect = ast_tvnow();
 		ast_log(LOG_WARNING, "res_odbc: Error SQLConnect=%d errno=%d %s\n", res, (int)err, msg);


### PR DESCRIPTION
This is just a cleanup of some repetitive code.