### PR TITLE
main/dial.c: Set channel hangup cause on timeout in handle_timeout_trip

### DIFF
--- a/main/dial.c
+++ b/main/dial.c
@@ -731,6 +731,9 @@ static int handle_timeout_trip(struct ast_dial *dial, struct timeval start)
 	/* Go through dropping out channels that have met their timeout */
 	AST_LIST_TRAVERSE(&dial->channels, channel, list) {
 		if (dial->state == AST_DIAL_RESULT_TIMEOUT || diff >= channel->timeout) {
+			ast_channel_lock(channel->owner);
+			ast_channel_hangupcause_set(channel->owner, AST_CAUSE_NO_ANSWER);
+			ast_channel_unlock(channel->owner);
 			ast_hangup(channel->owner);
 			channel->cause = AST_CAUSE_NO_ANSWER;
 			channel->owner = NULL;


### PR DESCRIPTION
When dial attempts timeout in the core dialing API, the channel's hangup cause was not being set before hanging up. Only the ast_dial_channel structure's internal cause field was updated, but the actual ast_channel hangup cause remained unset.

This resulted in incorrect or missing hangup cause information being reported through CDRs, AMI events, and other mechanisms that read the channel's hangup cause when dial timeouts occurred via applications using the dialing API (FollowMe, Page, etc.).

The fix adds proper channel locking and sets AST_CAUSE_NO_ANSWER on the channel before calling ast_hangup(), ensuring consistent hangup cause reporting across all interfaces.

Resolves: #1660