### PR TITLE
rtp/rtcp: Configure dual-stack behavior via IPV6_V6ONLY

### DIFF
--- a/configure
+++ b/configure
@@ -31433,6 +31433,40 @@ esac
 fi
 
 
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if setsockopt() accepts the IPV6_V6ONLY socket option" >&5
+printf %s "checking if setsockopt() accepts the IPV6_V6ONLY socket option... " >&6; }
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+	   #include <sys/socket.h>
+	   #include <netinet/in.h>
+
+int
+main (void)
+{
+
+	   int opt = IPV6_V6ONLY;
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+
+printf "%s\n" "#define HAVE_SOCK_IPV6_V6ONLY 1" >>confdefs.h
+
+else case e in #(
+  e) { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+ ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+
+
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if we can increase the maximum select-able file descriptor" >&5
 printf %s "checking if we can increase the maximum select-able file descriptor... " >&6; }
 if test "$cross_compiling" = yes

--- a/configure.ac
+++ b/configure.ac
@@ -1248,6 +1248,19 @@ AC_RUN_IFELSE(
 	AC_MSG_RESULT(cross-compile)
 )
 
+AC_MSG_CHECKING([if setsockopt() accepts the IPV6_V6ONLY socket option])
+AC_COMPILE_IFELSE(
+[AC_LANG_PROGRAM([
+	   #include <sys/socket.h>
+	   #include <netinet/in.h>
+	], [
+	   int opt = IPV6_V6ONLY;
+	])],
+        AC_MSG_RESULT(yes)
+        AC_DEFINE(HAVE_SOCK_IPV6_V6ONLY, 1, [Define to 1 if your socket() implementation has the IPV6_V6ONLY socket option.]),
+	AC_MSG_RESULT(no)
+)
+
 AC_MSG_CHECKING(if we can increase the maximum select-able file descriptor)
 AC_RUN_IFELSE(
 [AC_LANG_PROGRAM([

--- a/include/asterisk/autoconfig.h.in
+++ b/include/asterisk/autoconfig.h.in
@@ -914,6 +914,9 @@
 /* Define to 1 if your socket() implementation can accept SOCK_NONBLOCK. */
 #undef HAVE_SOCK_NONBLOCK
 
+/* Define to 1 if your socket() implementation has the IPV6_V6ONLY socket option. */
+#undef HAVE_SOCK_IPV6_V6ONLY
+
 /* Define to 1 if your system has soxmix application. */
 #undef HAVE_SOXMIX
 


### PR DESCRIPTION
Dual-stack behavior (simultaneous listening for IPV4 and IPV6 connections on a single socket) is required by Asterisk's ICE implementation.  On systems with the IPV6_V6ONLY sockopt, set the option to 0 (dual-stack enabled) when binding to the IPV6 any address. This ensures correct behavior regardless of the system's default dual-stack configuration.
