### PR TITLE
res_geolocation:  Fix multiple issues with XML generation.

### DIFF
--- a/configs/samples/geolocation.conf.sample
+++ b/configs/samples/geolocation.conf.sample
@@ -69,7 +69,7 @@ civicAddress: [RFC4119] [RFC5139] [RFC5491]
               For chan_pjsip, this will be placed in the body of
               outgoing INVITE messages in addition to any SDP.
 
-GML:          [RFC4119] [RFC5491] [GeoShape]
+GML:          [RFC4119] [RFC4479] [RFC5491] [GeoShape]
               The location information will be placed in an XML document
               conforming to the PIDF-LO standard.
               For chan_pjsip, this will be placed in the body of
@@ -221,6 +221,28 @@ Per [RFC5491], "device" is preferred and therefore the default.
 
 Example:
 pidf_element = tuple
+
+-- pidf_element id(optional) ------------------------------------------
+Sets the value of the 'id' attribute for the top-level PIDF-LO element.
+You can reference channel variables in this parameter.
+
+pidf_element_id = <any valid attribute string>
+
+Example:
+pidf_element_id = ${CHANNEL(name)}
+
+-- device_id (optional) -----------------------------------------------
+Sets the contents of the <dm:deviceID> element in the top-level
+PIDF-LO element.  RFC4479 defined this only as a 'URN' with the only
+examples being a mac address in the format 'mac:XXXXXXXXXXXX'.
+You can reference channel variables in this parameter.
+
+device_id = <urn>
+
+Example:
+device_id = mac:40000b0c0d12
+device_id = mac:${MAC_ADDRESS}
+
 
 -- allow_routing_use (optional) ---------------------------------------
 Sets whether the "Geolocation-Routing" header is added to outgoing

--- a/include/asterisk/res_geolocation.h
+++ b/include/asterisk/res_geolocation.h
@@ -77,6 +77,8 @@ struct ast_geoloc_profile {
 		AST_STRING_FIELD(notes);
 		AST_STRING_FIELD(method);
 		AST_STRING_FIELD(location_source);
+		AST_STRING_FIELD(pidf_element_id);
+		AST_STRING_FIELD(device_id);
 	);
 	enum ast_geoloc_pidf_element pidf_element;
 	enum ast_geoloc_precedence precedence;
@@ -97,6 +99,8 @@ struct ast_geoloc_eprofile {
 		AST_STRING_FIELD(location_source);
 		AST_STRING_FIELD(method);
 		AST_STRING_FIELD(notes);
+		AST_STRING_FIELD(pidf_element_id);
+		AST_STRING_FIELD(device_id);
 	);
 	enum ast_geoloc_pidf_element pidf_element;
 	enum ast_geoloc_precedence precedence;
@@ -150,13 +154,15 @@ AST_OPTIONAL_API(struct ast_geoloc_profile *, ast_geoloc_get_profile,
 int ast_geoloc_civicaddr_is_code_valid(const char *code);
 
 enum ast_geoloc_validate_result {
-	AST_GEOLOC_VALIDATE_INVALID_VALUE = -1,
 	AST_GEOLOC_VALIDATE_SUCCESS = 0,
 	AST_GEOLOC_VALIDATE_MISSING_SHAPE,
 	AST_GEOLOC_VALIDATE_INVALID_SHAPE,
 	AST_GEOLOC_VALIDATE_INVALID_VARNAME,
 	AST_GEOLOC_VALIDATE_NOT_ENOUGH_VARNAMES,
 	AST_GEOLOC_VALIDATE_TOO_MANY_VARNAMES,
+	AST_GEOLOC_VALIDATE_INVALID_CRS,
+	AST_GEOLOC_VALIDATE_INVALID_CRS_FOR_SHAPE,
+	AST_GEOLOC_VALIDATE_INVALID_VALUE,
 };
 
 const char *ast_geoloc_validate_result_to_str(enum ast_geoloc_validate_result result);
@@ -170,7 +176,7 @@ const char *ast_geoloc_validate_result_to_str(enum ast_geoloc_validate_result re
  * \return result code.
  */
 enum ast_geoloc_validate_result ast_geoloc_civicaddr_validate_varlist(
-	const struct ast_variable *varlist, const char **result);
+	const struct ast_variable *varlist, char **result);
 
 /*!
  * \brief Validate that the variables in the list represent a valid GML shape
@@ -180,8 +186,8 @@ enum ast_geoloc_validate_result ast_geoloc_civicaddr_validate_varlist(
  *
  * \return result code.
  */
-enum ast_geoloc_validate_result ast_geoloc_gml_validate_varlist(const struct ast_variable *varlist,
-	const char **result);
+enum ast_geoloc_validate_result ast_geoloc_gml_validate_varlist(struct ast_variable *varlist,
+	char **result);
 
 
 /*!

--- a/res/res_geolocation/eprofile_to_pidf.xslt
+++ b/res/res_geolocation/eprofile_to_pidf.xslt
@@ -53,6 +53,9 @@
 
 	<xsl:template match="tuple">
 		<xsl:element name="tuple" namespace="urn:ietf:params:xml:ns:pidf">
+			<xsl:if test="@id">
+				<xsl:attribute name="id"><xsl:value-of select="@id"/></xsl:attribute>
+			</xsl:if>
 			<xsl:element name="status" namespace="urn:ietf:params:xml:ns:pidf">
 				<gp:geopriv>
 					<xsl:apply-templates select="./location-info"/>
@@ -65,6 +68,11 @@
 				<xsl:element name="timestamp" namespace="urn:ietf:params:xml:ns:pidf">
 					<xsl:value-of select="./timestamp"/>
 				</xsl:element>
+			</xsl:if>
+			<xsl:if test="./deviceID">
+				<dm:deviceID>
+					<xsl:value-of select="./deviceID"/>
+				</dm:deviceID>
 			</xsl:if>
 		</xsl:element>
 	</xsl:template>
@@ -171,11 +179,11 @@
 	</xsl:template>
 
 	<!-- usage-rules does have children so we add the "gp" namespace and copy in
-		the children, also adding the "gp" namespace -->
+		the children, also adding the "gbp" namespace -->
 	<xsl:template match="usage-rules">
 		<gp:usage-rules>
 			 <xsl:for-each select="*">
-				 <xsl:element name="gp:{local-name()}">
+				 <xsl:element name="gbp:{local-name()}">
 					 <xsl:value-of select="."/>
 				 </xsl:element>
 			 </xsl:for-each>
@@ -201,10 +209,10 @@
 		<xsl:element name="gs:{name()}">
 			<xsl:choose>
 				<xsl:when test="@uom = 'radians'">
-					<xsl:attribute name="uom">urn:ogc:def:uom:EPSG::9102</xsl:attribute>
+					<xsl:attribute name="uom">urn:ogc:def:uom:EPSG::9101</xsl:attribute>
 				</xsl:when>
 				<xsl:otherwise>
-					<xsl:attribute name="uom">urn:ogc:def:uom:EPSG::9101</xsl:attribute>
+					<xsl:attribute name="uom">urn:ogc:def:uom:EPSG::9102</xsl:attribute>
 				</xsl:otherwise>
 			</xsl:choose>
 			<xsl:value-of select="."/>

--- a/res/res_geolocation/geoloc_civicaddr.c
+++ b/res/res_geolocation/geoloc_civicaddr.c
@@ -73,13 +73,13 @@ int ast_geoloc_civicaddr_is_code_valid(const char *code)
 }
 
 enum ast_geoloc_validate_result ast_geoloc_civicaddr_validate_varlist(
-	const struct ast_variable *varlist,	const char **result)
+	const struct ast_variable *varlist,	char **result)
 {
 	const struct ast_variable *var = varlist;
 	for (; var; var = var->next) {
 		int valid = ast_geoloc_civicaddr_is_code_valid(var->name);
 		if (!valid) {
-			*result = var->name;
+			*result = ast_strdup(var->name);
 			return AST_GEOLOC_VALIDATE_INVALID_VARNAME;
 		}
 	}

--- a/res/res_geolocation/geoloc_common.c
+++ b/res/res_geolocation/geoloc_common.c
@@ -21,12 +21,14 @@
 
 static const char *result_names[] = {
 	"Success",
-	"Missing type",
+	"Missing shape type",
 	"Invalid shape type",
 	"Invalid variable name",
 	"Not enough variables",
 	"Too many variables",
-	"Invalid variable value"
+	"Invalid CRS",
+	"Invalid CRS for shape",
+	"Invalid variable value",
 };
 
 const char *ast_geoloc_validate_result_to_str(enum ast_geoloc_validate_result result)

--- a/res/res_geolocation/geoloc_doc.xml
+++ b/res/res_geolocation/geoloc_doc.xml
@@ -207,6 +207,24 @@
 					</see-also>
 				</configOption>
 
+				<configOption name="pidf_element_id" default="">
+					<since>
+						<version>20.18.0</version>
+						<version>22.8.0</version>
+						<version>23.2.0</version>
+					</since>
+					<synopsis>The id attribute value for the PIDF-LO element</synopsis>
+				</configOption>
+
+				<configOption name="device_id" default="">
+					<since>
+						<version>20.18.0</version>
+						<version>22.8.0</version>
+						<version>23.2.0</version>
+					</since>
+					<synopsis>The content of the deviceID element</synopsis>
+				</configOption>
+
 				<configOption name="location_reference" default="none">
 					<since>
 						<version>16.28.0</version>
@@ -341,6 +359,7 @@
 					<enum name="profile_precedence"/>
 					<enum name="format"/>
 					<enum name="pidf_element"/>
+					<enum name="pidf_element_id"/>
 					<enum name="location_source"/>
 					<enum name="notes"/>
 					<enum name="location_info"/>
@@ -349,6 +368,7 @@
 					<enum name="effective_location"/>
 					<enum name="usage_rules"/>
 					<enum name="confidence"/>
+					<enum name="device_id"/>
 				</enumlist>
 				<para>Additionally, the <literal>inheritable</literal> field may be
 				set to <literal>true</literal> or <literal>false</literal> to control

--- a/res/res_geolocation/geoloc_gml.c
+++ b/res/res_geolocation/geoloc_gml.c
@@ -20,174 +20,285 @@
 #include "asterisk/res_geolocation.h"
 #include "geoloc_private.h"
 
-
-#if 1 //not used yet.
-enum geoloc_shape_attrs {
-	GEOLOC_SHAPE_ATTR_POS = 0,
-	GEOLOC_SHAPE_ATTR_POS3D,
-	GEOLOC_SHAPE_ATTR_RADIUS,
-	GEOLOC_SHAPE_ATTR_SEMI_MAJOR_AXIS,
-	GEOLOC_SHAPE_ATTR_SEMI_MINOR_AXIS,
-	GEOLOC_SHAPE_ATTR_VERTICAL_AXIS,
-	GEOLOC_SHAPE_ATTR_HEIGHT,
-	GEOLOC_SHAPE_ATTR_ORIENTATION,
-	GEOLOC_SHAPE_ATTR_ORIENTATION_UOM,
-	GEOLOC_SHAPE_ATTR_INNER_RADIUS,
-	GEOLOC_SHAPE_ATTR_OUTER_RADIUS,
-	GEOLOC_SHAPE_ATTR_STARTING_ANGLE,
-	GEOLOC_SHAPE_ATTR_OPENING_ANGLE,
-	GEOLOC_SHAPE_ATTR_ANGLE_UOM,
-};
-
-struct geoloc_gml_attr_def {
-	enum geoloc_shape_attrs attr;
-	const char *name;
-	int (*validator)(const char *value);
-	int (*transformer)(struct ast_variable *value);
-};
-
-struct geoloc_gml_attr_def gml_attr_defs[] = {
-	{ GEOLOC_SHAPE_ATTR_POS, "pos", NULL, NULL},
-	{ GEOLOC_SHAPE_ATTR_POS3D,"pos3d", NULL, NULL},
-	{ GEOLOC_SHAPE_ATTR_RADIUS,"radius", NULL, NULL},
-	{ GEOLOC_SHAPE_ATTR_SEMI_MAJOR_AXIS,"semiMajorAxis", NULL, NULL},
-	{ GEOLOC_SHAPE_ATTR_SEMI_MINOR_AXIS,"semiMinorAxis", NULL, NULL},
-	{ GEOLOC_SHAPE_ATTR_VERTICAL_AXIS,"verticalAxis", NULL, NULL},
-	{ GEOLOC_SHAPE_ATTR_HEIGHT,"height", NULL, NULL},
-	{ GEOLOC_SHAPE_ATTR_ORIENTATION,"orientation", NULL, NULL},
-	{ GEOLOC_SHAPE_ATTR_ORIENTATION_UOM,"orientation_uom", NULL, NULL},
-	{ GEOLOC_SHAPE_ATTR_INNER_RADIUS,"innerRadius", NULL, NULL},
-	{ GEOLOC_SHAPE_ATTR_OUTER_RADIUS,"outerRadius", NULL, NULL},
-	{ GEOLOC_SHAPE_ATTR_STARTING_ANGLE,"startingAngle", NULL, NULL},
-	{ GEOLOC_SHAPE_ATTR_OPENING_ANGLE,"openingAngle", NULL, NULL},
-	{ GEOLOC_SHAPE_ATTR_ANGLE_UOM,"angle_uom", NULL, NULL},
-};
-#endif  //not used yet.
-
 struct geoloc_gml_attr {
-	const char *attribute;
+	const char *name;
 	int min_required;
 	int max_allowed;
-	int (*validator)(const char *value);
+	int (*validator)(const char *name, const char *value, const struct ast_variable *varlist,
+		char **result);
 };
 
+#define MAX_SHAPE_ATTRIBUTES 9
 struct geoloc_gml_shape_def {
 	const char *shape_type;
-	struct geoloc_gml_attr required_attributes[8];
+	const char *crs;
+	struct geoloc_gml_attr required_attributes[MAX_SHAPE_ATTRIBUTES];
 };
 
-static int pos_validator(const char *value)
+#define SET_RESULT(__result, ...) \
+({ \
+	if (__result) { \
+		__ast_asprintf(__FILE__, __LINE__, __PRETTY_FUNCTION__, result,  __VA_ARGS__); \
+	} \
+})
+
+static int crs_validator(const char *name, const char *value, const struct ast_variable *varlist,
+	char **result)
 {
-	float lat;
-	float lon;
-	return (sscanf(value, "%f %f", &lat, &lon) == 2);
+	if (!ast_strings_equal(value, "2d") && !ast_strings_equal(value, "3d")) {
+		SET_RESULT(result, "Invalid crs '%s'.  Must be either '2d' or '3d'", value);
+		return 0;
+	}
+	return 1;
 }
 
-static int pos3d_validator(const char *value)
+static int pos_validator(const char *name, const char *value, const struct ast_variable *varlist,
+	char **result)
 {
+	const char *crs = S_OR(ast_variable_find_in_list(varlist, "crs"), "2d");
 	float lat;
 	float lon;
 	float alt;
-	return (sscanf(value, "%f %f %f", &lat, &lon, &alt) == 3);
+	int count;
+
+	count = sscanf(value, "%f %f %f", &lat, &lon, &alt);
+	if (ast_strings_equal(crs, "3d") && count != 3) {
+		SET_RESULT(result, "Invalid 3d position '%s'.  Must be 3 floating point values.", value);
+		return 0;
+	}
+	if (ast_strings_equal(crs, "2d") && count != 2) {
+		SET_RESULT(result, "Invalid 2d position '%s'.  Must be 2 floating point values.", value);
+		return 0;
+	}
+	return 1;
 }
 
-static int float_validator(const char *value)
+static int float_validator(const char *name, const char *value, const struct ast_variable *varlist,
+	char **result)
 {
 	float val;
-	return (sscanf(value, "%f", &val) == 1);
+	if (sscanf(value, "%f", &val) != 1) {
+		SET_RESULT(result, "Invalid floating point value '%s' in '%s'.", value, name);
+		return 0;
+	}
+	return 1;
 }
 
-static int uom_validator(const char *value)
-{
-	return (ast_strings_equal(value, "degrees") || ast_strings_equal(value, "radians"));
-}
-
-
-static struct geoloc_gml_shape_def gml_shape_defs[8] = {
-	{ "Point", { {"pos", 1, 1, pos_validator}, {NULL, -1, -1} }},
-	{ "Polygon", { {"pos", 3, -1, pos_validator}, {NULL, -1, -1} }},
-	{ "Circle", { {"pos", 1, 1, pos_validator}, {"radius", 1, 1, float_validator},{NULL, -1, -1}}},
-	{ "Ellipse", { {"pos", 1, 1, pos_validator}, {"semiMajorAxis", 1, 1, float_validator},
-		{"semiMinorAxis", 1, 1, float_validator}, {"orientation", 1, 1, float_validator},
-		{"orientation_uom", 1, 1, uom_validator}, {NULL, -1, -1} }},
-	{ "ArcBand", { {"pos", 1, 1, pos_validator}, {"innerRadius", 1, 1, float_validator},
-		{"outerRadius", 1, 1, float_validator}, {"startAngle", 1, 1, float_validator},
-		{"startAngle_uom", 1, 1, uom_validator}, {"openingAngle", 1, 1, float_validator},
-		{"openingAngle_uom", 1, 1, uom_validator}, {NULL, -1, -1} }},
-	{ "Sphere", { {"pos3d", 1, 1, pos3d_validator}, {"radius", 1, 1, float_validator}, {NULL, -1, -1} }},
-	{ "Ellipse", { {"pos3d", 1, 1, pos3d_validator}, {"semiMajorAxis", 1, 1, float_validator},
-		{"semiMinorAxis", 1, 1, float_validator}, {"verticalAxis", 1, 1, float_validator},
-		{"orientation", 1, 1, float_validator}, {"orientation_uom", 1, 1, uom_validator}, {NULL, -1, -1} }},
-	{ "Prism", { {"pos3d", 3, -1, pos_validator}, {"height", 1, 1, float_validator}, {NULL, -1, -1} }},
+enum angle_parse_result {
+	ANGLE_PARSE_RESULT_SUCCESS = 0,
+	ANGLE_PARSE_ERROR_NO_ANGLE,
+	ANGLE_PARSE_ERROR_INVALID_ANGLE,
+	ANGLE_PARSE_ERROR_ANGLE_OUT_OF_RANGE,
+	ANGLE_PARSE_ERROR_INVALID_UOM,
 };
 
-enum ast_geoloc_validate_result ast_geoloc_gml_validate_varlist(const struct ast_variable *varlist,
-	const char **result)
+static enum angle_parse_result angle_parser(const char *name, const char *value,
+	char **angle, char **uom, char **result)
 {
-	int def_index = -1;
-	const struct ast_variable *var;
-	int i;
-	const char *shape_type = ast_variable_find_in_list(varlist, "shape");
+	char *tmp_angle = NULL;
+	char *tmp_uom = NULL;
+	float f_angle;
+	char *junk;
+	char *work = ast_strdupa(value);
 
-	if (!shape_type) {
-		return AST_GEOLOC_VALIDATE_MISSING_SHAPE;
+	tmp_angle = ast_strsep(&work, ' ', AST_STRSEP_ALL);
+	if (ast_strlen_zero(tmp_angle)) {
+		SET_RESULT(result, "Empty angle in '%s'", name);
+		return ANGLE_PARSE_ERROR_NO_ANGLE;
+	}
+	f_angle = strtof(tmp_angle, &junk);
+	if (!ast_strlen_zero(junk)) {
+		SET_RESULT(result, "Invalid angle '%s' in '%s'", value, name);
+		return ANGLE_PARSE_ERROR_INVALID_ANGLE;
 	}
 
-	for (i = 0; i < ARRAY_LEN(gml_shape_defs); i++) {
-		if (ast_strings_equal(gml_shape_defs[i].shape_type, shape_type)) {
-			def_index = i;
+	tmp_uom = ast_strsep(&work, ' ', AST_STRSEP_ALL);
+	if (ast_strlen_zero(tmp_uom)) {
+		tmp_uom = "degrees";
+	}
+
+	if (ast_begins_with(tmp_uom, "deg")) {
+		tmp_uom = "degrees";
+	} else if (ast_begins_with(tmp_uom, "rad")) {
+		tmp_uom = "radians";
+	} else {
+		SET_RESULT(result, "Invalid UOM '%s' in '%s'.  Must be 'degrees' or 'radians'.", value, name);
+		return ANGLE_PARSE_ERROR_INVALID_UOM;
+	}
+
+	if (ast_strings_equal(tmp_uom, "degrees") && f_angle > 360.0) {
+		SET_RESULT(result, "Angle '%s' must be <= 360.0 for UOM '%s' in '%s'", tmp_angle, tmp_uom, name);
+		return ANGLE_PARSE_ERROR_ANGLE_OUT_OF_RANGE;
+	}
+
+	if (ast_strings_equal(tmp_uom, "radians") && f_angle > 100.0) {
+		SET_RESULT(result, "Angle '%s' must be <= 100.0 for UOM '%s' in '%s'", tmp_angle, tmp_uom, name);
+		return ANGLE_PARSE_ERROR_ANGLE_OUT_OF_RANGE;
+	}
+
+	if (angle) {
+		*angle = ast_strdup(tmp_angle);
+	}
+	if (uom) {
+		*uom = ast_strdup(tmp_uom);
+	}
+	return ANGLE_PARSE_RESULT_SUCCESS;
+}
+
+static int angle_validator(const char *name, const char *value, const struct ast_variable *varlist,
+	char **result)
+{
+	enum angle_parse_result rc = angle_parser(name, value, NULL, NULL, result);
+
+	return rc == ANGLE_PARSE_RESULT_SUCCESS;
+}
+
+#define _SENTRY {NULL, -1, -1, NULL}
+
+#define CRS_OPT {"crs", 0, 1, crs_validator}
+#define CRS_REQ {"crs", 1, 1, crs_validator}
+
+static struct geoloc_gml_shape_def gml_shape_defs[] = {
+	{ "Point", "any", { CRS_OPT, {"pos", 1, 1, pos_validator}, _SENTRY }},
+	{ "Polygon", "any", { CRS_OPT, {"pos", 3, -1, pos_validator}, _SENTRY }},
+	{ "Circle", "2d", { CRS_OPT, {"pos", 1, 1, pos_validator}, {"radius", 1, 1, float_validator}, _SENTRY }},
+	{ "Ellipse", "2d", { CRS_OPT, {"pos", 1, 1, pos_validator}, {"semiMajorAxis", 1, 1, float_validator},
+		{"semiMinorAxis", 1, 1, float_validator}, {"orientation", 1, 1, angle_validator}, _SENTRY }},
+	{ "ArcBand", "2d", { CRS_OPT, {"pos", 1, 1, pos_validator}, {"innerRadius", 1, 1, float_validator},
+		{"outerRadius", 1, 1, float_validator}, {"startAngle", 1, 1, angle_validator},
+		{"openingAngle", 1, 1, angle_validator},
+		_SENTRY }},
+	{ "Sphere", "3d", { CRS_REQ, {"pos", 1, 1, pos_validator}, {"radius", 1, 1, float_validator}, _SENTRY }},
+	{ "Ellipsoid", "3d", { CRS_REQ, {"pos", 1, 1, pos_validator}, {"semiMajorAxis", 1, 1, float_validator},
+		{"semiMinorAxis", 1, 1, float_validator}, {"verticalAxis", 1, 1, float_validator},
+		{"orientation", 1, 1, angle_validator}, _SENTRY }},
+	{ "Prism", "3d", { CRS_REQ, {"pos", 3, -1, pos_validator}, {"height", 1, 1, float_validator}, _SENTRY }},
+};
+
+static int find_shape_index(const char *shape)
+{
+	int i = 0;
+	int shape_count = ARRAY_LEN(gml_shape_defs);
+
+	for (i = 0; i < shape_count; i++) {
+		if (ast_strings_equal(shape, gml_shape_defs[i].shape_type)) {
+			return i;
 		}
 	}
-	if (def_index < 0) {
-		return AST_GEOLOC_VALIDATE_INVALID_SHAPE;
+	return -1;
+}
+
+static int find_attribute_index(int shape_index, const char *name)
+{
+	int i = 0;
+
+	for (i = 0; i <  MAX_SHAPE_ATTRIBUTES; i++) {
+		if (gml_shape_defs[shape_index].required_attributes[i].name == NULL) {
+			return -1;
+		}
+		if (ast_strings_equal(name, gml_shape_defs[shape_index].required_attributes[i].name)) {
+			return i;
+		}
 	}
+	return -1;
+}
+
+static enum ast_geoloc_validate_result validate_def_varlist(int shape_index, const struct ast_variable *varlist,
+	char **result)
+{
+	const struct ast_variable *var;
+	int i;
 
 	for (var = varlist; var; var = var->next) {
 		int vname_index = -1;
 		if (ast_strings_equal("shape", var->name)) {
 			continue;
 		}
-		for (i = 0; i < ARRAY_LEN(gml_shape_defs[def_index].required_attributes); i++) {
-			if (gml_shape_defs[def_index].required_attributes[i].attribute == NULL) {
-				break;
-			}
-			if (ast_strings_equal(gml_shape_defs[def_index].required_attributes[i].attribute, var->name)) {
-				vname_index = i;
-				break;
-			}
-		}
+
+		vname_index = find_attribute_index(shape_index, var->name);
 		if (vname_index < 0) {
-			*result = var->name;
+			SET_RESULT(result, "Invalid variable name '%s'\n", var->name);
 			return AST_GEOLOC_VALIDATE_INVALID_VARNAME;
 		}
-		if (!gml_shape_defs[def_index].required_attributes[vname_index].validator(var->value)) {
-			*result = var->name;
+		if (!gml_shape_defs[shape_index].required_attributes[vname_index].validator(var->name, var->value,
+			varlist, result)) {
 			return AST_GEOLOC_VALIDATE_INVALID_VALUE;
 		}
 	}
 
-	for (i = 0; i < ARRAY_LEN(gml_shape_defs[def_index].required_attributes); i++) {
+	for (i = 0; i < ARRAY_LEN(gml_shape_defs[shape_index].required_attributes); i++) {
 		int count = 0;
-		if (gml_shape_defs[def_index].required_attributes[i].attribute == NULL) {
+		if (gml_shape_defs[shape_index].required_attributes[i].name == NULL) {
 			break;
 		}
 
 		for (var = varlist; var; var = var->next) {
-			if (ast_strings_equal(gml_shape_defs[def_index].required_attributes[i].attribute, var->name)) {
+			if (ast_strings_equal(gml_shape_defs[shape_index].required_attributes[i].name, var->name)) {
 				count++;
 			}
 		}
-		if (count < gml_shape_defs[def_index].required_attributes[i].min_required) {
-			*result = gml_shape_defs[def_index].required_attributes[i].attribute;
+		if (count < gml_shape_defs[shape_index].required_attributes[i].min_required) {
+			SET_RESULT(result, "Number of '%s' variables %d is < %d",
+				gml_shape_defs[shape_index].required_attributes[i].name,
+				count,
+				gml_shape_defs[shape_index].required_attributes[i].min_required);
 			return AST_GEOLOC_VALIDATE_NOT_ENOUGH_VARNAMES;
 		}
-		if (gml_shape_defs[def_index].required_attributes[i].max_allowed > 0 &&
-			count > gml_shape_defs[def_index].required_attributes[i].max_allowed) {
-			*result = gml_shape_defs[def_index].required_attributes[i].attribute;
+		if (gml_shape_defs[shape_index].required_attributes[i].max_allowed > 0 &&
+			count > gml_shape_defs[shape_index].required_attributes[i].max_allowed) {
+			SET_RESULT(result, "Number of '%s' variables %d is > %d",
+				gml_shape_defs[shape_index].required_attributes[i].name,
+				count,
+				gml_shape_defs[shape_index].required_attributes[i].max_allowed);
 			return AST_GEOLOC_VALIDATE_TOO_MANY_VARNAMES;
 		}
 	}
+
 	return AST_GEOLOC_VALIDATE_SUCCESS;
+}
+
+enum ast_geoloc_validate_result ast_geoloc_gml_validate_varlist(struct ast_variable *varlist,
+	char **result)
+{
+	const char *shape_type = ast_variable_find_in_list(varlist, "shape");
+	int shape_index = -1;
+	const char *crs = ast_variable_find_in_list(varlist, "crs");
+
+	if (!shape_type) {
+		SET_RESULT(result, "Missing 'shape'");
+		return AST_GEOLOC_VALIDATE_MISSING_SHAPE;
+	}
+
+	shape_index = find_shape_index(shape_type);
+	if (shape_index < 0) {
+		SET_RESULT(result, "Invalid shape '%s'", shape_type);
+		return AST_GEOLOC_VALIDATE_INVALID_SHAPE;
+	}
+
+	if (ast_strlen_zero(crs)) {
+		struct ast_variable *vcrs = NULL;
+		if (ast_strings_equal("any", gml_shape_defs[shape_index].crs)) {
+			crs = "2d";
+		} else {
+			crs = gml_shape_defs[shape_index].crs;
+		}
+
+		vcrs = ast_variable_new("crs", "2d", "");
+		if (vcrs) {
+			ast_variable_list_append(&varlist, vcrs);
+		}
+	}
+	if (!crs_validator("crs", crs, varlist, result)) {
+		return AST_GEOLOC_VALIDATE_INVALID_CRS;
+	}
+
+	if (!ast_strings_equal("any", gml_shape_defs[shape_index].crs)
+		&& !ast_strings_equal(crs, gml_shape_defs[shape_index].crs)) {
+		SET_RESULT(result, "Invalid crs '%s' for shape '%s'", crs, shape_type);
+		return AST_GEOLOC_VALIDATE_INVALID_CRS_FOR_SHAPE;
+	}
+
+	return validate_def_varlist(shape_index, varlist, result);
 }
 
 static char *handle_gml_show(struct ast_cli_entry *e, int cmd, struct ast_cli_args *a)
@@ -205,22 +316,22 @@ static char *handle_gml_show(struct ast_cli_entry *e, int cmd, struct ast_cli_ar
 		return NULL;
 	}
 
-	ast_cli(a->fd, "%-16s %-32s\n", "Shape", "Attributes name(min,max)");
-	ast_cli(a->fd, "================ ===============================\n");
+	ast_cli(a->fd, "%-16s %-3s %-32s\n", "Shape", "CRS", "Attributes name(min,max)");
+	ast_cli(a->fd, "================ === ===============================\n");
 
 	for (i = 0; i < ARRAY_LEN(gml_shape_defs); i++) {
 		int j;
-		ast_cli(a->fd, "%-16s", gml_shape_defs[i].shape_type);
+		ast_cli(a->fd, "%-16s %-3s", gml_shape_defs[i].shape_type, gml_shape_defs[i].crs);
 		for (j = 0; j < ARRAY_LEN(gml_shape_defs[i].required_attributes); j++) {
-			if (gml_shape_defs[i].required_attributes[j].attribute == NULL) {
+			if (gml_shape_defs[i].required_attributes[j].name == NULL) {
 				break;
 			}
 			if (gml_shape_defs[i].required_attributes[j].max_allowed >= 0) {
-				ast_cli(a->fd, " %s(%d,%d)", gml_shape_defs[i].required_attributes[j].attribute,
+				ast_cli(a->fd, " %s(%d,%d)", gml_shape_defs[i].required_attributes[j].name,
 					gml_shape_defs[i].required_attributes[j].min_required,
 					gml_shape_defs[i].required_attributes[j].max_allowed);
 			} else {
-				ast_cli(a->fd, " %s(%d,unl)", gml_shape_defs[i].required_attributes[j].attribute,
+				ast_cli(a->fd, " %s(%d,unl)", gml_shape_defs[i].required_attributes[j].name,
 					gml_shape_defs[i].required_attributes[j].min_required);
 			}
 		}
@@ -235,14 +346,16 @@ static struct ast_cli_entry geoloc_gml_cli[] = {
 	AST_CLI_DEFINE(handle_gml_show, "Show the GML Shape definitions"),
 };
 
-struct ast_xml_node *geoloc_gml_list_to_xml(const struct ast_variable *resolved_location,
+struct ast_xml_node *geoloc_gml_list_to_xml(struct ast_variable *resolved_location,
 	const char *ref_string)
 {
 	const char *shape;
-	char *crs;
+	const char *crs;
 	struct ast_variable *var;
 	struct ast_xml_node *gml_node;
 	struct ast_xml_node *child_node;
+	enum ast_geoloc_validate_result res;
+	RAII_VAR(char *, result, NULL, ast_free);
 	int rc = 0;
 
 	SCOPE_ENTER(3, "%s", ref_string);
@@ -252,13 +365,24 @@ struct ast_xml_node *geoloc_gml_list_to_xml(const struct ast_variable *resolved_
 			ref_string);
 	}
 
+	res = ast_geoloc_gml_validate_varlist(resolved_location, &result);
+	if (res != AST_GEOLOC_VALIDATE_SUCCESS) {
+		SCOPE_EXIT_LOG_RTN_VALUE(NULL, LOG_ERROR, "%s: %s\n",
+			ref_string, result);
+	}
+
 	shape = ast_variable_find_in_list(resolved_location, "shape");
 	if (ast_strlen_zero(shape)) {
 		SCOPE_EXIT_LOG_RTN_VALUE(NULL, LOG_ERROR, "%s: There's no 'shape' parameter\n",
 			ref_string);
 	}
-	crs = (char *)ast_variable_find_in_list(resolved_location, "crs");
+
+	crs = ast_variable_find_in_list(resolved_location, "crs");
 	if (ast_strlen_zero(crs)) {
+		struct ast_variable *vcrs = ast_variable_new("crs", "2d", "");
+		if (vcrs) {
+			ast_variable_list_append(&resolved_location, vcrs);
+		}
 		crs = "2d";
 	}
 
@@ -273,60 +397,9 @@ struct ast_xml_node *geoloc_gml_list_to_xml(const struct ast_variable *resolved_
 	}
 
 	for (var = (struct ast_variable *)resolved_location; var; var = var->next) {
-		RAII_VAR(char *, value, NULL, ast_free);
-		char *uom = NULL;
 
 		if (ast_strings_equal(var->name, "shape") || ast_strings_equal(var->name, "crs")) {
 			continue;
-		}
-		value = ast_strdup(var->value);
-
-		if (ast_strings_equal(var->name, "orientation") || ast_strings_equal(var->name, "startAngle")
-			|| ast_strings_equal(var->name, "openingAngle")) {
-			char *a = NULL;
-			char *junk = NULL;
-			float angle;
-			uom = value;
-
-			/* 'a' should now be the angle and 'uom' should be the uom */
-			a = strsep(&uom, " ");
-			angle = strtof(a, &junk);
-			/*
-			 * strtof sets junk to the first non-valid character so if it's
-			 * not empty after the conversion, there were unrecognized
-			 * characters in the angle.  It'll point to the NULL terminator
-			 * if angle was completely converted.
-			 */
-			if (!ast_strlen_zero(junk)) {
-				ast_xml_free_node(gml_node);
-				SCOPE_EXIT_LOG_RTN_VALUE(NULL, LOG_ERROR, "%s: The angle portion of parameter '%s' ('%s') is malformed\n",
-					ref_string, var->name, var->value);
-			}
-
-			if (ast_strlen_zero(uom)) {
-				uom = "degrees";
-			}
-
-			if (ast_begins_with(uom, "deg")) {
-				if (angle > 360.0) {
-					ast_xml_free_node(gml_node);
-					SCOPE_EXIT_LOG_RTN_VALUE(NULL, LOG_ERROR, "%s: Parameter '%s': '%s' is malformed. "
-						"Degrees can't be > 360.0\n",
-						ref_string, var->name, var->value);
-				}
-			} else if (ast_begins_with(uom, "rad")) {
-				if(angle > 100.0) {
-					ast_xml_free_node(gml_node);
-					SCOPE_EXIT_LOG_RTN_VALUE(NULL, LOG_ERROR, "%s: Parameter '%s': '%s' is malformed. "
-						"Radians can't be  > 100.0\n",
-						ref_string, var->name, var->value);
-				}
-			} else {
-				ast_xml_free_node(gml_node);
-				SCOPE_EXIT_LOG_RTN_VALUE(NULL, LOG_ERROR, "%s: Parameter '%s': '%s' is malformed. "
-					"The unit of measure must be 'deg[rees]' or 'rad[ians]'\n",
-					ref_string, var->name, var->value);
-			}
 		}
 
 		child_node = ast_xml_new_child(gml_node, var->name);
@@ -334,14 +407,26 @@ struct ast_xml_node *geoloc_gml_list_to_xml(const struct ast_variable *resolved_
 			ast_xml_free_node(gml_node);
 			SCOPE_EXIT_LOG_RTN_VALUE(NULL, LOG_ERROR, "%s: Unable to create '%s' XML node\n", var->name, ref_string);
 		}
-		if (!ast_strlen_zero(uom)) {
+
+		if (ast_strings_equal(var->name, "orientation") || ast_strings_equal(var->name, "startAngle")
+			|| ast_strings_equal(var->name, "openingAngle")) {
+			RAII_VAR(char *, angle, NULL, ast_free);
+			RAII_VAR(char *, uom, NULL, ast_free);
+
+			enum angle_parse_result rc = angle_parser(var->name, var->value, &angle, &uom, &result);
+			if (rc != ANGLE_PARSE_RESULT_SUCCESS) {
+				ast_xml_free_node(gml_node);
+				SCOPE_EXIT_LOG_RTN_VALUE(NULL, LOG_ERROR, "%s: %s\n", ref_string, result);
+			}
 			rc = ast_xml_set_attribute(child_node, "uom", uom);
 			if (rc != 0) {
 				ast_xml_free_node(gml_node);
 				SCOPE_EXIT_LOG_RTN_VALUE(NULL, LOG_ERROR, "%s: Unable to create 'uom' XML attribute\n", ref_string);
 			}
+			ast_xml_set_text(child_node, angle);
+		} else {
+			ast_xml_set_text(child_node, var->value);
 		}
-		ast_xml_set_text(child_node, value);
 	}
 
 	SCOPE_EXIT_RTN_VALUE(gml_node, "%s: Done\n", ref_string);

--- a/res/res_geolocation/geoloc_private.h
+++ b/res/res_geolocation/geoloc_private.h
@@ -135,7 +135,7 @@ int geoloc_civicaddr_load(void);
 int geoloc_civicaddr_unload(void);
 int geoloc_civicaddr_reload(void);
 
-struct ast_xml_node *geoloc_gml_list_to_xml(const struct ast_variable *resolved_location,
+struct ast_xml_node *geoloc_gml_list_to_xml(struct ast_variable *resolved_location,
 	const char *ref_string);
 int geoloc_gml_unload(void);
 int geoloc_gml_load(void);
@@ -158,5 +158,7 @@ struct ast_sorcery *geoloc_get_sorcery(void);
 struct ast_variable *geoloc_eprofile_resolve_varlist(struct ast_variable *source,
 	struct ast_variable *variables, struct ast_channel *chan);
 
+char *geoloc_eprofile_resolve_string(const char *source,
+	struct ast_variable *variables, struct ast_channel *chan);
 
 #endif /* GEOLOC_PRIVATE_H_ */

--- a/res/res_geolocation/pidf_lo_test.xml
+++ b/res/res_geolocation/pidf_lo_test.xml
@@ -1,33 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <presence entity="pres:alice@asterisk.org"
-	xmlns="urn:ietf:params:xml:ns:pidf"
-	xmlns:ca="urn:ietf:params:xml:ns:pidf:geopriv10:civicAddr"
-	xmlns:dm="urn:ietf:params:xml:ns:pidf:data-model"
-	xmlns:gbp="urn:ietf:params:xml:ns:pidf:geopriv10:basicPolicy"
-	xmlns:gml="http://www.opengis.net/gml"
-	xmlns:gp="urn:ietf:params:xml:ns:pidf:geopriv10"
-	xmlns:con="urn:ietf:params:xml:ns:geopriv:conf"
-	xmlns:gs="http://www.opengis.net/pidflo/1.0">
-	<tuple id="point-2d">
-		<status>
-			<gp:geopriv>
-				<gp:location-info>
-					<gml:Point srsName="urn:ogc:def:crs:EPSG::4326">
-						<gml:pos>-34.410649 150.87651</gml:pos>
-					</gml:Point>
-				<con:confidence pdf="normal">66</con:confidence>
-				</gp:location-info>
-				<gp:usage-rules>
-					<gbp:retransmission-allowed>no</gbp:retransmission-allowed>
-					<gbp:retention-expiry>2010-11-14T20:00:00Z</gbp:retention-expiry>
-				</gp:usage-rules>
-				<gp:method>Manual</gp:method>
-				<gp:note-well>
-					this is a test
-					of the emergency broadcast system
-				</gp:note-well>
-			</gp:geopriv>
-		</status>
-		<timestamp>2007-06-22T20:57:29Z</timestamp>
-	</tuple>
+    xmlns="urn:ietf:params:xml:ns:pidf"
+    xmlns:ca="urn:ietf:params:xml:ns:pidf:geopriv10:civicAddr"
+    xmlns:dm="urn:ietf:params:xml:ns:pidf:data-model"
+    xmlns:gbp="urn:ietf:params:xml:ns:pidf:geopriv10:basicPolicy"
+    xmlns:gml="http://www.opengis.net/gml"
+    xmlns:gp="urn:ietf:params:xml:ns:pidf:geopriv10"
+    xmlns:con="urn:ietf:params:xml:ns:geopriv:conf"
+    xmlns:gs="http://www.opengis.net/pidflo/1.0">
+    <tuple id="point-2d">
+        <status>
+            <gp:geopriv>
+                <gp:location-info>
+                    <gml:Point srsName="urn:ogc:def:crs:EPSG::4326">
+                        <gml:pos>-34.410649 150.87651</gml:pos>
+                    </gml:Point>
+                <con:confidence pdf="normal">66</con:confidence>
+                </gp:location-info>
+                <gp:usage-rules>
+                    <gbp:retransmission-allowed>no</gbp:retransmission-allowed>
+                    <gbp:retention-expiry>2010-11-14T20:00:00Z</gbp:retention-expiry>
+                </gp:usage-rules>
+                <gp:method>Manual</gp:method>
+                <gp:note-well>
+                    this is a test
+                    of the emergency broadcast system
+                </gp:note-well>
+            </gp:geopriv>
+        </status>
+        <timestamp>2007-06-22T20:57:29Z</timestamp>
+        <dm:deviceID>mac:112233445566</dm:deviceID>
+    </tuple>
 </presence>

--- a/res/res_geolocation/pidf_to_eprofile.xslt
+++ b/res/res_geolocation/pidf_to_eprofile.xslt
@@ -74,6 +74,11 @@
 			<xsl:attribute name="id"><xsl:value-of select="@id"/></xsl:attribute>
 			<xsl:call-template name="geopriv"/>
 			<xsl:apply-templates select="./def:timestamp"/>
+			<xsl:if test="./dm:deviceID">
+				<deviceID>
+					<xsl:value-of select="./dm:deviceID"/>
+				</deviceID>
+			</xsl:if>
 		</xsl:element>
 	</xsl:template>
 
@@ -82,7 +87,6 @@
 			<xsl:attribute name="id"><xsl:value-of select="@id"/></xsl:attribute>
 			<xsl:call-template name="geopriv"/>
 			<xsl:apply-templates select="./dm:timestamp"/>
-			<!-- deviceID should only apply to devices -->
 			<xsl:if test="./dm:deviceID">
 				<deviceID>
 					<xsl:value-of select="./dm:deviceID"/>
@@ -165,7 +169,7 @@
 	<xsl:template name="angle">
 		<xsl:element name="{local-name(.)}">
 			<xsl:choose>
-				<xsl:when test="@uom = 'urn:ogc:def:uom:EPSG::9102'">
+				<xsl:when test="@uom = 'urn:ogc:def:uom:EPSG::9101'">
 					<xsl:attribute name="uom">radians</xsl:attribute></xsl:when>
 				<xsl:otherwise>
 					<xsl:attribute name="uom">degrees</xsl:attribute></xsl:otherwise>


### PR DESCRIPTION
* 3d positions were being rendered without an enclosing `<gml:pos>`
  element resulting in invalid XML.
* There was no way to set the `id` attribute on the enclosing `tuple`, `device`
  and `person` elements.
* There was no way to set the value of the `deviceID` element.
* Parsing of degree and radian UOMs was broken resulting in them appearing
  outside an XML element.
* The UOM schemas for degrees and radians were reversed.
* The Ellipsoid shape was missing and the Ellipse shape was defined multiple
  times.
* The `crs` location_info parameter, although documented, didn't work.
* The `pos3d` location_info parameter appears in some documentation but
  wasn't being parsed correctly.
* The retransmission-allowed and retention-expiry sub-elements of usage-rules
  were using the `gp` namespace instead of the `gbp` namespace.

In addition to fixing the above, several other code refactorings were
performed and the unit test enhanced to include a round trip
XML -> eprofile -> XML validation.

Resolves: #1667

UserNote: Geolocation: Two new optional profile parameters have been added.
* `pidf_element_id` which sets the value of the `id` attribute on the top-level
  PIDF-LO `device`, `person` or `tuple` elements.
* `device_id` which sets the content of the `<deviceID>` element.
Both parameters can include channel variables.

UpgradeNote: Geolocation: In order to correct bugs in both code and
documentation, the following changes to the parameters for GML geolocation
locations are now in effect:
* The documented but unimplemented `crs` (coordinate reference system) element
  has been added to the location_info parameter that indicates whether the `2d`
  or `3d` reference system is to be used. If the crs isn't valid for the shape
  specified, an error will be generated. The default depends on the shape
  specified.
* The Circle, Ellipse and ArcBand shapes MUST use a `2d` crs.  If crs isn't
  specified, it will default to `2d` for these shapes.
  The Sphere, Ellipsoid and Prism shapes MUST use a `3d` crs. If crs isn't
  specified, it will default to `3d` for these shapes.
  The Point and Polygon shapes may use either crs.  The default crs is `2d`
  however so if `3d` positions are used, the crs must be explicitly set to `3d`.
* The `geoloc show gml_shape_defs` CLI command has been updated to show which
  coordinate reference systems are valid for each shape.
* The `pos3d` element has been removed in favor of allowing the `pos` element
  to include altitude if the crs is `3d`.  The number of values in the `pos`
  element MUST be 2 if the crs is `2d` and 3 if the crs is `3d`.  An error
  will be generated for any other combination.
* The angle unit-of-measure for shapes that use angles should now be included
  in the respective parameter.  The default is `degrees`. There were some
  inconsistent references to `orientation_uom` in some documentation but that
  parameter never worked and is now removed.  See examples below.
Examples...
```
  location_info = shape="Sphere", pos="39.0 -105.0 1620", radius="20"
  location_info = shape="Point", crs="3d", pos="39.0 -105.0 1620"
  location_info = shape="Point", pos="39.0 -105.0"
  location_info = shape=Ellipsoid, pos="39.0 -105.0 1620", semiMajorAxis="20"
                semiMinorAxis="10", verticalAxis="0", orientation="25 degrees"
  pidf_element_id = ${CHANNEL(name)}-${EXTEN}
  device_id = mac:001122334455
  Set(GEOLOC_PROFILE(pidf_element_id)=${CHANNEL(name)}/${EXTEN})
```
