### PR TITLE
main/file.c: Fix inconsistent voicemail video frame playback

### DIFF
--- a/main/file.c
+++ b/main/file.c
@@ -1028,6 +1028,7 @@ static int ast_fsread_audio(const void *data)
 	return 0;
 }
 
+#define FIXED_VIDEO_FRAME_MS 40 
 static int ast_fsread_video(const void *data);
 
 static enum fsread_res ast_readvideo_callback(struct ast_filestream *s)
@@ -1050,9 +1051,18 @@ static enum fsread_res ast_readvideo_callback(struct ast_filestream *s)
 			ast_frfree(fr);
 		}
 	}
-
+         
+        whennext = FIXED_VIDEO_FRAME_MS;
 	if (whennext != s->lasttimeout) {
-		ast_channel_vstreamid_set(s->owner, ast_sched_add(ast_channel_sched(s->owner), whennext / (ast_format_get_sample_rate(s->fmt->format) / 1000), ast_fsread_video, s));
+                ast_channel_vstreamid_set(
+                       s->owner,
+                       ast_sched_add(
+                       ast_channel_sched(s->owner),
+                       whennext,            // already in ms
+                      ast_fsread_video,
+                       s
+                       )
+                 );
 		s->lasttimeout = whennext;
 		return FSREAD_SUCCESS_NOSCHED;
 	}


### PR DESCRIPTION
The current ast_readvideo_callback implementation derives frame timing from the file format/reader. In many cases this timing is irregular or inaccurate, resulting in uneven playback, stuttering, or desynchronization during video voicemail playback.

Additionally, video voicemail recordings may play back extremely slowly (approximately 1/10th normal speed), leading to delayed playback and a significantly degraded user experience.

This patch enforces a fixed, consistent frame rate for voicemail video playback, ensuring smooth, natural, and correctly synchronized video output.

UserNote: Video files played via file-based streaming functions now use a fixed and stable FPS timing, providing smooth and reliable video playback when reviewing voicemail messages.

UpgradeNote: Systems experiencing slow or irregular voicemail video playback should upgrade to this version. With this patch applied, voicemail video playback will operate at normal, stable FPS. Without it, video voicemail playback may remain slow, delayed, or inconsistent.