### PR TITLE
chan_websocket: Use the channel's ability to poll fds for the websocket read.

### DIFF
--- a/include/asterisk/http_websocket.h
+++ b/include/asterisk/http_websocket.h
@@ -77,6 +77,26 @@ enum ast_websocket_opcode {
 	AST_WEBSOCKET_OPCODE_CONTINUATION = 0x0, /*!< Continuation of a previous frame */
 };
 
+/*! \brief Websocket Status Codes from RFC-6455 */
+enum ast_websocket_status_code {
+	AST_WEBSOCKET_STATUS_NORMAL = 1000,
+	AST_WEBSOCKET_STATUS_GOING_AWAY = 1001,
+	AST_WEBSOCKET_STATUS_PROTOCOL_ERROR = 1002,
+	AST_WEBSOCKET_STATUS_UNSUPPORTED_DATA = 1003,
+	AST_WEBSOCKET_STATUS_RESERVED_1004 = 1004,
+	AST_WEBSOCKET_STATUS_RESERVED_1005 = 1005,
+	AST_WEBSOCKET_STATUS_RESERVED_1006 = 1006,
+	AST_WEBSOCKET_STATUS_INVALID_FRAME = 1007,
+	AST_WEBSOCKET_STATUS_POLICY_VIOLATION = 1008,
+	AST_WEBSOCKET_STATUS_TOO_BIG = 1009,
+	AST_WEBSOCKET_STATUS_MANDATORY_EXT = 1010,
+	AST_WEBSOCKET_STATUS_INTERNAL_ERROR = 1011,
+	AST_WEBSOCKET_STATUS_RESERVED_1012 = 1012,
+	AST_WEBSOCKET_STATUS_RESERVED_1013 = 1013,
+	AST_WEBSOCKET_STATUS_BAD_GATEWAY = 1014,
+	AST_WEBSOCKET_STATUS_RESERVED_1015 = 1015,
+};
+
 #ifdef LOW_MEMORY
 /*! \brief Size of the pre-determined buffer for WebSocket frames */
 #define AST_WEBSOCKET_MAX_RX_PAYLOAD_SIZE 8192
@@ -550,5 +570,14 @@ AST_OPTIONAL_API(int, ast_websocket_set_timeout, (struct ast_websocket *session,
  * \return A string representation of the result code
  */
 AST_OPTIONAL_API(const char *, ast_websocket_result_to_str, (enum ast_websocket_result result), {return "";});
+
+/*!
+ * \brief Convert a websocket status code to a string.
+ *
+ * \param code The code to convert
+ *
+ * \return A string representation of the code
+ */
+AST_OPTIONAL_API(const char *, ast_websocket_status_to_str, (enum ast_websocket_status_code code), {return "";});
 
 #endif

--- a/res/res_http_websocket.c
+++ b/res/res_http_websocket.c
@@ -1632,6 +1632,43 @@ const char *AST_OPTIONAL_API_NAME(ast_websocket_result_to_str)
 	return websocket_result_string_map[result];
 }
 
+struct status_map {
+	enum ast_websocket_status_code code;
+	const char *desc;
+};
+
+static const struct status_map websocket_status_map[] = {
+	{ AST_WEBSOCKET_STATUS_NORMAL, "Normal" },
+	{ AST_WEBSOCKET_STATUS_GOING_AWAY, "Going away" },
+	{ AST_WEBSOCKET_STATUS_PROTOCOL_ERROR, "Protocol error" },
+	{ AST_WEBSOCKET_STATUS_UNSUPPORTED_DATA, "Unsupported data" },
+	{ AST_WEBSOCKET_STATUS_RESERVED_1004, "reserved 1004" },
+	{ AST_WEBSOCKET_STATUS_RESERVED_1005, "reserved 1005" },
+	{ AST_WEBSOCKET_STATUS_RESERVED_1006, "reserved 1006" },
+	{ AST_WEBSOCKET_STATUS_INVALID_FRAME, "Invalid frame" },
+	{ AST_WEBSOCKET_STATUS_POLICY_VIOLATION, "Policy violation" },
+	{ AST_WEBSOCKET_STATUS_TOO_BIG, "Data too big" },
+	{ AST_WEBSOCKET_STATUS_MANDATORY_EXT, "Mandatory extension" },
+	{ AST_WEBSOCKET_STATUS_INTERNAL_ERROR, "Internal error" },
+	{ AST_WEBSOCKET_STATUS_RESERVED_1012, "reserved 1012" },
+	{ AST_WEBSOCKET_STATUS_RESERVED_1013, "reserved 1013" },
+	{ AST_WEBSOCKET_STATUS_BAD_GATEWAY, "Bad gateway" },
+	{ AST_WEBSOCKET_STATUS_RESERVED_1015, "reserved 1015" },
+};
+
+const char *AST_OPTIONAL_API_NAME(ast_websocket_status_to_str)
+	(enum ast_websocket_status_code code)
+{
+	int i;
+
+	for (i = 0; i < ARRAY_LEN(websocket_status_map); i++) {
+		if (websocket_status_map[i].code == code)
+			return websocket_status_map[i].desc;
+	}
+
+	return "Unknown";
+}
+
 static int load_module(void)
 {
 	websocketuri.data = websocket_server_internal_create();


### PR DESCRIPTION
We now add the websocket's file descriptor to the channel's fd array and let
it poll for data availability instead if having a dedicated thread that
does the polling. This eliminates the thread and allows removal of most
explicit locking since the core channel code will lock the channel to prevent
simultaneous calls to webchan_read, webchan_hangup, etc.

While we were here, the hangup code was refactored to use ast_hangup_with_cause
instead of directly queueing an AST_CONTROL_HANGUP frame.  This allows us
to set hangup causes and generate snapshots.

For a bit of extra debugging, a table of websocket close codes was added
to http_websocket.h with an accompanying "to string" function added to
res_http_websocket.c

Resolves: #1683
