### PR TITLE
main/file.c: Smooth and stabilize video playback by clamping frame de…

### DIFF
--- a/main/file.c
+++ b/main/file.c
@@ -1080,7 +1080,7 @@ static enum fsread_res ast_readvideo_callback(struct ast_filestream *s)
                          s->owner,
                          ast_sched_add(ast_channel_sched(s->owner), delay_ms, ast_fsread_video, s)
                  );
-                s->lasttimeout = frame_ms;
+                s->lasttimeout = whennext;
                 return FSREAD_SUCCESS_NOSCHED;
 	}
 


### PR DESCRIPTION
 …lay timing

Video voicemail playback could appear inconsistent, with frames sometimes playing too fast and sometimes too slow due to irregular RTP timestamps. This patch smooths playback by clamping the calculated frame delay to a safe operational range, preventing extremely small delays (causing overly fast playback) and very large delays (causing visible pauses).

A minimum delay is enforced to avoid burst-style frame playback, while a reduced maximum delay cap helps maintain visually smooth and consistent video output.

This results in more natural, predictable, and stable video playback behavior during voicemail review.

UserNote: Video voicemail playback is now smoother and more consistent, without sudden fast or slow playback behavior.

UpgradeNote: Systems experiencing uneven, fast, slow, or jittery voicemail video playback are recommended to upgrade. With this patch applied, playback timing is stabilized using controlled frame delay clamping.