### PR TITLE
app_queue: Only compare calls at 1st position across queues when forcing longest waiting caller.

### DIFF
--- a/apps/app_queue.c
+++ b/apps/app_queue.c
@@ -4758,10 +4758,12 @@ static int is_longest_waiting_caller(struct queue_ent *caller, struct member *me
 					 * is already ringing at another agent. Ignore such callers; otherwise, all agents
 					 * will be unused until the first caller is picked up.
 					 */
-					if (ch->start < caller->start && !ch->pending) {
-						ast_debug(1, "Queue %s has a call at position %i that's been waiting longer (%li vs %li)\n",
-								  q->name, ch->pos, ch->start, caller->start);
-						is_longest_waiting = 0;
+					if (!ch->pending) {
+						if (ch->start < caller->start) {
+							ast_debug(1, "Queue %s has a call at position %i that's been waiting longer (%li vs %li)\n",
+									  q->name, ch->pos, ch->start, caller->start);
+							is_longest_waiting = 0;
+						}
 						break;
 					}
 					ch = ch->next;


### PR DESCRIPTION
This prevents a situation where a call joining at 1st position to a queue with calls leads to a state where no callers are considered the longest waiting, causing queues to stop offering calls.

Resolves: #1691