### PR TITLE
media_cache: harden remote media cache refresh under concurrency

### DIFF
--- a/main/file.c
+++ b/main/file.c
@@ -1382,9 +1382,9 @@ int ast_streamfile(struct ast_channel *chan, const char *filename,
 	cel_event = ast_json_pack("{ s: s, s: {s: s, s: s, s: s}}",
 		"event", "FILE_STREAM_BEGIN",
 		"extra",
-			"sound", tmp_filename,
+			"sound", AST_JSON_UTF8_VALIDATE(tmp_filename),
 			"format", ast_format_get_name(ast_channel_writeformat(chan)),
-			"language", preflang ? preflang : "default"
+			"language", AST_JSON_UTF8_VALIDATE(preflang ? preflang : "default")
 	);
 	if (cel_event) {
 		ast_cel_publish_event(chan, AST_CEL_STREAM_BEGIN, cel_event);

--- a/res/res_stasis_playback.c
+++ b/res/res_stasis_playback.c
@@ -276,6 +276,9 @@ static void playback_final_update(struct stasis_app_playback *playback,
 		if (playback->state == STASIS_PLAYBACK_STATE_STOPPED) {
 			ast_log(LOG_NOTICE, "%s: Playback stopped for %s\n",
 				uniqueid, playback->media);
+		} else if (hangup) {
+			ast_log(LOG_DEBUG, "%s: Playback interrupted by hangup for %s\n",
+				uniqueid, playback->media);
 		} else {
 			ast_log(LOG_WARNING, "%s: Playback failed for %s\n",
 				uniqueid, playback->media);


### PR DESCRIPTION
When playing remote media via ARI, concurrent refreshes could delete or
replace cached files while other channels were opening them, leading to
ENOENT in ast_streamfile() and spurious playback failures. Rework the
cache update flow to keep readable files on disk until a new file is
confirmed readable and safely linked, and avoid deleting shared paths.

Also sanitize FILE_STREAM_BEGIN JSON payloads to avoid invalid UTF-8
errors under load, and downgrade playback failure log level when the
channel is already hung up.

Fixes: #1689