### PR TITLE
main/file.c: Video Voicemail Playback Fix

### DIFF
--- a/main/file.c
+++ b/main/file.c
@@ -1055,7 +1055,7 @@ static enum fsread_res ast_readvideo_callback(struct ast_filestream *s)
                 int delta = whennext - s->lasttimeout;
                 int delay_ms;
 
-                /* Video RTP clock rate 90000Hz */
+                /* Video RTP clock rate*/
                 int rtp_clock = 90000;
 
                 /* Compute raw delta in milliseconds */


### PR DESCRIPTION
main/file.c: Video Voicemail Playback Fix

This patch fixes uneven video playback in voicemails, where frames could appear too fast or too slow due to irregular RTP timestamps. It ensures smoother playback by clamping frame delays within a controlled range:

Minimum delay avoids rapid, burst-style frame playback.

Maximum delay prevents long pauses, keeping video timing smooth.

The result is more stable and consistent video playback during voicemail review.

User Note: Video voicemails now play naturally, without sudden speed changes.

Upgrade Note: Systems experiencing jittery or uneven voicemail video playback should apply this patch to stabilize playback timing.