### PR TITLE
app_queue: Fix rN raise_penalty ignoring min_penalty in calc_metric

### DIFF
--- a/apps/app_queue.c
+++ b/apps/app_queue.c
@@ -6204,7 +6204,7 @@ static int calc_metric(struct call_queue *q, struct member *mem, int pos, struct
 	int penalty = mem->penalty;
 
 	if (usepenalty) {
-		if (qe->raise_penalty != INT_MAX && penalty < qe->raise_penalty) {
+		if (qe->raise_penalty != INT_MAX && penalty < qe->raise_penalty && !(qe->raise_respect_min && qe->min_penalty != INT_MAX && penalty < qe->min_penalty)) {
 			/* Low penalty is raised up to the current minimum */
 			penalty = qe->raise_penalty;
 		}


### PR DESCRIPTION
QUEUE_RAISE_PENALTY=rN was not respected during member selection. calc_metric() raised penalties below QUEUE_MIN_PENALTY, allowing excluded members to be selected.

This change makes calc_metric() honor raise_respect_min, keeping behavior consistent with queue empty checks and expected rN semantics

UserNote: Fixes an issue where QUEUE_RAISE_PENALTY=rN could raise a member’s penalty below QUEUE_MIN_PENALTY during member selection. This could allow members intended to be excluded to be selected. The queue now consistently respects the minimum penalty when raising penalties, aligning member selection behavior with queue empty checks and documented rN semantics.