### PR TITLE
chan_iax2: Fix crash due to negative length frame lengths.

### DIFF
--- a/channels/iax2/parser.c
+++ b/channels/iax2/parser.c
@@ -1210,6 +1210,7 @@ void iax_frame_wrap(struct iax_frame *fr, struct ast_frame *f)
 	if (fr->af.datalen) {
 		size_t copy_len = fr->af.datalen;
 		if (copy_len > fr->afdatalen) {
+			ast_assert(fr->af.datalen >= 0); /* Length should never be negative */
 			ast_log(LOG_ERROR, "Losing frame data because destination buffer size '%d' bytes not big enough for '%d' bytes in the frame\n",
 				(int) fr->afdatalen, (int) fr->af.datalen);
 			copy_len = fr->afdatalen;
@@ -1229,6 +1230,8 @@ void iax_frame_wrap(struct iax_frame *fr, struct ast_frame *f)
 struct iax_frame *iax_frame_new(int direction, int datalen, unsigned int cacheable)
 {
 	struct iax_frame *fr;
+
+	ast_assert(datalen >= 0); /* Length should never be negative */
 
 #if !defined(NO_FRAME_CACHE)
 	if (cacheable) {


### PR DESCRIPTION
chan_iax2 has several code paths where a frame's data length is calculated by subtraction. On some paths, there is a check for negative length. One of these paths is missing this check, and on this path, it is possible for the result to be negative, leading to a crash as a result of memory operations using the bogus length.

Add a check to capture this off-nominal case. This will log the appropriate warnings as in other cases and prevent a crash. Also update the log messages to be clearer.

Resolves: #1707