### PR TITLE
res_pjsip_rfc7329: Add RFC7329 Session-ID support

### DIFF
--- a/channels/chan_pjsip.c
+++ b/channels/chan_pjsip.c
@@ -2756,6 +2756,9 @@ static struct ast_channel *chan_pjsip_request_with_stream_topology(const char *t
 		SCOPE_EXIT_RTN_VALUE(NULL, "Couldn't create channel\n");
 	}
 
+	/* Notify supplements that need channel-backed state (e.g., RFC7329 linkedid map). */
+	ast_sip_session_channel_created(session);
+
 	SCOPE_EXIT_RTN_VALUE(session->channel, "Channel: %s\n", ast_channel_name(session->channel));
 }
 
@@ -3060,6 +3063,9 @@ static int chan_pjsip_incoming_request(struct ast_sip_session *session, struct p
 		SCOPE_EXIT_LOG_RTN_VALUE(-1, LOG_ERROR, "%s: Failed to allocate new PJSIP channel on incoming SIP INVITE\n",
 			 ast_sip_session_get_name(session));
 	}
+
+	/* Notify supplements that need channel-backed state (e.g., RFC7329 linkedid map). */
+	ast_sip_session_channel_created(session);
 
 	set_sipdomain_variable(session);
 

--- a/configs/samples/pjsip.conf.sample
+++ b/configs/samples/pjsip.conf.sample
@@ -1349,6 +1349,8 @@
                                                         ; int")
 ;debug=no ; Enable/Disable SIP debug logging.  Valid options include yes|no
           ; or a host address (default: "no")
+;rfc7329_enable=no ; Enable RFC7329 Session-ID handling (default: "no")
+                   ; When enabled, PJSIP_HEADER cannot add, update, or remove Session-ID.
 ;keep_alive_interval=90 ; The interval (in seconds) at which to send (double CRLF)
                         ; keep-alives on all active connection-oriented transports;
                         ; for connection-less like UDP see qualify_frequency.

--- a/contrib/ast-db-manage/config/versions/7b1b2f4c9d6e_add_rfc7329_enable_to_ps_globals.py
+++ b/contrib/ast-db-manage/config/versions/7b1b2f4c9d6e_add_rfc7329_enable_to_ps_globals.py
@@ -1,0 +1,37 @@
+"""add rfc7329_enable to ps_globals
+
+Revision ID: 7b1b2f4c9d6e
+Revises: bb6d54e22913
+Create Date: 2025-01-12 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import ENUM
+
+# revision identifiers, used by Alembic.
+revision = '7b1b2f4c9d6e'
+down_revision = 'bb6d54e22913'
+AST_BOOL_NAME = 'ast_bool_values'
+# We'll just ignore the n/y and f/t abbreviations as Asterisk does not write
+# those aliases.
+AST_BOOL_VALUES = [ '0', '1',
+                    'off', 'on',
+                    'false', 'true',
+                    'no', 'yes' ]
+
+
+def upgrade():
+    ############################# Enums ##############################
+
+    # ast_bool_values has already been created, so use postgres enum object
+    # type to get around "already created" issue - works okay with mysql
+    ast_bool_values = ENUM(*AST_BOOL_VALUES, name=AST_BOOL_NAME, create_type=False)
+
+    op.add_column('ps_globals', sa.Column('rfc7329_enable', ast_bool_values))
+
+
+def downgrade():
+    if op.get_context().bind.dialect.name == 'mssql':
+        op.drop_constraint('ck_ps_globals_rfc7329_enable_ast_bool_values', 'ps_globals')
+    op.drop_column('ps_globals', 'rfc7329_enable')

--- a/include/asterisk/res_pjsip.h
+++ b/include/asterisk/res_pjsip.h
@@ -4381,6 +4381,13 @@ struct pjsip_param *ast_sip_pjsip_uri_get_other_param(pjsip_uri *uri, const pj_s
  */
 unsigned int ast_sip_get_all_codecs_on_empty_reinvite(void);
 
+/*!
+ * \brief Retrieve the global setting 'rfc7329_enable'.
+ *
+ * \retval non zero if RFC7329 Session-ID handling is enabled
+ */
+unsigned int ast_sip_get_rfc7329_enable(void);
+
 
 /*!
  * \brief Convert SIP hangup causes to Asterisk hangup causes

--- a/include/asterisk/res_pjsip_session.h
+++ b/include/asterisk/res_pjsip_session.h
@@ -364,6 +364,11 @@ struct ast_sip_session_supplement {
 	 * Defaults to AST_SIP_SESSION_BEFORE_MEDIA
 	 */
 	enum ast_sip_session_response_priority response_priority;
+	/*!
+	 * \brief Notification that the session has an associated channel
+	 * This method will always be called from a SIP servant thread.
+	 */
+	void (*session_channel_created)(struct ast_sip_session *session);
 };
 
 enum ast_sip_session_sdp_stream_defer {
@@ -624,6 +629,12 @@ void ast_sip_session_register_supplement_with_module(struct ast_module *module, 
  * \param supplement The supplement to unregister
  */
 void ast_sip_session_unregister_supplement(struct ast_sip_session_supplement *supplement);
+
+/*!
+ * \brief Notify supplements that a session now has an associated channel
+ * \param session The session whose channel has been created
+ */
+void ast_sip_session_channel_created(struct ast_sip_session *session);
 
 /*!
  * \brief Add supplements to a SIP session

--- a/res/res_pjsip/config_global.c
+++ b/res/res_pjsip/config_global.c
@@ -55,6 +55,7 @@
 #define DEFAULT_TASKPROCESSOR_OVERLOAD_TRIGGER TASKPROCESSOR_OVERLOAD_TRIGGER_GLOBAL
 #define DEFAULT_NOREFERSUB 1
 #define DEFAULT_ALL_CODECS_ON_EMPTY_REINVITE 0
+#define DEFAULT_RFC7329_ENABLE 0
 #define DEFAULT_AUTH_ALGORITHMS_UAS "MD5"
 #define DEFAULT_AUTH_ALGORITHMS_UAC "MD5"
 
@@ -128,6 +129,8 @@ struct global_config {
 	unsigned int norefersub;
 	/*! Nonzero if we should return all codecs on empty re-INVITE */
 	unsigned int all_codecs_on_empty_reinvite;
+	/*! Nonzero if RFC7329 Session-ID handling is enabled */
+	unsigned int rfc7329_enable;
 };
 
 static void global_destructor(void *obj)
@@ -608,6 +611,21 @@ unsigned int ast_sip_get_all_codecs_on_empty_reinvite(void)
 	return all_codecs_on_empty_reinvite;
 }
 
+unsigned int ast_sip_get_rfc7329_enable(void)
+{
+	unsigned int enabled;
+	struct global_config *cfg;
+
+	cfg = get_global_cfg();
+	if (!cfg) {
+		return DEFAULT_RFC7329_ENABLE;
+	}
+
+	enabled = cfg->rfc7329_enable;
+	ao2_ref(cfg, -1);
+	return enabled;
+}
+
 static int overload_trigger_handler(const struct aco_option *opt,
 	struct ast_variable *var, void *obj)
 {
@@ -818,6 +836,9 @@ int ast_sip_initialize_sorcery_global(void)
 	ast_sorcery_object_field_register(sorcery, "global", "all_codecs_on_empty_reinvite",
 		DEFAULT_ALL_CODECS_ON_EMPTY_REINVITE ? "yes" : "no",
 		OPT_BOOL_T, 1, FLDSET(struct global_config, all_codecs_on_empty_reinvite));
+	ast_sorcery_object_field_register(sorcery, "global", "rfc7329_enable",
+		DEFAULT_RFC7329_ENABLE ? "yes" : "no",
+		OPT_BOOL_T, 1, FLDSET(struct global_config, rfc7329_enable));
 	ast_sorcery_object_field_register(sorcery, "global", "default_auth_algorithms_uas",
 		DEFAULT_AUTH_ALGORITHMS_UAS, OPT_STRINGFIELD_T, 0,
 		STRFLDSET(struct global_config, default_auth_algorithms_uas));

--- a/res/res_pjsip/pjsip_config.xml
+++ b/res/res_pjsip/pjsip_config.xml
@@ -3513,6 +3513,14 @@
 						<para>If not specified, the default is <literal>MD5</literal> only.</para>
 					</description>
 				</configOption>
+				<configOption name="rfc7329_enable" default="no">
+					<synopsis>Enable RFC7329 Session-ID handling for PJSIP</synopsis>
+					<description><para>
+						When enabled, Asterisk applies RFC7329 Session-ID handling to PJSIP
+						requests and responses through <literal>res_pjsip_rfc7329</literal>.
+						When disabled, RFC7329 handling is not applied.
+					</para></description>
+				</configOption>
 			</configObject>
 		</configFile>
 	</configInfo>

--- a/res/res_pjsip_refer.c
+++ b/res/res_pjsip_refer.c
@@ -731,6 +731,8 @@ struct refer_blind {
 	pjsip_replaces_hdr *replaces;
 	/*! \brief Optional Refer-To header */
 	pjsip_sip_uri *refer_to;
+	/*! \brief Session-ID extracted from Refer-To URI parameter */
+	char refer_to_session_id[33];
 	/*! \brief Attended transfer flag */
 	unsigned int attended:1;
 };
@@ -747,6 +749,9 @@ static void refer_blind_callback(struct ast_channel *chan, struct transfer_chann
 	const char *get_xfrdata;
 
 	pbx_builtin_setvar_helper(chan, "SIPTRANSFER", "yes");
+	if (!ast_strlen_zero(refer->refer_to_session_id)) {
+		pbx_builtin_setvar_helper(chan, "__SIPSESSIONID_REFERTO", refer->refer_to_session_id);
+	}
 
 	if (refer->progress && !refer->attended && !refer->progress->refer_blind_progress) {
 		/* If blind transfer and endpoint doesn't want to receive all the progress details */
@@ -962,6 +967,115 @@ struct refer_data {
 	char *refer_to;
 	int to_self;
 };
+
+/* Gate RFC7329 behavior on the module being loaded. */
+static int rfc7329_module_loaded(void)
+{
+	return ast_sip_get_rfc7329_enable() && ast_module_check("res_pjsip_rfc7329.so");
+}
+
+struct rfc7329_store_data {
+	char *session_id;
+};
+
+static const char *get_session_id_from_session(struct ast_sip_session *session)
+{
+	RAII_VAR(struct ast_datastore *, datastore,
+		ast_sip_session_get_datastore(session, "rfc7329_session_id"), ao2_cleanup);
+	struct rfc7329_store_data *store;
+
+	if (!datastore) {
+		return NULL;
+	}
+
+	store = datastore->data;
+	return store ? store->session_id : NULL;
+}
+
+static void set_refer_to_session_id_if_empty(struct ast_channel *chan, const char *session_id)
+{
+	const char *existing;
+
+	if (!chan || !rfc7329_module_loaded() || ast_strlen_zero(session_id)) {
+		return;
+	}
+
+	ast_channel_lock(chan);
+	existing = pbx_builtin_getvar_helper(chan, "SIPSESSIONID_REFERTO");
+	if (ast_strlen_zero(existing)) {
+		pbx_builtin_setvar_helper(chan, "__SIPSESSIONID_REFERTO", session_id);
+	}
+	ast_channel_unlock(chan);
+}
+
+static void add_session_id_header_param(pjsip_tx_data *tdata, const char *session_id)
+{
+	static const pj_str_t session_id_param = { "Session-ID", 10 };
+	static const pj_str_t refer_to_name = { "Refer-To", 8 };
+	pjsip_generic_string_hdr *refer_to_hdr;
+	pjsip_uri *parsed_uri;
+	pjsip_sip_uri *sip_uri;
+	pjsip_param *param;
+	struct ast_str *refer_to_str;
+
+	if (!rfc7329_module_loaded() || ast_strlen_zero(session_id)) {
+		return;
+	}
+
+	refer_to_hdr = pjsip_msg_find_hdr_by_name(tdata->msg, &refer_to_name, NULL);
+
+	if (!refer_to_hdr) {
+		return;
+	}
+
+	parsed_uri = pjsip_parse_uri(tdata->pool, refer_to_hdr->hvalue.ptr, refer_to_hdr->hvalue.slen, 0);
+	if (!parsed_uri || (!PJSIP_URI_SCHEME_IS_SIP(parsed_uri) && !PJSIP_URI_SCHEME_IS_SIPS(parsed_uri))) {
+		return;
+	}
+
+	sip_uri = pjsip_uri_get_uri(parsed_uri);
+	param = pjsip_param_find(&sip_uri->header_param, &session_id_param);
+	if (!param) {
+		param = PJ_POOL_ALLOC_T(tdata->pool, pjsip_param);
+		param->name = session_id_param;
+		param->value = pj_str((char *) session_id);
+		pj_list_insert_before(&sip_uri->header_param, param);
+	} else if (pj_stricmp2(&param->value, session_id)) {
+		pj_strdup2(tdata->pool, &param->value, session_id);
+	}
+
+	refer_to_str = ast_str_create(PJSIP_MAX_URL_SIZE);
+	if (!refer_to_str) {
+		return;
+	}
+	pjsip_uri_print(PJSIP_URI_IN_CONTACT_HDR, parsed_uri, ast_str_buffer(refer_to_str), ast_str_size(refer_to_str));
+	pj_strdup2(tdata->pool, &refer_to_hdr->hvalue, ast_str_buffer(refer_to_str));
+	ast_free(refer_to_str);
+}
+
+static void store_refer_to_session_id(struct ast_sip_session *session, pjsip_sip_uri *target_uri)
+{
+	static const pj_str_t session_id_param = { "Session-ID", 10 };
+	pjsip_param *param;
+	char session_id[33];
+
+	if (!rfc7329_module_loaded() || !session || !session->channel || !target_uri) {
+		return;
+	}
+
+	param = pjsip_param_find(&target_uri->header_param, &session_id_param);
+	if (!param || !param->value.slen) {
+		ast_channel_lock(session->channel);
+		pbx_builtin_setvar_helper(session->channel, "SIPSESSIONID_REFERTO", NULL);
+		ast_channel_unlock(session->channel);
+		return;
+	}
+
+	ast_copy_pj_str(session_id, &param->value, sizeof(session_id));
+	ast_channel_lock(session->channel);
+	pbx_builtin_setvar_helper(session->channel, "__SIPSESSIONID_REFERTO", session_id);
+	ast_channel_unlock(session->channel);
+}
 
 static void refer_data_destroy(void *obj)
 {
@@ -1403,6 +1517,13 @@ static int refer_send(void *data)
 	ast_sip_update_to_uri(tdata, uri);
 	ast_sip_update_from(tdata, rdata->from);
 
+	if (rfc7329_module_loaded()) {
+		/* Embed Session-ID in Refer-To URI when available. */
+		const char *session_id_refer_to = ast_refer_get_var(rdata->refer, "Session-ID-Refer-To");
+		const char *session_id = session_id_refer_to ? session_id_refer_to : ast_refer_get_var(rdata->refer, "Session-ID");
+		add_session_id_header_param(tdata, session_id);
+	}
+
 	/*
 	 * This copies any headers found in the refer's variables to
 	 * tdata.
@@ -1558,6 +1679,8 @@ static int refer_incoming_ari_request(struct ast_sip_session *session, pjsip_rx_
 		if (dlg) {
 			state->other_session = ast_sip_dialog_get_session(dlg);
 			pjsip_dlg_dec_lock(dlg);
+			set_refer_to_session_id_if_empty(session->channel,
+				get_session_id_from_session(state->other_session));
 		}
 
 		state->protocol_id = copy_string(&replaces->call_id);
@@ -1636,6 +1759,9 @@ static int refer_incoming_attended_request(struct ast_sip_session *session, pjsi
 			return 603;
 		}
 
+		set_refer_to_session_id_if_empty(session->channel,
+			get_session_id_from_session(other_session));
+
 		/* We defer actually doing the attended transfer to the other session so no deadlock can occur */
 		if (!(attended = refer_attended_alloc(session, other_session, progress))) {
 			ast_log(LOG_ERROR, "Received REFER request on channel '%s' from endpoint '%s' for local dialog but could not allocate structure to complete, rejecting\n",
@@ -1708,6 +1834,7 @@ static int refer_incoming_blind_request(struct ast_sip_session *session, pjsip_r
 	char exten[AST_MAX_EXTENSION];
 	struct refer_blind refer = { 0, };
 	int response;
+	const char *refer_to_session_id;
 
 	/* If no explicit transfer context has been provided use their configured context */
 	DETERMINE_TRANSFER_CONTEXT(context, session);
@@ -1739,6 +1866,14 @@ static int refer_incoming_blind_request(struct ast_sip_session *session, pjsip_r
 	refer.rdata = rdata;
 	refer.refer_to = target;
 	refer.attended = 0;
+	if (rfc7329_module_loaded()) {
+		ast_channel_lock(session->channel);
+		refer_to_session_id = pbx_builtin_getvar_helper(session->channel, "SIPSESSIONID_REFERTO");
+		if (!ast_strlen_zero(refer_to_session_id)) {
+			ast_copy_string(refer.refer_to_session_id, refer_to_session_id, sizeof(refer.refer_to_session_id));
+		}
+		ast_channel_unlock(session->channel);
+	}
 
 	if (ast_sip_session_defer_termination(session)) {
 		ast_log(LOG_ERROR, "Channel '%s' from endpoint '%s' attempted blind transfer but could not defer termination, rejecting\n",
@@ -1967,6 +2102,11 @@ static int refer_incoming_refer_request(struct ast_sip_session *session, struct 
 	}
 	target_uri = pjsip_uri_get_uri(target);
 
+	if (rfc7329_module_loaded()) {
+		/* Persist inbound Refer-To Session-ID for transfer handling. */
+		store_refer_to_session_id(session, target_uri);
+	}
+
 	/* Set up REFER progress subscription if requested/possible */
 	if (refer_progress_alloc(session, rdata, &progress)) {
 		pjsip_dlg_respond(session->inv_session->dlg, rdata, 500, NULL, NULL, NULL);
@@ -2067,17 +2207,111 @@ static void add_header_from_channel_var(struct ast_channel *chan, const char *va
 	ast_sip_add_header(tdata, header_name, var_value);
 }
 
+/*!
+ * \brief Set or replace a SIP header from a channel variable value.
+ *
+ * This looks up a variable on a channel and enforces that value on the outgoing
+ * SIP request header. If the header does not exist, it is added.
+ *
+ * \pre chan is locked.
+ */
+static void set_or_replace_header_from_channel_var(struct ast_channel *chan, const char *var_name,
+	const char *header_name, pjsip_tx_data *tdata)
+{
+	const char *var_value;
+	pj_str_t pj_header_name;
+	pjsip_generic_string_hdr *header;
+	pj_str_t header_value;
+
+	var_value = pbx_builtin_getvar_helper(chan, var_name);
+	if (ast_strlen_zero(var_value)) {
+		return;
+	}
+
+	pj_cstr(&pj_header_name, header_name);
+	header = pjsip_msg_find_hdr_by_name(tdata->msg, &pj_header_name, NULL);
+	if (!header) {
+		header_value = pj_str((char *) var_value);
+		header = pjsip_generic_string_hdr_create(tdata->pool, &pj_header_name, &header_value);
+		pjsip_msg_add_hdr(tdata->msg, (pjsip_hdr *) header);
+		return;
+	}
+
+	if (pj_strcmp2(&header->hvalue, var_value)) {
+		pj_strdup2(tdata->pool, &header->hvalue, var_value);
+	}
+}
+
+/*!
+ * \brief Keep RFC7329 session datastore aligned with channel override value.
+ *
+ * RFC7329 in-dialog requests (e.g., ACK) use the stored per-session Session-ID.
+ * When REFER logic overrides Session-ID from SIPSESSIONID_REFERTO on initial
+ * INVITE, we must also update the stored value so subsequent requests match.
+ *
+ * \pre chan is locked.
+ */
+static void sync_rfc7329_store_from_channel_var(struct ast_sip_session *session, struct ast_channel *chan,
+	const char *var_name)
+{
+	RAII_VAR(struct ast_datastore *, datastore, NULL, ao2_cleanup);
+	struct rfc7329_store_data *store;
+	const char *var_value;
+	char *copy;
+
+	if (!rfc7329_module_loaded() || !session || !chan || ast_strlen_zero(var_name)) {
+		return;
+	}
+
+	var_value = pbx_builtin_getvar_helper(chan, var_name);
+	if (ast_strlen_zero(var_value)) {
+		return;
+	}
+
+	datastore = ast_sip_session_get_datastore(session, "rfc7329_session_id");
+	if (!datastore) {
+		return;
+	}
+
+	store = datastore->data;
+	if (!store || (store->session_id && !strcmp(store->session_id, var_value))) {
+		return;
+	}
+
+	copy = ast_strdup(var_value);
+	if (!copy) {
+		return;
+	}
+
+	ast_free(store->session_id);
+	store->session_id = copy;
+}
+
 static void refer_outgoing_request(struct ast_sip_session *session, struct pjsip_tx_data *tdata)
 {
-	if (pjsip_method_cmp(&tdata->msg->line.req.method, &pjsip_invite_method)
-		|| !session->channel
-		|| session->inv_session->state != PJSIP_INV_STATE_NULL) {
+	int is_initial_invite;
+	int is_ack;
+
+	if (!session->channel || !session->inv_session) {
+		return;
+	}
+
+	is_initial_invite = !pjsip_method_cmp(&tdata->msg->line.req.method, &pjsip_invite_method)
+		&& session->inv_session->state == PJSIP_INV_STATE_NULL;
+	is_ack = !pjsip_method_cmp(&tdata->msg->line.req.method, &pjsip_ack_method);
+	if (!is_initial_invite && !is_ack) {
 		return;
 	}
 
 	ast_channel_lock(session->channel);
-	add_header_from_channel_var(session->channel, "SIPREPLACESHDR", "Replaces", tdata);
-	add_header_from_channel_var(session->channel, "SIPREFERREDBYHDR", "Referred-By", tdata);
+	if (rfc7329_module_loaded()) {
+		set_or_replace_header_from_channel_var(session->channel, "SIPSESSIONID_REFERTO", "Session-ID", tdata);
+		sync_rfc7329_store_from_channel_var(session, session->channel, "SIPSESSIONID_REFERTO");
+	}
+	if (is_initial_invite) {
+		add_header_from_channel_var(session->channel, "SIPREPLACESHDR", "Replaces", tdata);
+		add_header_from_channel_var(session->channel, "SIPREFERREDBYHDR", "Referred-By", tdata);
+	}
 	ast_channel_unlock(session->channel);
 }
 

--- a/res/res_pjsip_rfc7329.c
+++ b/res/res_pjsip_rfc7329.c
@@ -1,0 +1,1133 @@
+/*
+ * Asterisk -- An open source telephony toolkit.
+ *
+ * Copyright (C) 2025
+ *
+ * See http://www.asterisk.org for more information about
+ * the Asterisk project. Please do not directly contact
+ * any of the maintainers of this project for assistance;
+ * the project provides a web site, mailing lists and IRC
+ * channels for your use.
+ *
+ * This program is free software, distributed under the terms of
+ * the GNU General Public License Version 2. See the LICENSE file
+ * at the top of the source tree.
+ */
+
+/*** MODULEINFO
+	<depend>pjproject</depend>
+	<depend>res_pjsip</depend>
+	<depend>res_pjsip_session</depend>
+	<support_level>core</support_level>
+ ***/
+
+#include "asterisk.h"
+
+#include <pjsip.h>
+#include <pjsip_ua.h>
+
+#include "asterisk/channel.h"
+#include "asterisk/strings.h"
+#include "asterisk/utils.h"
+#include "asterisk/module.h"
+#include "asterisk/astobj2.h"
+#include "asterisk/res_pjsip.h"
+#include "asterisk/res_pjsip_session.h"
+#include <pjlib-util/hmac_sha1.h>
+
+#define RFC7329_MOD_DATA_SESSION_ID "rfc7329_session_id"
+
+/* Per-session datastore for the active Session-ID and linkedid mapping. */
+struct rfc7329_store_data {
+	char *session_id;
+	char *linkedid;
+	int linkedid_refcounted;
+};
+
+AST_MUTEX_DEFINE_STATIC(rfc7329_secret_lock);
+static unsigned char rfc7329_secret[16];
+static int rfc7329_secret_initialized;
+static const pj_str_t session_id_hdr_name = { "Session-ID", 10 };
+static pjsip_module rfc7329_tsx_module;
+static struct ao2_container *rfc7329_callid_map;
+static struct ao2_container *rfc7329_linkedid_map;
+static int rfc7329_active;
+static struct ast_sip_session_supplement rfc7329_supplement;
+static struct ast_sip_supplement rfc7329_out_of_dialog_supplement;
+
+static void ensure_secret(void);
+
+static int rfc7329_option_enabled(void)
+{
+	return ast_sip_get_rfc7329_enable();
+}
+
+/* Cache for out-of-dialog response matching using Call-ID. */
+struct rfc7329_callid_entry {
+	char *call_id;
+	char *session_id;
+};
+
+/* Cross-leg Session-ID mapping keyed by channel linkedid. */
+struct rfc7329_linkedid_entry {
+	char *linkedid;
+	char *session_id;
+	int refcount;
+};
+
+static void rfc7329_callid_entry_destroy(void *obj)
+{
+	struct rfc7329_callid_entry *entry = obj;
+
+	ast_free(entry->call_id);
+	ast_free(entry->session_id);
+}
+
+static int rfc7329_callid_cmp(void *obj, void *arg, int flags)
+{
+	const struct rfc7329_callid_entry *entry = obj;
+	const char *call_id = arg;
+
+	return entry->call_id && call_id && !strcmp(entry->call_id, call_id) ? CMP_MATCH : 0;
+}
+
+static int rfc7329_callid_hash(const void *obj, int flags)
+{
+	const struct rfc7329_callid_entry *entry = obj;
+	const char *call_id;
+
+	if (flags & OBJ_SEARCH_KEY) {
+		call_id = obj;
+	} else {
+		call_id = entry ? entry->call_id : NULL;
+	}
+
+	return call_id ? (int) ast_str_hash(call_id) : 0;
+}
+
+static void rfc7329_linkedid_entry_destroy(void *obj)
+{
+	struct rfc7329_linkedid_entry *entry = obj;
+
+	ast_free(entry->linkedid);
+	ast_free(entry->session_id);
+}
+
+static int rfc7329_linkedid_cmp(void *obj, void *arg, int flags)
+{
+	const struct rfc7329_linkedid_entry *entry = obj;
+	const char *linkedid = arg;
+
+	return entry->linkedid && linkedid && !strcmp(entry->linkedid, linkedid) ? CMP_MATCH : 0;
+}
+
+static int rfc7329_linkedid_hash(const void *obj, int flags)
+{
+	const struct rfc7329_linkedid_entry *entry = obj;
+	const char *linkedid;
+
+	if (flags & OBJ_SEARCH_KEY) {
+		linkedid = obj;
+	} else {
+		linkedid = entry ? entry->linkedid : NULL;
+	}
+
+	return linkedid ? (int) ast_str_hash(linkedid) : 0;
+}
+
+static int rfc7329_activate(void)
+{
+	ensure_secret();
+	rfc7329_callid_map = ao2_container_alloc_hash(AO2_ALLOC_OPT_LOCK_RWLOCK, 0, 37,
+		rfc7329_callid_hash, NULL, rfc7329_callid_cmp);
+	rfc7329_linkedid_map = ao2_container_alloc_hash(AO2_ALLOC_OPT_LOCK_RWLOCK, 0, 37,
+		rfc7329_linkedid_hash, NULL, rfc7329_linkedid_cmp);
+	if (!rfc7329_callid_map || !rfc7329_linkedid_map) {
+		ao2_cleanup(rfc7329_callid_map);
+		rfc7329_callid_map = NULL;
+		ao2_cleanup(rfc7329_linkedid_map);
+		rfc7329_linkedid_map = NULL;
+		return -1;
+	}
+	ast_sip_session_register_supplement(&rfc7329_supplement);
+	ast_sip_register_supplement(&rfc7329_out_of_dialog_supplement);
+
+	if (pjsip_endpt_register_module(ast_sip_get_pjsip_endpoint(), &rfc7329_tsx_module) != PJ_SUCCESS) {
+		ao2_cleanup(rfc7329_callid_map);
+		rfc7329_callid_map = NULL;
+		ao2_cleanup(rfc7329_linkedid_map);
+		rfc7329_linkedid_map = NULL;
+		ast_sip_session_unregister_supplement(&rfc7329_supplement);
+		ast_sip_unregister_supplement(&rfc7329_out_of_dialog_supplement);
+		return -1;
+	}
+
+	rfc7329_active = 1;
+	return 0;
+}
+
+static void rfc7329_deactivate(void)
+{
+	if (!rfc7329_active) {
+		return;
+	}
+
+	pjsip_endpt_unregister_module(ast_sip_get_pjsip_endpoint(), &rfc7329_tsx_module);
+	ast_sip_unregister_supplement(&rfc7329_out_of_dialog_supplement);
+	ast_sip_session_unregister_supplement(&rfc7329_supplement);
+	ao2_cleanup(rfc7329_callid_map);
+	rfc7329_callid_map = NULL;
+	ao2_cleanup(rfc7329_linkedid_map);
+	rfc7329_linkedid_map = NULL;
+	rfc7329_active = 0;
+}
+
+/* Return the channel linkedid if the session has a channel. */
+static const char *rfc7329_get_linkedid(struct ast_sip_session *session)
+{
+	if (!session || !session->channel) {
+		return NULL;
+	}
+
+	return ast_channel_linkedid(session->channel);
+}
+
+/* Attach Session-ID to linkedid for later reuse on other call legs. */
+static void rfc7329_linkedid_map_add(struct ast_sip_session *session,
+	struct rfc7329_store_data *store)
+{
+	RAII_VAR(struct rfc7329_linkedid_entry *, entry, NULL, ao2_cleanup);
+	struct rfc7329_linkedid_entry *new_entry;
+	const char *linkedid;
+	char *linkedid_copy;
+
+	if (!rfc7329_linkedid_map || !session || !store || store->linkedid_refcounted) {
+		return;
+	}
+
+	linkedid = rfc7329_get_linkedid(session);
+	if (ast_strlen_zero(linkedid) || ast_strlen_zero(store->session_id)) {
+		return;
+	}
+
+	linkedid_copy = ast_strdup(linkedid);
+	if (!linkedid_copy) {
+		return;
+	}
+
+	entry = ao2_find(rfc7329_linkedid_map, linkedid, OBJ_SEARCH_KEY);
+	if (entry) {
+		if (entry->session_id && strcmp(entry->session_id, store->session_id)) {
+			ast_log(LOG_WARNING,
+				"RFC7329: linkedid '%s' already mapped to Session-ID '%s'; keeping existing\n",
+				linkedid, entry->session_id);
+		} else if (!entry->session_id) {
+			entry->session_id = ast_strdup(store->session_id);
+		}
+		/* Track multiple sessions sharing the same linkedid. */
+		entry->refcount++;
+	} else {
+		new_entry = ao2_alloc(sizeof(*new_entry), rfc7329_linkedid_entry_destroy);
+		if (!new_entry) {
+			ast_free(linkedid_copy);
+			return;
+		}
+
+		new_entry->linkedid = ast_strdup(linkedid);
+		new_entry->session_id = ast_strdup(store->session_id);
+		new_entry->refcount = 1;
+		if (!new_entry->linkedid || !new_entry->session_id) {
+			ao2_cleanup(new_entry);
+			ast_free(linkedid_copy);
+			return;
+		}
+
+		/* First mapping for this linkedid; used to reuse Session-ID across legs. */
+		ao2_link(rfc7329_linkedid_map, new_entry);
+		ao2_cleanup(new_entry);
+	}
+
+	store->linkedid = linkedid_copy;
+	store->linkedid_refcounted = 1;
+}
+
+/* Lookup Session-ID by linkedid for a new leg. */
+static const char *rfc7329_find_linkedid_map(struct ast_sip_session *session)
+{
+	RAII_VAR(struct rfc7329_linkedid_entry *, entry, NULL, ao2_cleanup);
+	const char *linkedid;
+
+	if (!rfc7329_linkedid_map || !session) {
+		return NULL;
+	}
+
+	linkedid = rfc7329_get_linkedid(session);
+	if (ast_strlen_zero(linkedid)) {
+		return NULL;
+	}
+
+	entry = ao2_find(rfc7329_linkedid_map, linkedid, OBJ_SEARCH_KEY);
+	if (!entry) {
+		return NULL;
+	}
+
+	return entry->session_id;
+}
+
+/* Drop linkedid mapping when the last session referencing it ends. */
+static void rfc7329_linkedid_map_remove(struct rfc7329_store_data *store)
+{
+	RAII_VAR(struct rfc7329_linkedid_entry *, entry, NULL, ao2_cleanup);
+
+	if (!rfc7329_linkedid_map || !store || !store->linkedid_refcounted
+		|| ast_strlen_zero(store->linkedid)) {
+		return;
+	}
+
+	entry = ao2_find(rfc7329_linkedid_map, store->linkedid, OBJ_SEARCH_KEY);
+	if (!entry) {
+		return;
+	}
+
+	if (entry->refcount > 1) {
+		entry->refcount--;
+		return;
+	}
+
+	ao2_unlink(rfc7329_linkedid_map, entry);
+}
+
+static void datastore_destroy_cb(void *data)
+{
+	struct rfc7329_store_data *store = data;
+
+	if (!store) {
+		return;
+	}
+
+	ast_free(store->session_id);
+	ast_free(store->linkedid);
+	ast_free(store);
+}
+
+static const struct ast_datastore_info rfc7329_store_datastore = {
+	.type = "rfc7329_session_id",
+	.destroy = datastore_destroy_cb,
+};
+
+static void ensure_secret(void)
+{
+	int i;
+
+	if (rfc7329_secret_initialized) {
+		return;
+	}
+
+	ast_mutex_lock(&rfc7329_secret_lock);
+	if (!rfc7329_secret_initialized) {
+		for (i = 0; i < (int) sizeof(rfc7329_secret); ++i) {
+			rfc7329_secret[i] = ast_random() & 0xFF;
+		}
+		rfc7329_secret_initialized = 1;
+	}
+	ast_mutex_unlock(&rfc7329_secret_lock);
+}
+
+static void hmac_sha1_128_hex(const unsigned char *msg, size_t msg_len, char out_hex[33])
+{
+	unsigned char digest[20];
+	int i;
+
+	ensure_secret();
+	pj_hmac_sha1(msg, msg_len, rfc7329_secret, sizeof(rfc7329_secret), digest);
+
+	for (i = 0; i < 16; ++i) {
+		sprintf(out_hex + (i * 2), "%02x", digest[i]);
+	}
+	out_hex[32] = '\0';
+}
+
+static char *dup_pj_str(const pj_str_t *value)
+{
+	char *buf;
+
+	if (!value || !value->slen) {
+		return NULL;
+	}
+
+	buf = ast_malloc(value->slen + 1);
+	if (!buf) {
+		return NULL;
+	}
+
+	ast_copy_pj_str(buf, value, value->slen + 1);
+	return buf;
+}
+
+static char *pj_strdup2_pool(pj_pool_t *pool, const pj_str_t *value)
+{
+	char *buf;
+
+	if (!pool || !value || !value->slen) {
+		return NULL;
+	}
+
+	buf = pj_pool_alloc(pool, value->slen + 1);
+	if (!buf) {
+		return NULL;
+	}
+
+	pj_memcpy(buf, value->ptr, value->slen);
+	buf[value->slen] = '\0';
+
+	return buf;
+}
+
+static char *dup_cstr_pool(pj_pool_t *pool, const char *value)
+{
+	size_t len;
+	char *buf;
+
+	if (!pool || !value) {
+		return NULL;
+	}
+
+	len = strlen(value);
+	buf = pj_pool_alloc(pool, len + 1);
+	if (!buf) {
+		return NULL;
+	}
+
+	memcpy(buf, value, len + 1);
+	return buf;
+}
+
+static int header_value_matches(pjsip_generic_string_hdr *hdr, const char *value)
+{
+	size_t len;
+
+	if (!hdr || !value) {
+		return 0;
+	}
+
+	len = strlen(value);
+	return hdr->hvalue.slen == (pj_ssize_t) len
+		&& !pj_memcmp(hdr->hvalue.ptr, value, len);
+}
+
+static char *build_session_id_from_msg(pj_pool_t *pool, pjsip_msg *msg)
+{
+	pjsip_generic_string_hdr *hdr;
+	pjsip_cid_hdr *call_id;
+	char hex_id[33];
+
+	if (!pool || !msg) {
+		return NULL;
+	}
+
+	hdr = pjsip_msg_find_hdr_by_name(msg, &session_id_hdr_name, NULL);
+	if (hdr && hdr->hvalue.slen) {
+		return pj_strdup2_pool(pool, &hdr->hvalue);
+	}
+
+	call_id = pjsip_msg_find_hdr(msg, PJSIP_H_CALL_ID, NULL);
+	if (!call_id || !call_id->id.slen) {
+		return NULL;
+	}
+
+	hmac_sha1_128_hex((const unsigned char *) call_id->id.ptr, call_id->id.slen, hex_id);
+	return dup_cstr_pool(pool, hex_id);
+}
+
+static char *build_session_id_from_call_id(pj_pool_t *pool, pjsip_msg *msg)
+{
+	pjsip_cid_hdr *call_id;
+	char hex_id[33];
+
+	if (!pool || !msg) {
+		return NULL;
+	}
+
+	call_id = pjsip_msg_find_hdr(msg, PJSIP_H_CALL_ID, NULL);
+	if (!call_id || !call_id->id.slen) {
+		return NULL;
+	}
+
+	hmac_sha1_128_hex((const unsigned char *) call_id->id.ptr, call_id->id.slen, hex_id);
+	return dup_cstr_pool(pool, hex_id);
+}
+
+static const char *store_session_id_str(struct ast_sip_session *session, const char *value)
+{
+	RAII_VAR(struct ast_datastore *, datastore, NULL, ao2_cleanup);
+	struct rfc7329_store_data *store;
+
+	if (ast_strlen_zero(value)) {
+		return NULL;
+	}
+
+	datastore = ast_sip_session_get_datastore(session, "rfc7329_session_id");
+	if (datastore) {
+		store = datastore->data;
+		if (store) {
+			rfc7329_linkedid_map_add(session, store);
+		}
+		return store ? store->session_id : NULL;
+	}
+
+	datastore = ast_sip_session_alloc_datastore(&rfc7329_store_datastore, "rfc7329_session_id");
+	if (!datastore) {
+		return NULL;
+	}
+
+	store = ast_calloc(1, sizeof(*store));
+	if (!store) {
+		return NULL;
+	}
+
+	store->session_id = ast_strdup(value);
+	if (!store->session_id) {
+		ast_free(store);
+		return NULL;
+	}
+
+	datastore->data = store;
+	ast_sip_session_add_datastore(session, datastore);
+	rfc7329_linkedid_map_add(session, store);
+
+	return store->session_id;
+}
+
+static const char *store_session_id_pjstr(struct ast_sip_session *session, const pj_str_t *value)
+{
+	char *buf;
+	const char *stored;
+
+	buf = dup_pj_str(value);
+	if (!buf) {
+		return NULL;
+	}
+
+	stored = store_session_id_str(session, buf);
+	ast_free(buf);
+	return stored;
+}
+
+static const char *get_stored_session_id(struct ast_sip_session *session)
+{
+	RAII_VAR(struct ast_datastore *, datastore, NULL, ao2_cleanup);
+	struct rfc7329_store_data *store;
+
+	if (!session) {
+		return NULL;
+	}
+
+	datastore = ast_sip_session_get_datastore(session, RFC7329_MOD_DATA_SESSION_ID);
+	if (!datastore) {
+		return NULL;
+	}
+
+	store = datastore->data;
+	if (store) {
+		rfc7329_linkedid_map_add(session, store);
+	}
+	return store ? store->session_id : NULL;
+}
+
+static void rfc7329_store_callid_map(const pj_str_t *call_id, const char *session_id)
+{
+	RAII_VAR(struct rfc7329_callid_entry *, entry, NULL, ao2_cleanup);
+	struct rfc7329_callid_entry *new_entry;
+	char call_id_buf[256];
+
+	if (!rfc7329_callid_map || !call_id || !call_id->slen || ast_strlen_zero(session_id)) {
+		return;
+	}
+
+	if (call_id->slen >= (pj_ssize_t) sizeof(call_id_buf)) {
+		return;
+	}
+
+	ast_copy_pj_str(call_id_buf, call_id, sizeof(call_id_buf));
+	entry = ao2_find(rfc7329_callid_map, call_id_buf, OBJ_SEARCH_KEY);
+	if (entry) {
+		ast_free(entry->session_id);
+		entry->session_id = ast_strdup(session_id);
+		return;
+	}
+
+	new_entry = ao2_alloc(sizeof(*new_entry), rfc7329_callid_entry_destroy);
+	if (!new_entry) {
+		return;
+	}
+
+	new_entry->call_id = ast_strdup(call_id_buf);
+	new_entry->session_id = ast_strdup(session_id);
+	if (!new_entry->call_id || !new_entry->session_id) {
+		ao2_cleanup(new_entry);
+		return;
+	}
+
+	ao2_link(rfc7329_callid_map, new_entry);
+	ao2_cleanup(new_entry);
+}
+
+static const char *rfc7329_find_callid_map(const pj_str_t *call_id)
+{
+	RAII_VAR(struct rfc7329_callid_entry *, entry, NULL, ao2_cleanup);
+	char call_id_buf[256];
+
+	if (!rfc7329_callid_map || !call_id || !call_id->slen) {
+		return NULL;
+	}
+
+	if (call_id->slen >= (pj_ssize_t) sizeof(call_id_buf)) {
+		return NULL;
+	}
+
+	ast_copy_pj_str(call_id_buf, call_id, sizeof(call_id_buf));
+	entry = ao2_find(rfc7329_callid_map, call_id_buf, OBJ_SEARCH_KEY);
+	if (!entry) {
+		return NULL;
+	}
+
+	return entry->session_id;
+}
+
+static void rfc7329_remove_callid_map(const pj_str_t *call_id)
+{
+	RAII_VAR(struct rfc7329_callid_entry *, entry, NULL, ao2_cleanup);
+	char call_id_buf[256];
+
+	if (!rfc7329_callid_map || !call_id || !call_id->slen) {
+		return;
+	}
+
+	if (call_id->slen >= (pj_ssize_t) sizeof(call_id_buf)) {
+		return;
+	}
+
+	ast_copy_pj_str(call_id_buf, call_id, sizeof(call_id_buf));
+	entry = ao2_find(rfc7329_callid_map, call_id_buf, OBJ_SEARCH_KEY);
+	if (!entry) {
+		return;
+	}
+
+	ao2_unlink(rfc7329_callid_map, entry);
+}
+
+static const char *get_session_id(struct ast_sip_session *session, pjsip_msg *msg)
+{
+	pjsip_generic_string_hdr *hdr;
+	pjsip_cid_hdr *call_id;
+	char hex_id[33];
+	const char *stored;
+
+	if (!session || !msg) {
+		return NULL;
+	}
+
+	stored = get_stored_session_id(session);
+	if (stored) {
+		return stored;
+	}
+
+	hdr = pjsip_msg_find_hdr_by_name(msg, &session_id_hdr_name, NULL);
+	if (hdr && hdr->hvalue.slen) {
+		return store_session_id_pjstr(session, &hdr->hvalue);
+	}
+
+	/* Reuse Session-ID across call legs using linkedid. */
+	stored = rfc7329_find_linkedid_map(session);
+	if (stored) {
+		return store_session_id_str(session, stored);
+	}
+
+	call_id = pjsip_msg_find_hdr(msg, PJSIP_H_CALL_ID, NULL);
+	if (call_id && call_id->id.slen) {
+		hmac_sha1_128_hex((const unsigned char *) call_id->id.ptr, call_id->id.slen, hex_id);
+		return store_session_id_str(session, hex_id);
+	}
+
+	return NULL;
+}
+
+static void set_or_replace_session_id_header(pjsip_tx_data *tdata, const char *expected)
+{
+	pjsip_generic_string_hdr *hdr;
+	pj_str_t hdr_value;
+
+	if (!tdata || ast_strlen_zero(expected)) {
+		return;
+	}
+
+	hdr = pjsip_msg_find_hdr_by_name(tdata->msg, &session_id_hdr_name, NULL);
+	if (!hdr) {
+		hdr_value = pj_str((char *) expected);
+		hdr = pjsip_generic_string_hdr_create(tdata->pool, &session_id_hdr_name, &hdr_value);
+		pjsip_msg_add_hdr(tdata->msg, (pjsip_hdr *) hdr);
+		return;
+	}
+
+	if (!header_value_matches(hdr, expected)) {
+		ast_log(LOG_WARNING, "RFC7329: Replacing Session-ID header value '%.*s' with '%s'\n",
+			(int) hdr->hvalue.slen, hdr->hvalue.ptr, expected);
+		pj_strdup2(tdata->pool, &hdr->hvalue, expected);
+	}
+}
+
+static void add_session_id_header_from_value(pjsip_tx_data *tdata, const char *session_id)
+{
+	if (!tdata || ast_strlen_zero(session_id)) {
+		return;
+	}
+
+	set_or_replace_session_id_header(tdata, session_id);
+}
+
+static void add_session_id_header_from_call_id(pjsip_tx_data *tdata)
+{
+	char *session_id;
+
+	if (!tdata) {
+		return;
+	}
+
+	if (pjsip_msg_find_hdr_by_name(tdata->msg, &session_id_hdr_name, NULL)) {
+		return;
+	}
+
+	session_id = build_session_id_from_call_id(tdata->pool, tdata->msg);
+	if (!session_id) {
+		return;
+	}
+
+	add_session_id_header_from_value(tdata, session_id);
+}
+
+static void add_session_id_header_request(struct ast_sip_session *session, pjsip_tx_data *tdata)
+{
+	const char *session_id;
+	pjsip_generic_string_hdr *hdr;
+	pj_str_t hdr_value;
+
+	if (!session || !tdata) {
+		return;
+	}
+
+	hdr = pjsip_msg_find_hdr_by_name(tdata->msg, &session_id_hdr_name, NULL);
+	session_id = get_stored_session_id(session);
+	if (!session_id) {
+		session_id = get_session_id(session, tdata->msg);
+	}
+	if (!session_id) {
+		return;
+	}
+
+	if (hdr && header_value_matches(hdr, session_id)) {
+		return;
+	}
+
+	hdr_value = pj_str((char *) session_id);
+	if (!hdr) {
+		hdr = pjsip_generic_string_hdr_create(tdata->pool, &session_id_hdr_name, &hdr_value);
+		pjsip_msg_add_hdr(tdata->msg, (pjsip_hdr *) hdr);
+	} else {
+		pj_strdup2(tdata->pool, &hdr->hvalue, session_id);
+	}
+}
+
+static void add_session_id_header_response(struct ast_sip_session *session, pjsip_tx_data *tdata)
+{
+	const char *session_id;
+	pjsip_generic_string_hdr *hdr;
+	pj_str_t hdr_value;
+
+	if (!session || !tdata) {
+		return;
+	}
+
+	hdr = pjsip_msg_find_hdr_by_name(tdata->msg, &session_id_hdr_name, NULL);
+	session_id = get_stored_session_id(session);
+
+	if (!session_id) {
+		if (hdr && hdr->hvalue.slen) {
+			store_session_id_pjstr(session, &hdr->hvalue);
+		}
+		return;
+	}
+
+	if (hdr && header_value_matches(hdr, session_id)) {
+		return;
+	}
+
+	hdr_value = pj_str((char *) session_id);
+	if (!hdr) {
+		hdr = pjsip_generic_string_hdr_create(tdata->pool, &session_id_hdr_name, &hdr_value);
+		pjsip_msg_add_hdr(tdata->msg, (pjsip_hdr *) hdr);
+	} else {
+		pj_strdup2(tdata->pool, &hdr->hvalue, session_id);
+	}
+}
+
+static int rfc7329_incoming_request(struct ast_sip_session *session, struct pjsip_rx_data *rdata)
+{
+	if (!rfc7329_option_enabled()) {
+		return 0;
+	}
+
+	if (!session || !rdata) {
+		return 0;
+	}
+
+	get_session_id(session, rdata->msg_info.msg);
+	return 0;
+}
+
+static void rfc7329_outgoing_request(struct ast_sip_session *session, struct pjsip_tx_data *tdata)
+{
+	if (!rfc7329_option_enabled()) {
+		return;
+	}
+
+	add_session_id_header_request(session, tdata);
+}
+
+static void rfc7329_outgoing_response(struct ast_sip_session *session, struct pjsip_tx_data *tdata)
+{
+	if (!rfc7329_option_enabled()) {
+		return;
+	}
+
+	add_session_id_header_response(session, tdata);
+}
+
+static void rfc7329_session_begin(struct ast_sip_session *session)
+{
+	if (!rfc7329_option_enabled()) {
+		return;
+	}
+
+	if (!session) {
+		return;
+	}
+
+	get_stored_session_id(session);
+}
+
+static void rfc7329_session_channel_created(struct ast_sip_session *session)
+{
+	if (!rfc7329_option_enabled()) {
+		return;
+	}
+
+	if (!session) {
+		return;
+	}
+
+	/* Session-ID may be known before channel creation; link it now. */
+	get_stored_session_id(session);
+}
+
+static void rfc7329_session_destroy(struct ast_sip_session *session)
+{
+	RAII_VAR(struct ast_datastore *, datastore, NULL, ao2_cleanup);
+	struct rfc7329_store_data *store;
+
+	if (!rfc7329_option_enabled()) {
+		return;
+	}
+
+	if (!session) {
+		return;
+	}
+
+	datastore = ast_sip_session_get_datastore(session, RFC7329_MOD_DATA_SESSION_ID);
+	if (!datastore) {
+		return;
+	}
+
+	store = datastore->data;
+	rfc7329_linkedid_map_remove(store);
+}
+
+static struct ast_sip_session_supplement rfc7329_supplement = {
+	.session_begin = rfc7329_session_begin,
+	.session_channel_created = rfc7329_session_channel_created,
+	.incoming_request = rfc7329_incoming_request,
+	.outgoing_request = rfc7329_outgoing_request,
+	.outgoing_response = rfc7329_outgoing_response,
+	.session_destroy = rfc7329_session_destroy,
+};
+
+static void rfc7329_outgoing_request_out_of_dialog(struct ast_sip_endpoint *endpoint,
+	struct ast_sip_contact *contact, struct pjsip_tx_data *tdata)
+{
+	if (!rfc7329_option_enabled()) {
+		return;
+	}
+
+	if (!tdata) {
+		return;
+	}
+
+	add_session_id_header_from_call_id(tdata);
+}
+
+static struct ast_sip_supplement rfc7329_out_of_dialog_supplement = {
+	.outgoing_request = rfc7329_outgoing_request_out_of_dialog,
+};
+
+/* Ensure Session-ID on in-dialog requests (e.g., ACK) that bypass supplements. */
+static pj_status_t rfc7329_on_tx_request(pjsip_tx_data *tdata)
+{
+	pjsip_dialog *dlg;
+	struct ast_sip_session *session;
+	const char *session_id;
+
+	if (!rfc7329_option_enabled()) {
+		return PJ_SUCCESS;
+	}
+
+	if (!tdata || tdata->msg->type != PJSIP_REQUEST_MSG) {
+		return PJ_SUCCESS;
+	}
+
+	if (pjsip_msg_find_hdr_by_name(tdata->msg, &session_id_hdr_name, NULL)) {
+		return PJ_SUCCESS;
+	}
+
+	dlg = pjsip_tdata_get_dlg(tdata);
+	session = dlg ? ast_sip_dialog_get_session(dlg) : NULL;
+	if (session) {
+		/* Cover ACK and other in-dialog requests that bypass session supplements. */
+		session_id = get_stored_session_id(session);
+		if (!session_id) {
+			session_id = get_session_id(session, tdata->msg);
+		}
+		if (session_id) {
+			set_or_replace_session_id_header(tdata, session_id);
+			ao2_cleanup(session);
+			return PJ_SUCCESS;
+		}
+		ao2_cleanup(session);
+	}
+
+	add_session_id_header_from_call_id(tdata);
+	return PJ_SUCCESS;
+}
+
+static pj_bool_t rfc7329_on_rx_request(pjsip_rx_data *rdata)
+{
+	pjsip_transaction *tsx;
+	pjsip_dialog *dlg;
+	char *session_id;
+	pjsip_generic_string_hdr *hdr;
+	pjsip_cid_hdr *call_id;
+	char hex_id[33];
+
+	if (!rfc7329_option_enabled()) {
+		return PJ_FALSE;
+	}
+
+	if (!rdata) {
+		return PJ_FALSE;
+	}
+
+	dlg = pjsip_rdata_get_dlg(rdata);
+	if (dlg) {
+		return PJ_FALSE;
+	}
+
+	call_id = pjsip_msg_find_hdr(rdata->msg_info.msg, PJSIP_H_CALL_ID, NULL);
+	if (call_id && call_id->id.slen) {
+		hdr = pjsip_msg_find_hdr_by_name(rdata->msg_info.msg, &session_id_hdr_name, NULL);
+		if (hdr && hdr->hvalue.slen) {
+			char session_id_buf[64];
+			ast_copy_pj_str(session_id_buf, &hdr->hvalue, sizeof(session_id_buf));
+			rfc7329_store_callid_map(&call_id->id, session_id_buf);
+		} else {
+			hmac_sha1_128_hex((const unsigned char *) call_id->id.ptr, call_id->id.slen, hex_id);
+			rfc7329_store_callid_map(&call_id->id, hex_id);
+		}
+	}
+
+	tsx = pjsip_rdata_get_tsx(rdata);
+	if (!tsx) {
+		return PJ_FALSE;
+	}
+
+	if (ast_sip_mod_data_get(tsx->mod_data, rfc7329_tsx_module.id, RFC7329_MOD_DATA_SESSION_ID)) {
+		return PJ_FALSE;
+	}
+
+	session_id = build_session_id_from_msg(tsx->pool, rdata->msg_info.msg);
+	if (session_id) {
+		ast_sip_mod_data_set(tsx->pool, tsx->mod_data, rfc7329_tsx_module.id,
+			RFC7329_MOD_DATA_SESSION_ID, session_id);
+	}
+
+	return PJ_FALSE;
+}
+
+static void rfc7329_on_tsx_state(pjsip_transaction *tsx, pjsip_event *event)
+{
+	pjsip_tx_data *tdata;
+	pjsip_dialog *dlg;
+	const char *stored;
+	pjsip_rx_data *rdata;
+	pjsip_cid_hdr *call_id_hdr;
+	const char *mapped;
+
+	if (!rfc7329_option_enabled()) {
+		return;
+	}
+
+	if (!tsx || !event) {
+		return;
+	}
+
+	if (event->type != PJSIP_EVENT_TSX_STATE) {
+		return;
+	}
+
+	if (event->body.tsx_state.type == PJSIP_EVENT_RX_MSG) {
+		rdata = event->body.tsx_state.src.rdata;
+		if (!rdata || rdata->msg_info.msg->type != PJSIP_REQUEST_MSG) {
+			return;
+		}
+		dlg = pjsip_tsx_get_dlg(tsx);
+		if (dlg) {
+			return;
+		}
+
+		if (!ast_sip_mod_data_get(tsx->mod_data, rfc7329_tsx_module.id, RFC7329_MOD_DATA_SESSION_ID)) {
+			char *session_id = build_session_id_from_msg(tsx->pool, rdata->msg_info.msg);
+			if (session_id) {
+				ast_sip_mod_data_set(tsx->pool, tsx->mod_data, rfc7329_tsx_module.id,
+					RFC7329_MOD_DATA_SESSION_ID, session_id);
+			}
+		}
+		return;
+	}
+
+	if (event->body.tsx_state.type != PJSIP_EVENT_TX_MSG) {
+		return;
+	}
+
+	dlg = pjsip_tsx_get_dlg(tsx);
+	if (dlg) {
+		return;
+	}
+
+	tdata = event->body.tsx_state.src.tdata;
+	if (!tdata || tdata->msg->type != PJSIP_RESPONSE_MSG) {
+		return;
+	}
+
+	if (pjsip_msg_find_hdr_by_name(tdata->msg, &session_id_hdr_name, NULL)) {
+		return;
+	}
+
+	stored = ast_sip_mod_data_get(tsx->mod_data, rfc7329_tsx_module.id, RFC7329_MOD_DATA_SESSION_ID);
+	if (stored) {
+		set_or_replace_session_id_header(tdata, stored);
+		return;
+	}
+
+	call_id_hdr = pjsip_msg_find_hdr(tdata->msg, PJSIP_H_CALL_ID, NULL);
+	mapped = call_id_hdr ? rfc7329_find_callid_map(&call_id_hdr->id) : NULL;
+	if (mapped) {
+		set_or_replace_session_id_header(tdata, mapped);
+		if (tdata->msg->line.status.code >= 200) {
+			rfc7329_remove_callid_map(&call_id_hdr->id);
+		}
+		return;
+	}
+
+	add_session_id_header_from_call_id(tdata);
+}
+
+static pj_status_t rfc7329_on_tx_response(pjsip_tx_data *tdata)
+{
+	pjsip_cid_hdr *call_id_hdr;
+	const char *mapped;
+
+	if (!rfc7329_option_enabled()) {
+		return PJ_SUCCESS;
+	}
+
+	if (!tdata || tdata->msg->type != PJSIP_RESPONSE_MSG) {
+		return PJ_SUCCESS;
+	}
+
+	if (pjsip_msg_find_hdr_by_name(tdata->msg, &session_id_hdr_name, NULL)) {
+		return PJ_SUCCESS;
+	}
+
+	call_id_hdr = pjsip_msg_find_hdr(tdata->msg, PJSIP_H_CALL_ID, NULL);
+	mapped = call_id_hdr ? rfc7329_find_callid_map(&call_id_hdr->id) : NULL;
+	if (mapped) {
+		set_or_replace_session_id_header(tdata, mapped);
+		if (tdata->msg->line.status.code >= 200) {
+			rfc7329_remove_callid_map(&call_id_hdr->id);
+		}
+		return PJ_SUCCESS;
+	}
+
+	add_session_id_header_from_call_id(tdata);
+	return PJ_SUCCESS;
+}
+
+static pjsip_module rfc7329_tsx_module = {
+	.name = { "RFC7329 Session-ID TSX", 24 },
+	.id = -1,
+	.priority = PJSIP_MOD_PRIORITY_TSX_LAYER - 1,
+	.on_rx_request = rfc7329_on_rx_request,
+	.on_tx_request = rfc7329_on_tx_request,
+	.on_tx_response = rfc7329_on_tx_response,
+	.on_tsx_state = rfc7329_on_tsx_state,
+};
+
+static int load_module(void)
+{
+	if (!rfc7329_option_enabled()) {
+		rfc7329_active = 0;
+		return AST_MODULE_LOAD_SUCCESS;
+	}
+
+	if (rfc7329_activate()) {
+		return AST_MODULE_LOAD_DECLINE;
+	}
+	return AST_MODULE_LOAD_SUCCESS;
+}
+
+static int unload_module(void)
+{
+	rfc7329_deactivate();
+	return 0;
+}
+
+static int reload_module(void)
+{
+	ast_sorcery_reload_object(ast_sip_get_sorcery(), "global");
+
+	if (rfc7329_option_enabled() && !rfc7329_active) {
+		return rfc7329_activate();
+	}
+
+	if (!rfc7329_option_enabled() && rfc7329_active) {
+		rfc7329_deactivate();
+	}
+
+	return 0;
+}
+
+AST_MODULE_INFO(ASTERISK_GPL_KEY, AST_MODFLAG_LOAD_ORDER, "PJSIP RFC7329 Session-ID Support",
+	.support_level = AST_MODULE_SUPPORT_CORE,
+	.load = load_module,
+	.unload = unload_module,
+	.reload = reload_module,
+	.load_pri = AST_MODPRI_APP_DEPEND,
+	.requires = "res_pjsip,res_pjsip_session",
+);

--- a/res/res_pjsip_session.c
+++ b/res/res_pjsip_session.c
@@ -4416,6 +4416,18 @@ static void handle_session_begin(struct ast_sip_session *session)
 	}
 }
 
+/* Invoke supplements that rely on channel-backed state. */
+static void handle_session_channel_created(struct ast_sip_session *session)
+{
+	struct ast_sip_session_supplement *iter;
+
+	AST_LIST_TRAVERSE(&session->supplements, iter, next) {
+		if (iter->session_channel_created) {
+			iter->session_channel_created(session);
+		}
+	}
+}
+
 static void handle_session_destroy(struct ast_sip_session *session)
 {
 	struct ast_sip_session_supplement *iter;
@@ -4437,6 +4449,16 @@ static void handle_session_end(struct ast_sip_session *session)
 			iter->session_end(session);
 		}
 	}
+}
+
+void ast_sip_session_channel_created(struct ast_sip_session *session)
+{
+	if (!session) {
+		return;
+	}
+
+	/* Fan out channel-created notifications to supplements. */
+	handle_session_channel_created(session);
 }
 
 static void handle_incoming_response(struct ast_sip_session *session, pjsip_rx_data *rdata,


### PR DESCRIPTION
Introduce a new res_pjsip_rfc7329 module that generates, stores, and propagates RFC7329 Session-ID values for PJSIP requests and responses. Session-IDs are reused across call legs via linkedid mapping and are ensured for in-dialog requests that bypass supplements. A new session supplement callback is added to hook channel creation so linkedid-based state can be attached when the channel is available.
Session-ID handling is now controlled by pjsip.conf. The module loads but remains inactive unless [global] rfc7329_enable=yes is set. rfc7329_enable=no, or an empty [global] leaves behavior disabled. Module reload res_pjsip_rfc7329.so re-reads the config and activates/deactivates the logic live.
The change also integrates Session-ID into REFER handling by persisting the inbound Refer-To Session-ID and adding a Session-ID parameter to outgoing Refer-To URIs.
When enabled, attempts to add, update, or remove Session-ID with PJSIP_HEADER are blocked to preserve RFC7329 immutability.

UserNote: Enable RFC7329 by setting [global] rfc7329_enable=yes in pjsip.conf and reloading the module. When enabled, Session-ID propagation is enforced and PJSIP_HEADER cannot modify Session-ID. REFER processing preserves Session-ID in Refer-To when available. https://www.rfc-editor.org/rfc/rfc7329

UpgradeNote: Realtime users must apply the Alembic migration that adds `rfc7329_enable` to `ps_globals` (config DB) to keep the schema in sync with the new global option.