### PR TITLE
res_pjsip_session: Make sure NAT hook runs when packet is retransmitted for whatever reason.

### DIFF
--- a/res/res_pjsip_session.c
+++ b/res/res_pjsip_session.c
@@ -58,7 +58,6 @@
 #define SDP_HANDLER_BUCKETS 11
 
 #define MOD_DATA_ON_RESPONSE "on_response"
-#define MOD_DATA_NAT_HOOK "nat_hook"
 
 /* Most common case is one audio and one video stream */
 #define DEFAULT_NUM_SESSION_MEDIA 2
@@ -5494,8 +5493,6 @@ static pjsip_inv_callback inv_callback = {
 static void session_outgoing_nat_hook(pjsip_tx_data *tdata, struct ast_sip_transport *transport)
 {
 	RAII_VAR(struct ast_sip_transport_state *, transport_state, ast_sip_get_transport_state(ast_sorcery_object_get_id(transport)), ao2_cleanup);
-	struct ast_sip_nat_hook *hook = ast_sip_mod_data_get(
-		tdata->mod_data, session_module.id, MOD_DATA_NAT_HOOK);
 	pjsip_sdp_info *sdp_info;
 	pjmedia_sdp_session *sdp;
 	pjsip_dialog *dlg = pjsip_tdata_get_dlg(tdata);
@@ -5503,10 +5500,9 @@ static void session_outgoing_nat_hook(pjsip_tx_data *tdata, struct ast_sip_trans
 	int stream;
 
 	/*
-	 * If there's no transport_state or body, or the hook
-	 * has already been run, just return.
+	 * If there's no transport_state or body, just return.
 	 */
-	if (ast_strlen_zero(transport->external_media_address) || !transport_state || hook || !tdata->msg->body) {
+	if (ast_strlen_zero(transport->external_media_address) || !transport_state || !tdata->msg->body) {
 		return;
 	}
 
@@ -5557,8 +5553,6 @@ static void session_outgoing_nat_hook(pjsip_tx_data *tdata, struct ast_sip_trans
 		}
 	}
 
-	/* We purposely do this so that the hook will not be invoked multiple times, ie: if a retransmit occurs */
-	ast_sip_mod_data_set(tdata->pool, tdata->mod_data, session_module.id, MOD_DATA_NAT_HOOK, nat_hook);
 }
 
 #ifdef TEST_FRAMEWORK


### PR DESCRIPTION
This hook may not be necessary when we do a retransmit, but when there are two
INVITEs, one *initial* and one with auth digest, the second INVITE contains wrong (unmodified) media address
due to the commented line below.
The NAT hook needs to run due to filters potentially reverting previously modified packets.

Fixes: #449