### PR TITLE
res_pjsip_messaging: Remove Contact header from out-of-dialog MESSAGE as per RFC3428

### DIFF
--- a/res/res_pjsip_messaging.c
+++ b/res/res_pjsip_messaging.c
@@ -912,6 +912,7 @@ static int msg_send(void *data)
 		.body_text = ast_msg_get_body(mdata->msg)
 	};
 
+	pjsip_hdr *contact;
 	pjsip_tx_data *tdata;
 	RAII_VAR(char *, uri, NULL, ast_free);
 	RAII_VAR(struct ast_sip_endpoint *, endpoint, NULL, ao2_cleanup);
@@ -1023,7 +1024,11 @@ static int msg_send(void *data)
 	 * tdata.
 	 */
 	vars_to_headers(mdata->msg, tdata);
-
+	/* Remove Contact header fields as per RFC 3428*/
+	contact = pjsip_msg_find_hdr(tdata->msg, PJSIP_H_CONTACT, NULL);
+	if (contact) {
+		pj_list_erase(contact);
+	}
 	ast_debug(1, "Sending message to '%s' (via endpoint %s) from '%s'\n",
 		uri, ast_sorcery_object_get_id(endpoint), mdata->from);
 


### PR DESCRIPTION
According to RFC 3428 (Section 5), a Contact header is not required in a
MESSAGE request unless the sender wants to establish a session. This
patch ensures that the Contact header is removed from out-of-dialog
MESSAGE requests within res_pjsip_messaging.c.

Fixes: #1356