### PR TITLE
CEL: Introduce Advanced CEL custom mapping for performance.

### DIFF
--- a/cel/Makefile
+++ b/cel/Makefile
@@ -18,3 +18,9 @@ MENUSELECT_DESCRIPTION=Channel Event Logging
 all: _all
 
 include $(ASTTOPDIR)/Makefile.moddir_rules
+
+# Our build system only allows a source file to be included in one module
+# so cel_custom gets it and cel_sqlite3_custom just adds it as
+# a regular 'make' dependency.
+$(call MOD_ADD_C,cel_custom,custom_common.c)
+cel_sqlite3_custom.so: custom_common.o

--- a/cel/cel_custom.c
+++ b/cel/cel_custom.c
@@ -42,6 +42,10 @@
 #include "asterisk/lock.h"
 #include "asterisk/threadstorage.h"
 #include "asterisk/strings.h"
+#include "asterisk/vector.h"
+#include "asterisk/json.h"
+
+#include "custom_common.h"
 
 #define CONFIG "cel_custom.conf"
 
@@ -49,14 +53,6 @@ AST_THREADSTORAGE(custom_buf);
 
 static const char name[] = "cel-custom";
 
-struct cel_config {
-	AST_DECLARE_STRING_FIELDS(
-		AST_STRING_FIELD(filename);
-		AST_STRING_FIELD(format);
-	);
-	ast_mutex_t lock;
-	AST_RWLIST_ENTRY(cel_config) list;
-};
 
 #define CUSTOM_BACKEND_NAME "CEL Custom CSV Logging"
 
@@ -67,17 +63,178 @@ static void free_config(void)
 	struct cel_config *sink;
 
 	while ((sink = AST_RWLIST_REMOVE_HEAD(&sinks, list))) {
-		ast_mutex_destroy(&sink->lock);
-		ast_string_field_free_memory(sink);
-		ast_free(sink);
+		cel_free_sink(sink);
 	}
+}
+
+static int load_basic_config(struct ast_category *category, int *mappings)
+{
+	struct ast_variable *var = NULL;
+	struct cel_config *sink = NULL;
+	int res = 0;
+
+	for (var = ast_category_first(category); var; var = var->next) {
+		if (ast_strlen_zero(var->name) || ast_strlen_zero(var->value)) {
+			ast_log(LOG_WARNING, "CEL Mapping must have both a filename and a template at line %d\n", var->lineno);
+			continue;
+		}
+		sink = ast_calloc_with_stringfields(1, struct cel_config, 1024);
+		if (!sink) {
+			return -2;
+		}
+		sink->sink_type = cel_sink_legacy;
+		res = ast_string_field_build(sink, template, "%s\n", var->value);
+		if (res != 0) {
+			cel_free_sink(sink);
+			return -2;
+		}
+		if (var->name[0] == '/') {
+			res = ast_string_field_build(sink, filename, "%s", var->name);
+		} else {
+			res = ast_string_field_build(sink, filename, "%s/%s/%s", ast_config_AST_LOG_DIR, name, var->name);
+		}
+		if (res != 0) {
+			cel_free_sink(sink);
+			return -2;
+		}
+		ast_mutex_init(&sink->lock);
+		ast_verb(3, "Added CEL basic CSV mapping for '%s'.\n", sink->filename);
+		AST_RWLIST_INSERT_TAIL(&sinks, sink, list);
+		(*mappings)++;
+		sink = NULL;
+	}
+
+	return 0;
+}
+
+
+static int load_advanced_config(struct ast_category *category, int *mappings)
+{
+	const char *category_name = ast_category_get_name(category);
+	struct cel_config *sink = NULL;
+	const char *value;
+	int res = 0;
+
+	char *fields = NULL;
+	char *field = NULL;
+
+	ast_debug(2, "Processing CEL file '%s'\n", category_name);
+	sink = ast_calloc_with_stringfields(1, struct cel_config, 512);
+	if (!sink) {
+		ast_log(LOG_ERROR, "Unable to allocate memory for configuration settings.\n");
+		return -2;
+	}
+	sink->sink_type = cel_sink_advanced;
+	if (category_name[0] == '/') {
+		res = ast_string_field_build(sink, filename, "%s", category_name);
+	} else {
+		res = ast_string_field_build(sink, filename, "%s/%s/%s", ast_config_AST_LOG_DIR, name, category_name);
+	}
+	if (res != 0) {
+		cel_free_sink(sink);
+		return -2;
+	}
+	sink->format_type = cel_format_csv;
+	strcpy(sink->separator, ","); /* Safe */
+	strcpy(sink->quote, "\""); /* Safe */
+	strcpy(sink->quote_escape, sink->quote); /* Safe */
+	sink->quoting_method = cel_quoting_method_all;
+
+	value = ast_variable_find(category, "format");
+	if (!ast_strlen_zero(value)) {
+		if (ast_strings_equal(value, "json")) {
+			sink->format_type = cel_format_json;
+		} else if (ast_strings_equal(value, "csv")) {
+			sink->format_type = cel_format_csv;
+		} else {
+			ast_log(LOG_WARNING, "Custom CEL destination '%s' has invalid format '%s'\n",
+				sink->filename, value);
+			cel_free_sink(sink);
+			return -1;
+		}
+	}
+	ast_debug(2, "%s: format: %s\n", category_name, S_OR(value, "csv"));
+
+	value = ast_variable_find(category, "separator_character");
+	if (!ast_strlen_zero(value)) {
+		ast_copy_string(sink->separator, ast_unescape_c(ast_strdupa(value)), 2);
+	}
+	ast_debug(2, "%s: separator: %s\n", category_name, sink->separator);
+
+	value = ast_variable_find(category, "quote_character");
+	if (!ast_strlen_zero(value)) {
+		ast_copy_string(sink->quote, value, 2);
+	}
+	ast_debug(2, "%s: quote: %s\n", category_name, sink->quote);
+
+	value = ast_variable_find(category, "quote_escape_character");
+	if (!ast_strlen_zero(value)) {
+		ast_copy_string(sink->quote_escape, value, 2);
+	}
+	ast_debug(2, "%s: quote_escape: %s\n", category_name, sink->quote_escape);
+
+	value = ast_variable_find(category, "quoting_method");
+	if (!ast_strlen_zero(value)) {
+		if (ast_strings_equal(value, "all")) {
+			sink->quoting_method = cel_quoting_method_all;
+		} else if (ast_strings_equal(value, "minimal")) {
+			sink->quoting_method = cel_quoting_method_minimal;
+		} else if (ast_strings_equal(value, "non_numeric")) {
+			sink->quoting_method = cel_quoting_method_non_numeric;
+		} else if (ast_strings_equal(value, "none")) {
+			sink->quoting_method = cel_quoting_method_none;
+		} else {
+			ast_log(LOG_WARNING, "Custom CEL destination '%s' has invalid quoting method '%s'\n",
+				sink->filename, value);
+			cel_free_sink(sink);
+			return -1;
+		}
+	}
+	ast_debug(2, "%s: quoting_method: %s\n", category_name, S_OR(value, "all"));
+
+	value = ast_variable_find(category, "fields");
+	if (ast_strlen_zero(value)) {
+		ast_log(LOG_WARNING, "Custom CEL destination '%s' 'fields' parameter is missing or empty\n",
+			sink->filename);
+		cel_free_sink(sink);
+		return -1;
+	}
+	fields = ast_strdupa(value);
+
+	if (AST_VECTOR_INIT(&sink->fields, 20) != 0) {
+		cel_free_sink(sink);
+		return -2;
+	}
+
+	while((field = ast_strsep_quoted(&fields, ',', '"', AST_STRSEP_ALL))) {
+		struct cel_field *cel_field = cel_field_alloc(field, sink->format_type, category_name);
+
+		if (!cel_field) {
+			ast_log(LOG_WARNING, "nf: %s\n", field);
+			continue;
+		}
+
+		res = AST_VECTOR_APPEND(&sink->fields, cel_field);
+		if (res != 0) {
+			cel_free_sink(sink);
+			return -1;
+		}
+	}
+	ast_debug(2, "fields: %d\n", (int) AST_VECTOR_SIZE(&sink->fields));
+
+	ast_mutex_init(&sink->lock);
+	ast_verb(3, "Added CEL advanced CSV mapping for '%s'.\n", sink->filename);
+	AST_RWLIST_INSERT_TAIL(&sinks, sink, list);
+	(*mappings)++;
+	return 0;
 }
 
 static int load_config(void)
 {
 	struct ast_config *cfg;
-	struct ast_variable *var;
 	struct ast_flags config_flags = { 0 };
+	struct ast_category *category = NULL;
+
 	int mappings = 0;
 	int res = 0;
 
@@ -87,36 +244,16 @@ static int load_config(void)
 		return -1;
 	}
 
-	if (!(var = ast_variable_browse(cfg, "mappings"))) {
-		ast_log(LOG_NOTICE, "No mappings found in " CONFIG ". Not logging CEL to custom CSVs.\n");
-	}
+	while ((category = ast_category_browse_filtered(cfg, NULL, category, NULL))) {
+		const char *category_name = ast_category_get_name(category);
 
-	while (var) {
-		if (!ast_strlen_zero(var->name) && !ast_strlen_zero(var->value)) {
-			struct cel_config *sink = ast_calloc_with_stringfields(1, struct cel_config, 1024);
-
-			if (!sink) {
-				ast_log(LOG_ERROR, "Unable to allocate memory for configuration settings.\n");
-				res = -2;
-				break;
-			}
-
-			ast_string_field_build(sink, format, "%s\n", var->value);
-			if (var->name[0] == '/') {
-				ast_string_field_build(sink, filename, "%s", var->name);
-			} else {
-				ast_string_field_build(sink, filename, "%s/%s/%s", ast_config_AST_LOG_DIR, name, var->name);
-			}
-			ast_mutex_init(&sink->lock);
-
-			ast_verb(3, "Added CEL CSV mapping for '%s'.\n", sink->filename);
-			mappings += 1;
-			AST_RWLIST_INSERT_TAIL(&sinks, sink, list);
+		if (ast_strings_equal(category_name, "mappings")) {
+			res += load_basic_config(category, &mappings);
 		} else {
-			ast_log(LOG_NOTICE, "Mapping must have both a filename and a format at line %d\n", var->lineno);
+			res += load_advanced_config(category, &mappings);
 		}
-		var = var->next;
 	}
+
 	ast_config_destroy(cfg);
 
 	ast_verb(1, "Added CEL CSV mapping for %d files.\n", mappings);
@@ -124,53 +261,119 @@ static int load_config(void)
 	return res;
 }
 
-static void custom_log(struct ast_event *event)
+static void custom_log_basic(struct ast_event *event, struct cel_config *config,
+	struct ast_channel *dummy)
 {
-	struct ast_channel *dummy;
 	struct ast_str *str;
-	struct cel_config *config;
+	FILE *out;
 
 	/* Batching saves memory management here.  Otherwise, it's the same as doing an allocation and free each time. */
 	if (!(str = ast_str_thread_get(&custom_buf, 16))) {
 		return;
 	}
 
-	dummy = ast_cel_fabricate_channel_from_event(event);
-	if (!dummy) {
-		ast_log(LOG_ERROR, "Unable to fabricate channel from CEL event.\n");
-		return;
+	ast_str_substitute_variables(&str, 0, dummy, config->template);
+
+	/* Even though we have a lock on the list, we could be being chased by
+	   another thread and this lock ensures that we won't step on anyone's
+	   toes.  Once each CEL backend gets it's own thread, this lock can be
+	   removed. */
+	ast_mutex_lock(&config->lock);
+
+	/* Because of the absolutely unconditional need for the
+	   highest reliability possible in writing billing records,
+	   we open write and close the log file each time */
+	if ((out = fopen(config->filename, "a"))) {
+		fputs(ast_str_buffer(str), out);
+		fflush(out); /* be particularly anal here */
+		fclose(out);
+	} else {
+		ast_log(LOG_ERROR, "Unable to re-open master file %s : %s\n", config->filename, strerror(errno));
 	}
+
+	ast_mutex_unlock(&config->lock);
+}
+
+static void custom_log_advanced(struct ast_event *event, struct cel_config *config)
+{
+	int ix = 0;
+	struct ast_str *str;
+	RAII_VAR(struct ast_json *, json, NULL, ast_json_unref);
+	FILE *out;
+
+	if (config->format_type == cel_format_csv) {
+		if (!(str = ast_str_thread_get(&custom_buf, 512))) {
+			return;
+		}
+		ast_str_reset(str);
+	} else {
+		if (!(json = ast_json_object_create())) {
+			return;
+		}
+	}
+
+	for (ix = 0; ix < AST_VECTOR_SIZE(&config->fields); ix++) {
+		struct cel_field *cel_field = AST_VECTOR_GET(&config->fields, ix);
+		if (config->format_type == cel_format_csv) {
+			cel_field->csv_field_appender(&str, event, config, cel_field, ix == 0);
+		} else {
+			cel_field->json_field_appender(json, event, config, cel_field, ix == 0);
+		}
+	}
+
+	ast_mutex_lock(&config->lock);
+	/* Because of the absolutely unconditional need for the
+	   highest reliability possible in writing billing records,
+	   we open write and close the log file each time */
+	if ((out = fopen(config->filename, "a"))) {
+		if (config->format_type == cel_format_csv) {
+			ast_str_append(&str, 0, "\n");
+			fputs(ast_str_buffer(str), out);
+		} else {
+			ast_json_dump_file_format(json, out, AST_JSON_COMPACT);
+			fputs("\n", out);
+		}
+		fflush(out); /* be particularly anal here */
+		fclose(out);
+	} else {
+		ast_log(LOG_ERROR, "Unable to open CEL file %s : %s\n", config->filename, strerror(errno));
+	}
+	ast_mutex_unlock(&config->lock);
+}
+
+
+static void custom_log(struct ast_event *event)
+{
+	struct cel_config *config = NULL;
+	struct ast_channel *dummy = NULL;
+	int skip_basic = 0;
 
 	AST_RWLIST_RDLOCK(&sinks);
 
 	AST_LIST_TRAVERSE(&sinks, config, list) {
-		FILE *out;
-
-		ast_str_substitute_variables(&str, 0, dummy, config->format);
-
-		/* Even though we have a lock on the list, we could be being chased by
-		   another thread and this lock ensures that we won't step on anyone's
-		   toes.  Once each CEL backend gets it's own thread, this lock can be
-		   removed. */
-		ast_mutex_lock(&config->lock);
-
-		/* Because of the absolutely unconditional need for the
-		   highest reliability possible in writing billing records,
-		   we open write and close the log file each time */
-		if ((out = fopen(config->filename, "a"))) {
-			fputs(ast_str_buffer(str), out);
-			fflush(out); /* be particularly anal here */
-			fclose(out);
+		if (config->sink_type == cel_sink_legacy) {
+			if (skip_basic) {
+				continue;
+			}
+			if (!dummy) {
+				dummy = ast_cel_fabricate_channel_from_event(event);
+				if (!dummy) {
+					ast_log(LOG_ERROR, "Unable to fabricate channel from CEL event for '%s'\n",
+						config->filename);
+					skip_basic = 1;
+				}
+			}
+			custom_log_basic(event, config, dummy);
 		} else {
-			ast_log(LOG_ERROR, "Unable to re-open master file %s : %s\n", config->filename, strerror(errno));
+			custom_log_advanced(event, config);
 		}
-
-		ast_mutex_unlock(&config->lock);
 	}
 
 	AST_RWLIST_UNLOCK(&sinks);
 
-	ast_channel_unref(dummy);
+	if (dummy) {
+		ast_channel_unref(dummy);
+	}
 }
 
 static int unload_module(void)
@@ -189,13 +392,18 @@ static int unload_module(void)
 
 static enum ast_module_load_result load_module(void)
 {
+	int res = 0;
 	if (AST_RWLIST_WRLOCK(&sinks)) {
 		ast_log(LOG_ERROR, "Unable to lock sink list.  Load failed.\n");
 		return AST_MODULE_LOAD_DECLINE;
 	}
 
-	load_config();
+	res = load_config();
 	AST_RWLIST_UNLOCK(&sinks);
+	if  (res != 0) {
+		free_config();
+		return AST_MODULE_LOAD_DECLINE;
+	}
 
 	if (ast_cel_backend_register(CUSTOM_BACKEND_NAME, custom_log)) {
 		free_config();
@@ -206,13 +414,19 @@ static enum ast_module_load_result load_module(void)
 
 static int reload(void)
 {
+	int res = 0;
 	if (AST_RWLIST_WRLOCK(&sinks)) {
 		ast_log(LOG_ERROR, "Unable to lock sink list.  Load failed.\n");
 		return AST_MODULE_LOAD_DECLINE;
 	}
 
 	free_config();
-	load_config();
+	res = load_config();
+	if  (res != 0) {
+		free_config();
+		return AST_MODULE_LOAD_DECLINE;
+	}
+
 	AST_RWLIST_UNLOCK(&sinks);
 	return AST_MODULE_LOAD_SUCCESS;
 }

--- a/cel/custom_common.c
+++ b/cel/custom_common.c
@@ -1,0 +1,296 @@
+/*
+ * Asterisk -- An open source telephony toolkit.
+ *
+ * Copyright (C) 2026, Sangoma Technologies Corporation
+ *
+ * George Joseph <gjoseph@sangoma.com>
+ *
+ * See http://www.asterisk.org for more information about
+ * the Asterisk project. Please do not directly contact
+ * any of the maintainers of this project for assistance;
+ * the project provides a web site, mailing lists and IRC
+ * channels for your use.
+ *
+ * This program is free software, distributed under the terms of
+ * the GNU General Public License Version 2. See the LICENSE file
+ * at the top of the source tree.
+ */
+
+#include "asterisk.h"
+
+#include "asterisk/strings.h"
+#include "asterisk/vector.h"
+#include "asterisk/lock.h"
+#include "asterisk/json.h"
+#include "asterisk/module.h"
+#include "asterisk/utils.h"
+#include "asterisk/cel.h"
+
+#include "custom_common.h"
+
+static char *quoter(const char *value, char quote, char quote_escape)
+{
+	char *bufptr = ast_malloc((strlen(value) * 2) + 1);
+	char *ptr = bufptr;
+	const char *dataptr = value;
+
+	if (!bufptr) {
+		return NULL;
+	}
+
+	while(*dataptr != '\0') {
+		if (*dataptr == quote) {
+			*bufptr++ = quote_escape;
+		}
+		*bufptr++ = *dataptr++;
+	}
+	*bufptr='\0';
+	return ptr;
+}
+
+static int csv_append_string(struct ast_str **str, int is_first, const char *value, struct cel_config *config)
+{
+	int res = 0;
+	char *sep_str = is_first ? "" : config->separator;
+
+	if (config->quoting_method == cel_quoting_method_all || config->quoting_method == cel_quoting_method_non_numeric) {
+		char *evalue = (char *)value;
+		if (strchr(value, config->quote[0])) {
+			evalue = quoter(value, config->quote[0], config->quote_escape[0]);
+		}
+		res = ast_str_append(str, 0, "%s%s%s%s", sep_str, config->quote, S_OR(evalue, ""), config->quote);
+		if (evalue != value) {
+			ast_free(evalue);
+		}
+	} else if (config->quoting_method == cel_quoting_method_minimal) {
+		if (strchr(value, config->separator[0])) {
+			char *evalue = (char *)value;
+			if (strchr(value, config->quote[0])) {
+				evalue = quoter(value, config->quote[0], config->quote_escape[0]);
+			}
+			res = ast_str_append(str, 0, "%s%s%s%s", sep_str, config->quote, S_OR(evalue, ""), config->quote);
+			if (evalue != value) {
+				ast_free(evalue);
+			}
+		} else {
+			res = ast_str_append(str, 0, "%s%s", sep_str, value);
+		}
+	} else {
+		res = ast_str_append(str, 0, "%s%s", sep_str, value);
+	}
+	return res;
+}
+
+static int csv_append_uint(struct ast_str **str, int is_first, uint32_t value, struct cel_config *config)
+{
+	int res = 0;
+	char *sep_str = is_first ? "" : config->separator;
+
+	if (config->quoting_method == cel_quoting_method_all) {
+		res = ast_str_append(str, 0, "%s%s%u%s", sep_str, config->quote, value, config->quote);
+	} else {
+		res = ast_str_append(str, 0, "%s%d", sep_str, value);
+	}
+	return res;
+}
+
+static char *get_event_time(struct ast_event *event)
+{
+	char timebuf[32];
+	struct timeval tv = {
+		.tv_sec = ast_event_get_ie_uint(event, AST_EVENT_IE_CEL_EVENT_TIME),
+		.tv_usec = ast_event_get_ie_uint(event, AST_EVENT_IE_CEL_EVENT_TIME_USEC)
+	};
+	ast_cel_format_eventtime(tv, timebuf, sizeof(timebuf));
+	return ast_strdup(timebuf);
+}
+
+const static char *get_event_type(struct ast_event *event, int explicit)
+{
+	const char *value = NULL;
+	if (explicit || ast_event_get_ie_uint(event, AST_EVENT_IE_CEL_EVENT_TYPE) != AST_CEL_USER_DEFINED) {
+		value = ast_cel_get_type_name(ast_event_get_ie_uint(event, AST_EVENT_IE_CEL_EVENT_TYPE));
+	} else {
+		value = ast_event_get_ie_str(event, AST_EVENT_IE_CEL_USEREVENT_NAME);
+	}
+	return value;
+}
+
+static void append_csv_event_string(struct ast_str **str, struct ast_event *event, struct cel_config *config,
+	struct cel_field *cel_field, int is_first)
+{
+	const char *value = ast_event_get_ie_str(event, cel_field->ie_type);
+	csv_append_string(str, is_first, value, config);
+}
+
+static void append_csv_event_time(struct ast_str **str, struct ast_event *event, struct cel_config *config,
+	struct cel_field *cel_field, int is_first)
+{
+	char *value = get_event_time(event);
+	csv_append_string(str, is_first, value, config);
+	ast_free(value);
+}
+
+static void append_csv_event_type(struct ast_str **str, struct ast_event *event, struct cel_config *config,
+	struct cel_field *cel_field, int is_first)
+{
+	const char *value = get_event_type(event, 0);
+	csv_append_string(str, is_first, value, config);
+}
+
+static void append_csv_event_enum(struct ast_str **str, struct ast_event *event, struct cel_config *config,
+	struct cel_field *cel_field, int is_first)
+{
+	const char *value = get_event_type(event, 1);
+	csv_append_string(str, is_first, value, config);
+}
+
+static void append_csv_literal(struct ast_str **str, struct ast_event *event, struct cel_config *config,
+	struct cel_field *cel_field, int is_first)
+{
+	csv_append_string(str, is_first, cel_field->literal_data, config);
+}
+
+static void append_csv_event_uint(struct ast_str **str, struct ast_event *event, struct cel_config *config,
+	struct cel_field *cel_field, int is_first)
+{
+	csv_append_uint(str, is_first, ast_event_get_ie_uint(event, cel_field->ie_type), config);
+}
+
+/* JSON */
+
+static void append_json_event_string(struct ast_json *json, struct ast_event *event, struct cel_config *config,
+	struct cel_field *cel_field, int is_first)
+{
+	const char *value = ast_event_get_ie_str(event, cel_field->ie_type);
+	ast_json_object_set(json, cel_field->name, ast_json_string_create(value));
+}
+
+static void append_json_event_time(struct ast_json *json, struct ast_event *event, struct cel_config *config,
+	struct cel_field *cel_field, int is_first)
+{
+	char *value = get_event_time(event);
+	ast_json_object_set(json, cel_field->name, ast_json_string_create(value));
+	ast_free(value);
+}
+
+static void append_json_event_type(struct ast_json *json, struct ast_event *event, struct cel_config *config,
+	struct cel_field *cel_field, int is_first)
+{
+	const char *value = get_event_type(event, 0);
+	ast_json_object_set(json, cel_field->name, ast_json_string_create(value));
+}
+
+static void append_json_event_enum(struct ast_json *json, struct ast_event *event, struct cel_config *config,
+	struct cel_field *cel_field, int is_first)
+{
+	const char *value = get_event_type(event, 1);
+	ast_json_object_set(json, cel_field->name, ast_json_string_create(value));
+}
+
+static void append_json_literal(struct ast_json *json, struct ast_event *event, struct cel_config *config,
+	struct cel_field *cel_field, int is_first)
+{
+	char *field_name = ast_strdupa(cel_field->literal_data);
+	char *sep = strchr(field_name, ':');
+	if (sep) {
+		*sep = '\0';
+		sep++;
+		ast_json_object_set(json, ast_strip(field_name), ast_json_string_create(ast_strip(sep)));
+	}
+}
+
+static void append_json_event_uint(struct ast_json *json, struct ast_event *event, struct cel_config *config,
+	struct cel_field *cel_field, int is_first)
+{
+	ast_json_object_set(json, cel_field->name, ast_json_integer_create(ast_event_get_ie_uint(event, cel_field->ie_type)));
+}
+
+
+static const struct cel_field cel_field_registry[] = {
+	{AST_EVENT_IE_CEL_EVENT_ENUM, AST_EVENT_IE_PLTYPE_UINT, append_csv_event_enum, append_json_event_enum, "EventEnum", 0 },
+	{AST_EVENT_IE_CEL_EVENT_TYPE, AST_EVENT_IE_PLTYPE_UINT, append_csv_event_type, append_json_event_type, "EventType", 0 },
+	{AST_EVENT_IE_CEL_EVENT_TIME, AST_EVENT_IE_PLTYPE_UINT, append_csv_event_time, append_json_event_time, "EventTime", 0 },
+	{AST_EVENT_IE_CEL_EVENT_TIME_USEC, AST_EVENT_IE_PLTYPE_UINT, append_csv_event_uint, append_json_event_uint, "EventTimeUSec", 0 },
+	{AST_EVENT_IE_CEL_USEREVENT_NAME, AST_EVENT_IE_PLTYPE_STR, append_csv_event_string, append_json_event_string,  "UserEventName", 0 },
+	{AST_EVENT_IE_CEL_USEREVENT_NAME, AST_EVENT_IE_PLTYPE_STR, append_csv_event_string, append_json_event_string,  "UserDefType", 0 },
+	{AST_EVENT_IE_CEL_CIDNAME, AST_EVENT_IE_PLTYPE_STR, append_csv_event_string, append_json_event_string,  "CIDName", 0 },
+	{AST_EVENT_IE_CEL_CIDNUM, AST_EVENT_IE_PLTYPE_STR, append_csv_event_string, append_json_event_string,  "CIDNum", 0 },
+	{AST_EVENT_IE_CEL_EXTEN, AST_EVENT_IE_PLTYPE_STR, append_csv_event_string, append_json_event_string,  "Exten", 0 },
+	{AST_EVENT_IE_CEL_CONTEXT, AST_EVENT_IE_PLTYPE_STR, append_csv_event_string, append_json_event_string,  "Context", 0 },
+	{AST_EVENT_IE_CEL_CHANNAME, AST_EVENT_IE_PLTYPE_STR, append_csv_event_string, append_json_event_string,  "ChanName", 0 },
+	{AST_EVENT_IE_CEL_APPNAME, AST_EVENT_IE_PLTYPE_STR, append_csv_event_string, append_json_event_string,  "AppName", 0 },
+	{AST_EVENT_IE_CEL_APPDATA, AST_EVENT_IE_PLTYPE_STR, append_csv_event_string, append_json_event_string,  "AppData", 0 },
+	{AST_EVENT_IE_CEL_AMAFLAGS, AST_EVENT_IE_PLTYPE_UINT, append_csv_event_uint, append_json_event_uint, "AMAFlags", 0 },
+	{AST_EVENT_IE_CEL_ACCTCODE, AST_EVENT_IE_PLTYPE_STR, append_csv_event_string, append_json_event_string,  "AcctCode", 0 },
+	{AST_EVENT_IE_CEL_UNIQUEID, AST_EVENT_IE_PLTYPE_STR, append_csv_event_string, append_json_event_string,  "UniqueID", 0 },
+	{AST_EVENT_IE_CEL_USERFIELD, AST_EVENT_IE_PLTYPE_STR, append_csv_event_string, append_json_event_string,  "UserField", 0 },
+	{AST_EVENT_IE_CEL_CIDANI, AST_EVENT_IE_PLTYPE_STR, append_csv_event_string, append_json_event_string,  "CIDani", 0 },
+	{AST_EVENT_IE_CEL_CIDRDNIS, AST_EVENT_IE_PLTYPE_STR, append_csv_event_string, append_json_event_string,  "CIDrdnis", 0 },
+	{AST_EVENT_IE_CEL_CIDDNID, AST_EVENT_IE_PLTYPE_STR, append_csv_event_string, append_json_event_string,  "CIDdnid", 0 },
+	{AST_EVENT_IE_CEL_PEER, AST_EVENT_IE_PLTYPE_STR, append_csv_event_string, append_json_event_string,  "Peer", 0 },
+	{AST_EVENT_IE_CEL_PEER, AST_EVENT_IE_PLTYPE_STR, append_csv_event_string, append_json_event_string,  "BridgePeer", 0 },
+	{AST_EVENT_IE_CEL_LINKEDID, AST_EVENT_IE_PLTYPE_STR, append_csv_event_string, append_json_event_string,  "LinkedID", 0 },
+	{AST_EVENT_IE_CEL_PEERACCT, AST_EVENT_IE_PLTYPE_STR, append_csv_event_string, append_json_event_string,  "PeerAcct", 0 },
+	{AST_EVENT_IE_CEL_EXTRA, AST_EVENT_IE_PLTYPE_STR, append_csv_event_string, append_json_event_string,  "Extra", 0 },
+	{AST_EVENT_IE_CEL_EXTRA, AST_EVENT_IE_PLTYPE_STR, append_csv_event_string, append_json_event_string,  "EventExtra", 0 },
+	{AST_EVENT_IE_CEL_TENANTID, AST_EVENT_IE_PLTYPE_STR, append_csv_event_string, append_json_event_string,  "TenantID", 0 },
+	{AST_EVENT_IE_CEL_LITERAL, AST_EVENT_IE_PLTYPE_STR, append_csv_literal, append_json_literal,  "_LITERAL", 1 },
+};
+
+static const struct cel_field *get_registered_field_by_name(const char *name)
+{
+	int ix = 0;
+
+	for (ix = 0; ix < ARRAY_LEN(cel_field_registry); ix++) {
+		if (strcasecmp(cel_field_registry[ix].name, name) == 0) {
+			return &cel_field_registry[ix];
+		}
+	}
+	return NULL;
+}
+
+struct cel_field *cel_field_alloc(const char *field, enum cel_format_type format_type,
+	const char *filename)
+{
+	const struct cel_field *cel_field = NULL;
+	struct cel_field *rtn = NULL;
+
+	cel_field = get_registered_field_by_name(field);
+	if (cel_field) {
+		ast_debug(2, "%s: CEL event '%s' found\n", filename, field);
+		return (struct cel_field *)cel_field;
+	}
+
+	if (format_type == cel_format_json && !strchr(field, ':')) {
+		ast_log(LOG_WARNING, "%s: Literal field '%s' must be formatted as \"name: value\" when using the 'json' format\n",
+			filename, field);
+		return NULL;
+	}
+
+	cel_field = get_registered_field_by_name("_LITERAL");
+	rtn = ast_calloc(1, sizeof(*cel_field) + strlen(field) + 1);
+	if (!rtn) {
+		return NULL;
+	}
+	memcpy(rtn, cel_field, sizeof(*cel_field));
+	strcpy(rtn->literal_data, field); /* Safe */
+
+	ast_debug(2, "%s: Literal field '%s' found\n", filename, field);
+	return rtn;
+}
+
+static void free_field(struct cel_field *f) {
+	if (f->mallocd) {
+		ast_free(f);
+	}
+}
+
+void cel_free_sink(struct cel_config *sink)
+{
+	ast_mutex_destroy(&sink->lock);
+	ast_string_field_free_memory(sink);
+	AST_VECTOR_RESET(&sink->fields, free_field);
+	AST_VECTOR_FREE(&sink->fields);
+	ast_free(sink);
+}

--- a/cel/custom_common.h
+++ b/cel/custom_common.h
@@ -1,0 +1,86 @@
+/*
+ * Asterisk -- An open source telephony toolkit.
+ *
+ * Copyright (C) 2026, Sangoma Technologies Corporation
+ *
+ * George Joseph <gjoseph@sangoma.com>
+ *
+ * See http://www.asterisk.org for more information about
+ * the Asterisk project. Please do not directly contact
+ * any of the maintainers of this project for assistance;
+ * the project provides a web site, mailing lists and IRC
+ * channels for your use.
+ *
+ * This program is free software, distributed under the terms of
+ * the GNU General Public License Version 2. See the LICENSE file
+ * at the top of the source tree.
+ */
+
+#ifndef _CUSTOM_COMMON_H
+#define _CUSTOM_COMMON_H
+
+#include "asterisk/lock.h"
+#include "asterisk/strings.h"
+#include "asterisk/vector.h"
+
+enum cel_format_type {
+	cel_format_csv = 0,
+	cel_format_json,
+	cel_format_sql
+};
+
+enum cel_sink_type {
+	cel_sink_legacy = 0,
+	cel_sink_advanced,
+};
+
+enum cel_quoting_method {
+	cel_quoting_method_none = 0,
+	cel_quoting_method_all,
+	cel_quoting_method_minimal,
+	cel_quoting_method_non_numeric,
+};
+
+struct cel_config;
+struct cel_field;
+
+typedef void (*cel_csv_field_appender)(struct ast_str **str, struct ast_event *event, struct cel_config *config,
+	struct cel_field *cel_field, int is_first);
+
+typedef void (*cel_json_field_appender)(struct ast_json *, struct ast_event *event, struct cel_config *config,
+	struct cel_field *cel_field, int is_first);
+
+struct cel_field {
+	enum ast_event_ie_type ie_type;
+	enum ast_event_ie_pltype ie_pltype;
+	cel_csv_field_appender csv_field_appender;
+	cel_json_field_appender json_field_appender;
+	const char *name;
+	int mallocd;
+	char literal_data[0];
+};
+
+struct cel_config {
+	AST_DECLARE_STRING_FIELDS(
+		AST_STRING_FIELD(filename);
+		AST_STRING_FIELD(template);
+	);
+	enum cel_sink_type sink_type;
+	enum cel_format_type format_type;
+	enum cel_quoting_method quoting_method;
+	char separator[2];
+	char quote[2];
+	char quote_escape[2];
+	AST_VECTOR(, struct cel_field *) fields;
+	ast_mutex_t lock;
+	AST_RWLIST_ENTRY(cel_config) list;
+};
+
+#define AST_EVENT_IE_CEL_LITERAL (AST_EVENT_IE_TOTAL + 1)
+#define AST_EVENT_IE_CEL_EVENT_ENUM (AST_EVENT_IE_TOTAL + 2)
+
+struct cel_field *cel_field_alloc(const char *field, enum cel_format_type format_type,
+	const char *filename);
+void cel_free_sink(struct cel_config *sink);
+
+#endif /* _CUSTOM_COMMON_H */

--- a/configs/samples/cel_custom.conf.sample
+++ b/configs/samples/cel_custom.conf.sample
@@ -23,7 +23,13 @@
 ;
 
 ;
-; Within a mapping, use the CALLERID() and CHANNEL() functions to retrieve
+; Legacy Mappings
+;
+; Legacy mappings are VERY resource intensive.  In fact, they use
+; more resources to write the log entries than were used to actually
+; process the call.  Use the advanced mappings below going forward.
+;
+; Within a legacy mapping, use the CALLERID() and CHANNEL() functions to retrieve
 ; details from the CEL event.  There are also a few variables created by this
 ; module that can be used in a mapping:
 ;
@@ -37,4 +43,100 @@
 ;                  CHANNEL(peer) could also be used.
 ;
 [mappings]
-;Master.csv => ${CSV_QUOTE(${eventtype})},${CSV_QUOTE(${eventtime})},${CSV_QUOTE(${CALLERID(name)})},${CSV_QUOTE(${CALLERID(num)})},${CSV_QUOTE(${CALLERID(ANI)})},${CSV_QUOTE(${CALLERID(RDNIS)})},${CSV_QUOTE(${CALLERID(DNID)})},${CSV_QUOTE(${CHANNEL(exten)})},${CSV_QUOTE(${CHANNEL(context)})},${CSV_QUOTE(${CHANNEL(channame)})},${CSV_QUOTE(${CHANNEL(appname)})},${CSV_QUOTE(${CHANNEL(appdata)})},${CSV_QUOTE(${CHANNEL(amaflags)})},${CSV_QUOTE(${CHANNEL(accountcode)})},${CSV_QUOTE(${CHANNEL(uniqueid)})},${CSV_QUOTE(${CHANNEL(linkedid)})},${CSV_QUOTE(${BRIDGEPEER})},${CSV_QUOTE(${CHANNEL(userfield)})},${CSV_QUOTE(${userdeftype})},${CSV_QUOTE(${eventextra})}
+;Master.csv => ${CSV_QUOTE(${eventtype})},${CSV_QUOTE(My Literal)},${CSV_QUOTE(${eventtime})},${CSV_QUOTE(${CALLERID(name)})},${CSV_QUOTE(${CALLERID(num)})},${CSV_QUOTE(${CALLERID(ANI)})},${CSV_QUOTE(${CALLERID(RDNIS)})},${CSV_QUOTE(${CALLERID(DNID)})},${CSV_QUOTE(${CHANNEL(exten)})},${CSV_QUOTE(${CHANNEL(context)})},${CSV_QUOTE(${CHANNEL(channame)})},${CSV_QUOTE(${CHANNEL(appname)})},${CSV_QUOTE(${CHANNEL(appdata)})},${CSV_QUOTE(${CHANNEL(amaflags)})},${CSV_QUOTE(${CHANNEL(accountcode)})},${CSV_QUOTE(${CHANNEL(uniqueid)})},${CSV_QUOTE(${CHANNEL(linkedid)})},${CSV_QUOTE(${BRIDGEPEER})},${CSV_QUOTE(${CHANNEL(userfield)})},${CSV_QUOTE(${userdeftype})},${CSV_QUOTE(${eventextra})}
+
+;
+; Advanced Mappings
+;
+; Advanced mappings use SIGNIFICANTLY less resources than legacy mappings
+; because we don't need to use dialplan function replacement.
+;
+;[cel_master_advanced.csv]    ; The destination file name.
+                              ; Can be a name relative to ASTLOGDIR or an
+                              ; absolute path.
+
+;format = csv                 ; Sets the output format.  The default is "csv"
+                              ; but here "csv" really means "character-separated-values"
+                              ; because the separator doesn't have to be a comma.
+                              ; The other alternative is "json" (see example below).
+
+;separator_character = ,      ; Set the character to use between fields.
+                              ; Defaults to a comma but other characters
+                              ; can be used.  For example, if you want
+                              ; tab-separated fields, use \t as the separator.
+
+;quote_character = "          ; Set the quoting character.
+                              ; Defaults to double-quote (") but any character
+                              ; can be used although only the double and single
+                              ; quote (') characters make sense.
+
+;quote_escape_character = "   ; Sets the character used to escape quotes that
+                              ; may be in the field values. The default is the
+                              ; same character as the quote_character so an
+                              ; embedded JSON blob would look like this:
+                              ; "{""extra"":""somextratext""}"
+                              ; You could also use a backslash (\) in which case
+                              ; the blob would look like this:
+                              ; "{\"extra\":\"somextratext\"}"
+
+;quoting_method = all         ; Sets what/when to quote.
+                              ; all - Quote all fields. (the default)
+                              ; minimal - Only quote fields that have the
+                              ;           separator character in them.
+                              ; non_numeric - Quote all non-numeric fields.
+                              ; none - Don't quote anything.
+                              ;        Probably not a good idea but could
+                              ;        be useful in special circumstances.
+
+; The fields to output.  These names correspond to the internal CEL event
+; field names which is how some of the performance gains are realized.
+; Anything not recognized as a field name will be printed as a literal in
+; the output.
+;
+; CEL Event Field Names:
+;
+; eventtype - Could be a standard event name or a user event name
+; eventenum - Will always be a standard event name or 'USER_DEFINED'
+; eventtime - Uses the dateformat set in cel.conf.
+; usereventname - Will be the user event name if set.
+; cidname
+; cidnum
+; exten
+; context
+; channame
+; appname
+; appdata
+; amaflags
+; acctcode
+; uniqueid
+; userfield
+; cidani
+; cidrdnis
+; ciddnid
+; peer
+; linkedid
+; peeracct
+; extra
+; tenantid
+;
+; You MUST use the comma and double-quote here, not the separator or
+; or quote characters specified above.  The names are case-insensitive.
+;
+;fields = EventType,EventEnum,"My Literal",EventTime,UserEventName,CIDName,CIDNum,Exten,Context,ChanName,AppName,AppData,AMAFlags,AcctCode,UniqueID,UserField,CIDani,CIDrdnis,CIDdnid,Peer,LinkedID,PeerAcct,Extra,TenantID
+
+;
+;  A tab-separated-value example:
+;
+;[cel_master.tsv]
+;separator_character = \t
+;fields = EventType,EventEnum,"My Literal",EventTime,UserEventName,CIDName,CIDNum,Exten,Context,ChanName,AppName,AppData,AMAFlags,AcctCode,UniqueID,UserField,CIDani,CIDrdnis,CIDdnid,Peer,LinkedID,PeerAcct,Extra,TenantID
+
+;
+;  A JSON example:
+;
+; The separator and quoting options don't apply to JSON.
+; Literals must be specified as a "name: value" pair or they'll be ignored.
+;
+;[cel_master.json]
+;format = json
+;fields = EventType,eventenum,userdeftype,"My: Literal",EventTime,CIDName,CIDNum,CIDani,CIDrdnis,CIDdnid,Exten,Context,ChanName,AppName,AppData,AMAFlags,AcctCode,UniqueID,LinkedID,Peer,PeerAcct,UserField,Extra,TenantID

--- a/configs/samples/cel_sqlite3_custom.conf.sample
+++ b/configs/samples/cel_sqlite3_custom.conf.sample
@@ -5,7 +5,28 @@
 ;
 ; Mappings for sqlite3 config file
 ;
-; Within a mapping, use the CALLERID() and CHANNEL() functions to retrieve
+; Legacy vs Advanced Mappings
+;
+; Legacy mappings are very resource intentsive because you have to use
+; string substitutions and dialplan functions like CALLERID() and CHANNEL()
+; to retrieve the event values.
+;
+; Advanced mappings use a field list of event field names.  They're much more
+; efficient than legacy mappings because the field names map directly
+; to CEL event field names.
+;
+;[master] ; currently, only file "master.db" is supported, with only one table at a time.
+
+; Specify the database table name.
+;table = cel
+
+; Specify the column names for the event data.  In this example, the names
+; happen to match the CEL event names but they don't have to.  They MUST be
+; valid SQL names however.
+;
+;columns = eventtype, eventtime, cidname, cidnum, cidani, cidrdnis, ciddnid, context, exten, channame, appname, appdata, amaflags, accountcode, uniqueid, userfield, peer, userdeftype, eventextra
+
+; Within a legacy mapping, use the CALLERID() and CHANNEL() functions to retrieve
 ; details from the CEL event.  There are also a few variables created by this
 ; module that can be used in a mapping:
 ;
@@ -18,8 +39,46 @@
 ;    BRIDGEPEER  - Bridged peer channel name at the time of the CEL event.
 ;                  CHANNEL(peer) could also be used.
 ;
-;[master] ; currently, only file "master.db" is supported, with only one table at a time.
-;table	=> cel
-;columns	=> eventtype, eventtime, cidname, cidnum, cidani, cidrdnis, ciddnid, context, exten, channame, appname, appdata, amaflags, accountcode, uniqueid, userfield, peer, userdeftype, eventextra
-;values	=> '${eventtype}','${eventtime}','${CALLERID(name)}','${CALLERID(num)}','${CALLERID(ANI)}','${CALLERID(RDNIS)}','${CALLERID(DNID)}','${CHANNEL(context)}','${CHANNEL(exten)}','${CHANNEL(channame)}','${CHANNEL(appname)}','${CHANNEL(appdata)}','${CHANNEL(amaflags)}','${CHANNEL(accountcode)}','${CHANNEL(uniqueid)}','${CHANNEL(userfield)}','${BRIDGEPEER}','${userdeftype}','${eventextra}'
-;busy_timeout	=> 1000
+; Any value that can't be parsed will be treated as a literal.
+;
+; The number of values MUST match the number of columns or the driver will fail to load.
+;
+;values	= '${eventtype}','${eventtime}','${CALLERID(name)}','${CALLERID(num)}','${CALLERID(ANI)}','${CALLERID(RDNIS)}','${CALLERID(DNID)}','${CHANNEL(context)}','${CHANNEL(exten)}','${CHANNEL(channame)}','${CHANNEL(appname)}','${CHANNEL(appdata)}','${CHANNEL(amaflags)}','${CHANNEL(accountcode)}','${CHANNEL(uniqueid)}','${CHANNEL(userfield)}','${BRIDGEPEER}','${userdeftype}','${eventextra}'
+
+; For an advanced mapping, set 'fields' to a list of CEL event field names.
+;
+; CEL Event Field Names:
+;
+; eventtype - Could be a standard event name or a user event name
+; eventenum - Will always be a standard event name or 'USER_DEFINED'
+; eventtime - Uses the dateformat set in cel.conf.
+; usereventname - Will be the user event name if set.
+; cidname
+; cidnum
+; exten
+; context
+; channame
+; appname
+; appdata
+; amaflags
+; acctcode
+; uniqueid
+; userfield
+; cidani
+; cidrdnis
+; ciddnid
+; peer
+; linkedid
+; peeracct
+; extra
+; tenantid
+;
+; Any unrecognized field name will be treated as a literal.
+;
+; The number of values MUST match the number of columns or the driver will fail to load.
+;
+;fields = eventtype, eventtime, cidname, cidnum, cidani, cidrdnis, ciddnid, context, exten, channame, appname, appdata, amaflags, acctcode, uniqueid, userfield, peer, userdeftype, eventextra
+
+; The SQLite busy timeout in milliseconds.
+;busy_timeout = 1000
+

--- a/include/asterisk/cel.h
+++ b/include/asterisk/cel.h
@@ -118,6 +118,18 @@ const char *ast_cel_get_type_name(enum ast_cel_event_type type);
 enum ast_cel_event_type ast_cel_str_to_event_type(const char *name);
 
 /*!
+ * \brief Format an event timeval using dateformat from cel.conf
+ *
+ * \param eventtime The timeval to format
+ * \param timebuf A buffer of at least 30 chracters to place the result in
+ * \param len Length of buffer
+
+ * \retval zero Success
+ * \retval non-zero Failure
+ */
+int ast_cel_format_eventtime(struct timeval eventtime, char *timebuf, size_t len);
+
+/*!
  * \brief Create a fake channel from data in a CEL event
  *
  * \note


### PR DESCRIPTION
The legacy cel_custom and cel_sqlite3_custom channel event logging backends
are very heavy resource consumers because they use recursive string
interpolation and dialplan function evaluation. They're so resource intensive
that it actually takes more resources to write the event log records than it
does to actually process a call. Unfortunately, the existing configuration
file formats don't give us much leeway to capture the extra information
needed to shortcut the string interpolation so...

UpgradeNote: New "advanced" cel_custom and cel_sqlite3_custom configuration
formats are now available that allow significant reductions in resources
required to write channel event log entries.  The details are in the
cel_custom and cel_sqlite3_custom sample config files but by capturing
additional information at load time, we can eliminate the need for the string
interpolation and dialplan function calls which were the main contributors to
the resource over-utilization.  As an added benefit, the cel_custom module
can now also produce JSON formatted output.  The legacy configuration formats
are still supported but all users are encouraged to switch to the new format.
