### PR TITLE
chan_websocket.conf.sample: Fix category name.

### DIFF
--- a/configs/samples/chan_websocket.conf.sample
+++ b/configs/samples/chan_websocket.conf.sample
@@ -1,6 +1,6 @@
 ; Configuration for chan_websocket
 ;
-;[general]
+;[global]
 ;control_message_format = plain-text ; The format for the control messages sent
                                      ; and received on the websocket.
                                      ; plain-text: The legacy single-line message


### PR DESCRIPTION
UserNote: The category name in the chan_websocket.conf.sample file was
incorrect.  It should be "global" instead of "general".
