### PR TITLE
app_queue: fix double increment of member->calls with shared_lastcall

### DIFF
--- a/apps/app_queue.c
+++ b/apps/app_queue.c
@@ -6145,13 +6145,10 @@ static int update_queue(struct call_queue *q, struct member *member, int callcom
 	 * Consume the bridged starttime ONLY ONCE per call using the ORIGINAL member object.
 	 * This blocks duplicate triggers (status + hangup) from counting twice.
 	 */
-	{
-		time_t before_gate = member->starttime;
-		if (!__sync_bool_compare_and_swap(&member->starttime, starttime, 0)) {
-			return 0;
-		}
+	if (!__sync_bool_compare_and_swap(&member->starttime, starttime, 0)) {
+		return 0;
 	}
-
+	
 	if (shared_lastcall) {
 		/*
 		 * shared_lastcall behavior


### PR DESCRIPTION
Under high concurrency, update_queue() may be invoked multiple times for the same call, causing member->calls and queue-level counters to be incremented more than once.

The existing starttime check is not atomic and allows concurrent execution paths to pass. Treat member->starttime as a single-use token and consume it via CAS to ensure the call is counted exactly once.

This also prevents incorrect call distribution when using strategies such as fewestcalls.

Observed as a regression after upgrading to 20.17.