### PR TITLE
pjsip_configuration: Ensure s= and o= lines in SDP are never empty

### DIFF
--- a/res/res_pjsip/pjsip_config.xml
+++ b/res/res_pjsip/pjsip_config.xml
@@ -1274,12 +1274,24 @@
 						<version>12.0.0</version>
 					</since>
 					<synopsis>String placed as the username portion of an SDP origin (o=) line.</synopsis>
+					<description><para>
+						The username portion of an SDP origin to be used in the SDP 'o=' line.
+						Note: If this option is left empty or set only to whitespace, it will
+						automatically default to a hyphen ('-') to ensure compliance
+						with RFC 8866.
+					</para></description>
 				</configOption>
 				<configOption name="sdp_session" default="Asterisk">
 					<since>
 						<version>12.0.0</version>
 					</since>
 					<synopsis>String used for the SDP session (s=) line.</synopsis>
+					<description><para>
+						The session name to be used in the SDP 's=' line.
+						Note: If this option is left empty or set only to whitespace, it will
+						automatically default to a hyphen ('-') to ensure compliance
+						with RFC 8866.
+				</para></description>
 				</configOption>
 				<configOption name="tos_audio">
 					<since>

--- a/res/res_pjsip/pjsip_configuration.c
+++ b/res/res_pjsip/pjsip_configuration.c
@@ -1650,6 +1650,18 @@ static int sip_endpoint_apply_handler(const struct ast_sorcery *sorcery, void *o
 		return -1;
 	}
 
+	if (ast_strlen_zero(endpoint->media.sdpsession) || !*ast_skip_blanks(endpoint->media.sdpsession)) {
+		ast_log(LOG_WARNING, "SDP session was set to empty on endpoint '%s'. Not permitted as per RFC8866. SDP session set to '-'. \n",
+			ast_sorcery_object_get_id(endpoint));
+		ast_string_field_set(endpoint, media.sdpsession, "-");
+	}
+
+	if (ast_strlen_zero(endpoint->media.sdpowner) || *ast_skip_nonblanks(ast_skip_blanks(endpoint->media.sdpowner))) {
+		ast_log(LOG_WARNING, "SDP origin username on endpoint '%s' is empty or contains spaces ('%s'). Not permitted as per RFC8866. Setting to '-'.\n",
+			ast_sorcery_object_get_id(endpoint), endpoint->media.sdpowner);
+		ast_string_field_set(endpoint, media.sdpowner, "-");
+	}
+
 	if (ast_rtp_dtls_cfg_validate(&endpoint->media.rtp.dtls_cfg)) {
 		return -1;
 	}


### PR DESCRIPTION
According to RFC 8866 (Section 5.2), the Session Name (s=) field and
the username part of origin (o=) are both mandatory and cannot be
empty. If a session has no name, or no username part of origin, the
RFC recommends using a single dash (-) as a placeholder.

This fix ensures that if the session name or the username part of
origin length is zero , it defaults to -.

Fixes: #1524