### PR TITLE
app_dial, utils.h: Avoid old style declaration and discarded qualifier.

### DIFF
--- a/apps/app_dial.c
+++ b/apps/app_dial.c
@@ -951,7 +951,7 @@ static void do_forward(struct chanlist *o, struct cause_args *num,
 	struct ast_channel *c = o->chan; /* the winner */
 	struct ast_channel *in = num->chan; /* the input channel */
 	char *stuff;
-	char *tech;
+	const char *tech;
 	int cause;
 	struct ast_party_caller caller;
 

--- a/include/asterisk/utils.h
+++ b/include/asterisk/utils.h
@@ -769,7 +769,7 @@ void DO_CRASH_NORETURN __ast_assert_failed(int condition, const char *condition_
 		return __VA_ARGS__; \
 	}\
 })
-static void force_inline _ast_assert(int condition, const char *condition_str, const char *file, int line, const char *function)
+static force_inline void _ast_assert(int condition, const char *condition_str, const char *file, int line, const char *function)
 {
 	if (__builtin_expect(!condition, 1)) {
 		__ast_assert_failed(condition, condition_str, file, line, function);


### PR DESCRIPTION
* app_dial: Use const char* for fixed strings.
* utils.h: inline should come before return type.

Resolves: #1755