### PR TITLE
endpoints: Allow access to latest snapshot directly.

### DIFF
--- a/channels/chan_pjsip.c
+++ b/channels/chan_pjsip.c
@@ -1188,9 +1188,7 @@ static int chan_pjsip_devicestate(const char *data)
 		return AST_DEVICE_INVALID;
 	}
 
-	endpoint_snapshot = ast_endpoint_latest_snapshot(ast_endpoint_get_tech(endpoint->persistent),
-		ast_endpoint_get_resource(endpoint->persistent));
-
+	endpoint_snapshot = ast_endpoint_get_snapshot(endpoint->persistent);
 	if (!endpoint_snapshot) {
 		return AST_DEVICE_INVALID;
 	}

--- a/include/asterisk/endpoints.h
+++ b/include/asterisk/endpoints.h
@@ -170,6 +170,18 @@ const char *ast_endpoint_get_id(const struct ast_endpoint *endpoint);
 enum ast_endpoint_state ast_endpoint_get_state(const struct ast_endpoint *endpoint);
 
 /*!
+ * \brief Gets the latest snapshot of the given endpoint.
+ *
+ * \param endpoint The endpoint.
+ * \return Latest snapshot of the endpoint.
+ * \retval NULL if endpoint is \c NULL.
+ * \since 20.19.0
+ * \since 22.9.0
+ * \since 23.3.0
+ */
+struct ast_endpoint_snapshot *ast_endpoint_get_snapshot(struct ast_endpoint *endpoint);
+
+/*!
  * \brief Updates the state of the given endpoint.
  *
  * \param endpoint Endpoint to modify.


### PR DESCRIPTION
This change adds an API call to allow direct access to the latest snapshot of an ast_endpoint. This is then used by chan_pjsip when calculating device state, eliminating the need to access the cache which would incur a container find and access.