### PR TITLE
docs: fix dsp_talking_threshold description in TALK_DETECT

### DIFF
--- a/funcs/func_talkdetect.c
+++ b/funcs/func_talkdetect.c
@@ -86,9 +86,9 @@
 			<para>The function has two parameters that can optionally be passed
 			when <literal>set</literal> on a channel: <replaceable>dsp_talking_threshold</replaceable>
 			and <replaceable>dsp_silence_threshold</replaceable>.</para>
-			<para><replaceable>dsp_talking_threshold</replaceable> is the time in milliseconds of sound
-			above what the dsp has established as base line silence for a user
-			before a user is considered to be talking. By default, the value of
+			<para><replaceable>dsp_talking_threshold</replaceable> is the minimum average
+			magnitude per sample in a frame for the DSP to consider talking/noise present.
+			A value below this level is considered silence. By default, the value of
 			<replaceable>silencethreshold</replaceable> from <filename>dsp.conf</filename>
 			is used. If this value is set too tight events may be
 			falsely triggered by variants in room noise.</para>


### PR DESCRIPTION
fixes the description of dsp_talking_threshold in the TALK_DETECT function docs. the description section incorrectly said it was a time value in milliseconds, but it's actually a magnitude threshold (minimum average magnitude per sample). the parameter definition section already had this right, just needed to update the description to match.

fixes #1761