### PR TITLE
build: Fix GCC discarded-qualifiers const errors.

### DIFF
--- a/addons/res_config_mysql.c
+++ b/addons/res_config_mysql.c
@@ -426,7 +426,7 @@ static struct ast_config *realtime_multi_mysql(const char *database, const char 
 	int numFields, i;
 	struct ast_str *sql = ast_str_thread_get(&sql_buf, 16);
 	struct ast_str *buf = ast_str_thread_get(&scratch_buf, 16);
-	const char *initfield = NULL;
+	char *initfield = NULL;
 	char *stringp;
 	char *chunk;
 	char *op;

--- a/apps/app_playback.c
+++ b/apps/app_playback.c
@@ -188,6 +188,7 @@ static int do_say(say_args_t *a, const char *s, const char *options, int depth)
 	struct ast_variable *v;
 	char *lang;
 	char *x;
+	const char *y;
 	char *rule = NULL;
 	char *rule_head = NULL;
 	int ret = 0;
@@ -228,10 +229,10 @@ static int do_say(say_args_t *a, const char *s, const char *options, int depth)
 		return 0;
 
 	/* skip up to two prefixes to get the value */
-	if ( (x = strchr(s, ':')) )
-		s = x + 1;
-	if ( (x = strchr(s, ':')) )
-		s = x + 1;
+	if ( (y = strchr(s, ':')) )
+		s = y + 1;
+	if ( (y = strchr(s, ':')) )
+		s = y + 1;
 	ast_debug(2, "value is <%s>\n", s);
 	n = ast_var_assign("SAY", s);
 	if (!n) {

--- a/apps/app_record.c
+++ b/apps/app_record.c
@@ -187,9 +187,9 @@ static enum dtmf_response record_dtmf_response(struct ast_channel *chan,
 static int create_destination_directory(const char *path)
 {
 	int res;
-	char directory[PATH_MAX], *file_sep;
+	char *path_copy = ast_strdupa(path), directory[PATH_MAX], *file_sep;
 
-	if (!(file_sep = strrchr(path, '/'))) {
+	if (!(file_sep = strrchr(path_copy, '/'))) {
 		/* No directory to create */
 		return 0;
 	}
@@ -198,8 +198,8 @@ static int create_destination_directory(const char *path)
 	*file_sep = '\0';
 
 	/* Absolute path? */
-	if (path[0] == '/') {
-		res = ast_mkdir(path, 0777);
+	if (path_copy[0] == '/') {
+		res = ast_mkdir(path_copy, 0777);
 		*file_sep = '/';
 		return res;
 	}

--- a/apps/app_voicemail.c
+++ b/apps/app_voicemail.c
@@ -2104,7 +2104,7 @@ static void vm_change_password(struct ast_vm_user *vmu, const char *newpassword)
 		if ((cfg = ast_config_load(VOICEMAIL_CONFIG, config_flags)) && valid_config(cfg)) {
 			while ((category = ast_category_browse(cfg, category))) {
 				if (!strcasecmp(category, vmu->context)) {
-					char *value = NULL;
+					const char *value = NULL;
 					char *new = NULL;
 					if (!(tmp = ast_variable_retrieve(cfg, category, vmu->mailbox))) {
 						ast_log(AST_LOG_WARNING, "We could not find the mailbox.\n");

--- a/channels/chan_pjsip.c
+++ b/channels/chan_pjsip.c
@@ -2801,10 +2801,11 @@ static int sendtext(void *obj)
 	};
 
 	if (!ast_strlen_zero(content_type)) {
-		sep = strchr(content_type, '/');
+		char *content_type_copy = ast_strdupa(content_type);
+		sep = strchr(content_type_copy, '/');
 		if (sep) {
 			*sep = '\0';
-			body.type = content_type;
+			body.type = content_type_copy;
 			body.subtype = ++sep;
 		}
 	}

--- a/channels/iax2/provision.c
+++ b/channels/iax2/provision.c
@@ -116,7 +116,7 @@ static unsigned int iax_str2flags(const char *buf)
 	int x;
 	int len;
 	unsigned int flags = 0;
-	char *e;
+	const char *e;
 	while(buf && *buf) {
 		e = strchr(buf, ',');
 		if (e)

--- a/main/app.c
+++ b/main/app.c
@@ -1356,6 +1356,7 @@ static int control_streamfile(struct ast_channel *chan,
 	const char *lang,
 	ast_waitstream_fr_cb cb)
 {
+	char *file_copy = ast_strdupa(file);
 	char *breaks = NULL;
 	char *end = NULL;
 	int blen = 2;
@@ -1398,7 +1399,7 @@ static int control_streamfile(struct ast_channel *chan,
 		}
 	}
 
-	if ((end = strchr(file, ':'))) {
+	if ((end = strchr(file_copy, ':'))) {
 		if (!strcasecmp(end, ":end")) {
 			*end = '\0';
 			end++;
@@ -1409,7 +1410,7 @@ static int control_streamfile(struct ast_channel *chan,
 
 	for (;;) {
 		ast_stopstream(chan);
-		res = ast_streamfile(chan, file, lang);
+		res = ast_streamfile(chan, file_copy, lang);
 		if (!res) {
 			if (pause_restart_point) {
 				ast_seekstream(ast_channel_stream(chan), pause_restart_point, SEEK_SET);

--- a/main/ccss.c
+++ b/main/ccss.c
@@ -2817,7 +2817,7 @@ static void *generic_recall(void *data)
 {
 	struct ast_cc_agent *agent = data;
 	struct cc_generic_agent_pvt *generic_pvt = agent->private_data;
-	const char *interface = S_OR(ast_get_cc_agent_dialstring(agent->cc_params), ast_strdupa(agent->device_name));
+	char *interface = ast_strdupa(S_OR(ast_get_cc_agent_dialstring(agent->cc_params), agent->device_name));
 	const char *tech;
 	char *target;
 	int reason;

--- a/main/config.c
+++ b/main/config.c
@@ -840,7 +840,7 @@ const struct ast_variable *ast_variable_find_variable_in_list(const struct ast_v
 
 int ast_variables_match(const struct ast_variable *left, const struct ast_variable *right)
 {
-	char *op;
+	const char *op;
 
 	if (left == right) {
 		return 1;
@@ -873,7 +873,7 @@ int ast_variable_lists_match(const struct ast_variable *left, const struct ast_v
 	}
 
 	for (field = right; field; field = field->next) {
-		char *space = strrchr(field->name, ' ');
+		const char *space = strrchr(field->name, ' ');
 		const struct ast_variable *old;
 		char * name = (char *)field->name;
 

--- a/main/dns_core.c
+++ b/main/dns_core.c
@@ -707,7 +707,7 @@ char *dns_find_record(const char *record, size_t record_size, const char *respon
 	char *record_offset;
 
 	while (1) {
-		record_offset = memchr(search_base, record[0], remaining_size);
+		record_offset = memchr((void *)search_base, record[0], remaining_size);
 
 		ast_assert(record_offset != NULL);
 		ast_assert(search_base + remaining_size - record_offset >= record_size);

--- a/main/dns_naptr.c
+++ b/main/dns_naptr.c
@@ -142,7 +142,7 @@ static int services_invalid(const char *services, uint8_t services_size)
 	 * 32 characters
 	 */
 	while (1) {
-		char *plus_pos = memchr(current_pos, '+', end_of_services - current_pos);
+		const char *plus_pos = memchr(current_pos, '+', end_of_services - current_pos);
 		uint8_t current_size = plus_pos ? plus_pos - current_pos : end_of_services - current_pos;
 		int i;
 
@@ -235,7 +235,7 @@ static int regexp_repl_invalid(const char *repl, const char *end, char delim)
 	}
 
 	while (1) {
-		char *backslash_pos = memchr(ptr, '\\', end - ptr);
+		const char *backslash_pos = memchr(ptr, '\\', end - ptr);
 		if (!backslash_pos) {
 			break;
 		}

--- a/main/enum.c
+++ b/main/enum.c
@@ -759,7 +759,7 @@ int ast_get_enum(struct ast_channel *chan, const char *number, char *dst, int ds
 	 */
 	ast_copy_string(apex, suffix, sizeof(apex));
 	/* ISN rewrite */
-	if ((context->options & ENUMLOOKUP_OPTIONS_ISN) && (p1 = strchr(number, '*'))) {
+	if ((context->options & ENUMLOOKUP_OPTIONS_ISN) && (p1 = strchr((char *)number, '*'))) {
 		*p1++ = '\0';
 		ast_copy_string(left, number, sizeof(left));
 		ast_copy_string(middle, p1, sizeof(middle) - 1);

--- a/main/logger.c
+++ b/main/logger.c
@@ -634,7 +634,7 @@ static struct logchannel *find_logchannel(const char *channel)
 static struct logchannel *make_logchannel(const char *channel, const char *components, int lineno, int dynamic)
 {
 	struct logchannel *chan;
-	char *facility;
+	const char *facility;
 	struct ast_tm tm;
 	struct timeval now = ast_tvnow();
 	char datestring[256];

--- a/main/pbx_variables.c
+++ b/main/pbx_variables.c
@@ -435,7 +435,7 @@ void ast_str_substitute_variables_full2(struct ast_str **buf, ssize_t maxlen,
 		ast_str_reset(substr3);
 
 		/* Determine how much simply needs to be copied to the output buf. */
-		nextthing = strchr(whereweare, '$');
+		nextthing = strchr((char *)whereweare, '$');
 		if (nextthing) {
 			pos = nextthing - whereweare;
 			switch (nextthing[1]) {
@@ -704,7 +704,7 @@ void pbx_substitute_variables_helper_full_location(struct ast_channel *c, struct
 		int len;
 
 		/* Determine how much simply needs to be copied to the output buf. */
-		nextthing = strchr(whereweare, '$');
+		nextthing = strchr((char *)whereweare, '$');
 		if (nextthing) {
 			pos = nextthing - whereweare;
 			switch (nextthing[1]) {

--- a/main/say.c
+++ b/main/say.c
@@ -9436,7 +9436,7 @@ static int ast_say_number_full_ka(struct ast_channel *chan, int num, const char 
 {
 	int res = 0;
 	char fn[512] = "";
-	char* s = 0;
+	const char* s = 0;
 	const char* remaining = fn;
 
 	if (!num) {

--- a/main/taskprocessor.c
+++ b/main/taskprocessor.c
@@ -1048,7 +1048,7 @@ static void *default_listener_pvt_alloc(void)
 static struct ast_taskprocessor *__allocate_taskprocessor(const char *name, struct ast_taskprocessor_listener *listener)
 {
 	struct ast_taskprocessor *p;
-	char *subsystem_separator;
+	const char *subsystem_separator;
 	size_t subsystem_length = 0;
 	size_t name_length;
 

--- a/main/utils.c
+++ b/main/utils.c
@@ -1818,7 +1818,7 @@ int ast_carefulwrite(int fd, char *s, int len, int timeoutms)
 char *ast_strip_quoted(char *s, const char *beg_quotes, const char *end_quotes)
 {
 	char *e;
-	char *q;
+	const char *q;
 
 	s = ast_strip(s);
 	if ((q = strchr(beg_quotes, *s)) && *q != '\0') {

--- a/res/res_agi.c
+++ b/res/res_agi.c
@@ -2908,7 +2908,7 @@ static int handle_recordfile(struct ast_channel *chan, AGI *agi, int argc, const
 	int dspsilence = 0;
 	int silence = 0;                /* amount of silence to allow */
 	int gotsilence = 0;             /* did we timeout for silence? */
-	char *silencestr = NULL;
+	const char *silencestr = NULL;
 	RAII_VAR(struct ast_format *, rfmt, NULL, ao2_cleanup);
 	struct ast_silence_generator *silgen = NULL;
 

--- a/res/res_config_ldap.c
+++ b/res/res_config_ldap.c
@@ -742,7 +742,7 @@ static void append_var_and_value_to_filter(struct ast_str **filter,
 {
 	char *new_name = NULL;
 	char *new_value = NULL;
-	char *like_pos = strstr(name, " LIKE");
+	const char *like_pos = strstr(name, " LIKE");
 
 	ast_debug(2, "name='%s' value='%s'\n", name, value);
 
@@ -1042,7 +1042,7 @@ static struct ast_config *realtime_multi_ldap(const char *basedn,
       const char *table_name, const struct ast_variable *fields)
 {
 	char *op;
-	const char *initfield = NULL;
+	char *initfield = NULL;
 	struct ast_variable **vars =
 		realtime_ldap_base_ap(NULL, basedn, table_name, fields);
 	struct ast_config *cfg = NULL;

--- a/res/res_config_odbc.c
+++ b/res/res_config_odbc.c
@@ -349,7 +349,7 @@ static struct ast_config *realtime_multi_odbc(const char *database, const char *
 	char coltitle[256];
 	struct ast_str *sql = ast_str_thread_get(&sql_buf, SQL_BUF_SIZE);
 	struct ast_str *rowdata = ast_str_thread_get(&rowdata_buf, 128);
-	const char *initfield;
+	char *initfield;
 	char *op;
 	const struct ast_variable *field = fields;
 	char *stringp;

--- a/res/res_config_pgsql.c
+++ b/res/res_config_pgsql.c
@@ -530,7 +530,7 @@ static struct ast_config *realtime_multi_pgsql(const char *database, const char 
 	struct ast_str *sql = ast_str_thread_get(&sql_buf, 100);
 	struct ast_str *escapebuf = ast_str_thread_get(&escapebuf_buf, 100);
 	const struct ast_variable *field = fields;
-	const char *initfield = NULL;
+	char *initfield = NULL;
 	char *stringp;
 	char *chunk;
 	char *op;

--- a/res/res_fax.c
+++ b/res/res_fax.c
@@ -4628,7 +4628,7 @@ static int acf_faxopt_write(struct ast_channel *chan, const char *cmd, char *dat
 		}
 	} else if (!strcasecmp(data, "t38gateway") || !strcasecmp(data, "gateway") ||
 		   !strcasecmp(data, "t38_gateway") || !strcasecmp(data, "faxgateway")) {
-		const char *val = ast_skip_blanks(value);
+		char *val = ast_strdupa(ast_skip_blanks(value));
 		char *timeout = strchr(val, ',');
 
 		if (timeout) {
@@ -4667,7 +4667,7 @@ static int acf_faxopt_write(struct ast_channel *chan, const char *cmd, char *dat
 			ast_log(LOG_WARNING, "Unsupported value '%s' passed to FAXOPT(%s).\n", value, data);
 		}
 	} else if (!strcasecmp(data, "faxdetect")) {
-		const char *val = ast_skip_blanks(value);
+		char *val = ast_strdupa(ast_skip_blanks(value));
 		char *timeout = strchr(val, ',');
 		unsigned int fdtimeout = 0;
 		int flags;

--- a/res/res_http_media_cache.c
+++ b/res/res_http_media_cache.c
@@ -273,7 +273,7 @@ static void bucket_file_set_expiration(struct ast_bucket_file *bucket_file)
 
 	metadata = ast_bucket_file_metadata_get(bucket_file, "cache-control");
 	if (metadata) {
-		char *str_max_age;
+		const char *str_max_age;
 
 		str_max_age = strstr(metadata->value, "s-maxage");
 		if (!str_max_age) {
@@ -282,7 +282,7 @@ static void bucket_file_set_expiration(struct ast_bucket_file *bucket_file)
 
 		if (str_max_age) {
 			unsigned int max_age;
-			char *equal = strchr(str_max_age, '=');
+			const char *equal = strchr(str_max_age, '=');
 			if (equal && (sscanf(equal + 1, "%30u", &max_age) == 1)) {
 				actual_expires.tv_sec += max_age;
 			}

--- a/res/res_http_post.c
+++ b/res/res_http_post.c
@@ -372,7 +372,7 @@ static int http_post_callback(struct ast_tcptls_session_instance *ser, const str
 			}
 			ast_debug(1, "Got a Content-Length of %d\n", content_len);
 		} else if (!strcasecmp(var->name, "Content-Type")) {
-			boundary_marker = strstr(var->value, "boundary=");
+			boundary_marker = strstr((char *)var->value, "boundary=");
 			if (boundary_marker) {
 				boundary_marker += strlen("boundary=");
 			}

--- a/res/res_musiconhold.c
+++ b/res/res_musiconhold.c
@@ -1245,7 +1245,7 @@ static int on_moh_file(const char *directory, const char *filename, void *obj)
 {
 	struct ast_vector_string *files = obj;
 	char *full_path;
-	char *extension;
+	const char *extension;
 
 	/* Skip files that starts with a dot */
 	if (*filename == '.') {

--- a/res/res_phoneprov.c
+++ b/res/res_phoneprov.c
@@ -631,7 +631,7 @@ static void build_profile(const char *name, struct ast_variable *v)
 			ast_string_field_set(profile, staticdir, v->value);
 		} else {
 			struct phoneprov_file *pp_file;
-			char *file_extension;
+			const char *file_extension;
 			char value_copy[strlen(v->value) + 1];
 
 			AST_DECLARE_APP_ARGS(args,

--- a/res/res_pjsip_config_wizard.c
+++ b/res/res_pjsip_config_wizard.c
@@ -425,7 +425,7 @@ static int add_extension(struct ast_context *context, const char *exten,
 	char *data = NULL;
 	char *app = NULL;
 	void *free_ptr = NULL;
-	char *paren;
+	const char *paren;
 	const char *context_name;
 
 	if (!context || ast_strlen_zero(exten) || ast_strlen_zero(application)) {

--- a/res/res_pjsip_logger.c
+++ b/res/res_pjsip_logger.c
@@ -393,7 +393,7 @@ static char *pjsip_enable_logger_all(int fd)
 static char *pjsip_enable_logger_host(int fd, const char *arg, unsigned int add_host)
 {
 	const char *host = arg;
-	char *mask;
+	const char *mask;
 	struct ast_sockaddr address;
 	int error = 0;
 

--- a/res/res_pjsip_notify.c
+++ b/res/res_pjsip_notify.c
@@ -578,7 +578,7 @@ static void build_notify_body(pjsip_tx_data *tdata, struct ast_str *content_type
 		}
 
 		body.type = ast_str_buffer(content_type);
-		if ((p = strchr(body.type, '/'))) {
+		if ((p = strchr((char *)body.type, '/'))) {
 			*p++ = '\0';
 			body.subtype = p;
 		}

--- a/res/res_rtp_asterisk.c
+++ b/res/res_rtp_asterisk.c
@@ -10097,7 +10097,7 @@ static int rtp_reload(int reload, int by_external_config)
 			continue;
 		}
 
-		sep = strchr(var->value,',');
+		sep = strchr((char *)var->value,',');
 		if (sep) {
 			*sep = '\0';
 			sep++;

--- a/res/res_stir_shaken/verification.c
+++ b/res/res_stir_shaken/verification.c
@@ -127,7 +127,7 @@ static int add_cert_expiration_to_astdb(struct ast_stir_shaken_vs_ctx *cert,
 	config_expires = current_time + cfg->vcfg_common.max_cache_entry_age;
 
 	if (!ast_strlen_zero(cache_control_header)) {
-		char *str_max_age;
+		const char *str_max_age;
 
 		str_max_age = strstr(cache_control_header, "s-maxage");
 		if (!str_max_age) {
@@ -136,7 +136,7 @@ static int add_cert_expiration_to_astdb(struct ast_stir_shaken_vs_ctx *cert,
 
 		if (str_max_age) {
 			unsigned int m;
-			char *equal = strchr(str_max_age, '=');
+			const char *equal = strchr(str_max_age, '=');
 			if (equal && !ast_str_to_uint(equal + 1, &m)) {
 				max_age_hdr = current_time + m;
 			}
@@ -886,7 +886,7 @@ enum ast_stir_shaken_vs_response_code
 	RAII_VAR(char *, jwt_encoded, NULL, ast_free);
 	RAII_VAR(jwt_t *, jwt, NULL, jwt_free);
 	RAII_VAR(struct ast_json *, grants, NULL, ast_json_unref);
-	char *p = NULL;
+	const char *p = NULL;
 	char *grants_str = NULL;
 	const char *x5u;
 	const char *ppt_header = NULL;

--- a/res/stasis_recording/stored.c
+++ b/res/stasis_recording/stored.c
@@ -279,7 +279,7 @@ static int handle_scan_file(const char *dir_name, const char *filename, void *ob
 
 	ast_free(filepath);
 
-	dot = strrchr(recording->file, '.');
+	dot = strrchr((char *)recording->file, '.');
 	*dot = '\0';
 	recording->format = dot + 1;
 

--- a/utils/extconf.c
+++ b/utils/extconf.c
@@ -5166,7 +5166,7 @@ static void pbx_substitute_variables_helper_full(struct ast_channel *c, struct v
 		pos = strlen(whereweare);
 		nextvar = NULL;
 		nextexp = NULL;
-		nextthing = strchr(whereweare, '$');
+		nextthing = (char *)strchr(whereweare, '$');
 		if (nextthing) {
 			switch (nextthing[1]) {
 			case '{':


### PR DESCRIPTION
GCC 15.2.1 pays attention to the discarding of the const qualifier when strchr, strrchr, memchr, or memrchr are now used. This change fixes numerous errors with this throughout the tree. The fixes can be broken down into the following:

1. The return value should be considered const.
2. The value passed to strchr or strrchr can be cast as it is expected and allowed to be modified.
3. The pointer passed to strchr or strrchr is not meant to be modified and so the contents must be duplicated.
4. It was declared const and never should have been.