### PR TITLE
astconfigparser.py: Fix regex pattern error by properly escaping string

### DIFF
--- a/contrib/scripts/sip_to_pjsip/astconfigparser.py
+++ b/contrib/scripts/sip_to_pjsip/astconfigparser.py
@@ -240,7 +240,7 @@ def try_include(line):
     included filename, otherwise None.
     """
 
-    match = re.match('^#include\s*([^;]+).*$', line)
+    match = re.match(r'^#include\s*([^;]+).*$', line)
     if match:
         trimmed = match.group(1).rstrip()
         quoted = re.match('^"([^"]+)"$', trimmed)


### PR DESCRIPTION
"SyntaxWarning: invalid escape sequence '\s'" occurs when using the pjsip
migration script because '\' is an escape character in Python. Instead,
use a raw string for the regex.