### PR TITLE
build: Fix another GCC discarded-qualifiers const error.

### DIFF
--- a/main/backtrace.c
+++ b/main/backtrace.c
@@ -128,7 +128,7 @@ static void process_section(bfd *bfdobj, asection *section, void *obj)
 	bfd_vma vma;
 	bfd_size_type size;
 	bfd_boolean line_found = 0;
-	char *fn;
+	const char *fn;
 	int inlined = 0;
 
 	offset = data->pc - (data->dynamic ? (bfd_vma)(uintptr_t) data->dli.dli_fbase : 0);


### PR DESCRIPTION
Follow on commit to 27a39cba7e6832cb30cb64edaf879f447b669628
to fix compilation with BETTER_BACKTRACES with gcc 15.2.1.

Resolves: #1781