### PR TITLE
build: Fix unused-but-set-variable warnings with gcc 16.

### DIFF
--- a/apps/app_externalivr.c
+++ b/apps/app_externalivr.c
@@ -311,12 +311,11 @@ static void ast_eivr_getvariable(struct ast_channel *chan, char *data, char *out
 
 	char *inbuf, *variable;
 	const char *value;
-	int j;
 	struct ast_str *newstring = ast_str_alloca(outbuflen);
 
 	outbuf[0] = '\0';
 
-	for (j = 1, inbuf = data; ; j++) {
+	for (inbuf = data; ; ) {
 		variable = strsep(&inbuf, ",");
 		if (variable == NULL) {
 			int outstrlen = strlen(outbuf);

--- a/apps/app_minivm.c
+++ b/apps/app_minivm.c
@@ -2612,14 +2612,14 @@ static int timezone_add(const char *zonename, const char *config)
 }
 
 /*! \brief Read message template from file */
-static char *message_template_parse_filebody(const char *filename) {
+static char *message_template_parse_filebody(const char *filename)
+{
 	char buf[BUFSIZ * 6];
 	char readbuf[BUFSIZ];
 	char filenamebuf[BUFSIZ];
 	char *writepos;
 	char *messagebody;
 	FILE *fi;
-	int lines = 0;
 
 	if (ast_strlen_zero(filename))
 		return NULL;
@@ -2634,7 +2634,6 @@ static char *message_template_parse_filebody(const char *filename) {
 	}
 	writepos = buf;
 	while (fgets(readbuf, sizeof(readbuf), fi)) {
-		lines ++;
 		if (writepos != buf) {
 			*writepos = '\n';		/* Replace EOL with new line */
 			writepos++;

--- a/channels/chan_unistim.c
+++ b/channels/chan_unistim.c
@@ -5091,7 +5091,6 @@ static int unistimsock_read(int *id, int fd, short events, void *ignore)
 	struct sockaddr_in addr_from = { 0, };
 	struct unistimsession *cur = NULL;
 	int found = 0;
-	int tmp = 0;
 	int dw_num_bytes_rcvd;
 	unsigned int size_addr_from;
 #ifdef DUMP_PACKET
@@ -5119,7 +5118,6 @@ static int unistimsock_read(int *id, int fd, short events, void *ignore)
 			found = 1;
 			break;
 		}
-		tmp++;
 		cur = cur->next;
 	}
 	ast_mutex_unlock(&sessionlock);

--- a/funcs/func_curl.c
+++ b/funcs/func_curl.c
@@ -720,8 +720,8 @@ static int curl_instance_init(void *data)
 	if (!(*curl = curl_easy_init()))
 		return -1;
 
-	curl_easy_setopt(*curl, CURLOPT_NOSIGNAL, 1);
-	curl_easy_setopt(*curl, CURLOPT_TIMEOUT, 180);
+	curl_easy_setopt(*curl, CURLOPT_NOSIGNAL, 1L);
+	curl_easy_setopt(*curl, CURLOPT_TIMEOUT, 180L);
 	curl_easy_setopt(*curl, CURLOPT_WRITEFUNCTION, WriteMemoryCallback);
 	curl_easy_setopt(*curl, CURLOPT_USERAGENT, AST_CURL_USER_AGENT);
 

--- a/main/Makefile
+++ b/main/Makefile
@@ -151,6 +151,7 @@ endif
 stdtime/localtime.o: _ASTCFLAGS+=$(AST_NO_STRICT_OVERFLOW) -Wno-format-nonliteral
 
 asterisk.o: _ASTCFLAGS+=$(LIBEDIT_INCLUDE)
+ast_expr2.o: _ASTCFLAGS+=-Wno-unused
 ast_expr2f.o: _ASTCFLAGS+=-Wno-unused
 astmm.o: _ASTCFLAGS+=$(call get_menuselect_cflags,MALLOC_DEBUG DEBUG_CHAOS)
 astobj2.o astobj2_container.o astobj2_hash.o astobj2_rbtree.o: _ASTCFLAGS+=$(call get_menuselect_cflags,AO2_DEBUG)

--- a/main/fskmodem_float.c
+++ b/main/fskmodem_float.c
@@ -225,7 +225,6 @@ int fsk_serial(fsk_data *fskd, short *buffer, int *len, int *outbyte)
 {
 	int a;
 	int i,j,n1,r;
-	int samples = 0;
 	int olen;
 
 	switch (fskd->state) {
@@ -257,14 +256,12 @@ int fsk_serial(fsk_data *fskd, short *buffer, int *len, int *outbyte)
 		a start bit, perhaps. This whole thing stinks! */
 		if (demodulator(fskd, &fskd->x1, GET_SAMPLE))
 			return -1;
-		samples++;
 		for (;;) {
 search_startbit2:
 			if (*len <= 0) {
 				fskd->state  =  STATE_SEARCH_STARTBIT2;
 				return 0;
 			}
-			samples++;
 			if (demodulator(fskd, &fskd->x2, GET_SAMPLE))
 				return(-1);
 #if 0
@@ -286,7 +283,6 @@ search_startbit3:
 #if 0
 			printf("x1 = %5.5f ", fskd->x1);
 #endif
-			samples++;
 		}
 
 		/* x1 must be negative (start bit confirmation) */

--- a/main/say.c
+++ b/main/say.c
@@ -8671,8 +8671,6 @@ static int ast_say_number_full_gr(struct ast_channel *chan, int num, const char 
 {
 	int res = 0;
 	char fn[256] = "";
-	int i=0;
-
 
 	if (!num) {
 		ast_copy_string(fn, "digits/0", sizeof(fn));
@@ -8682,7 +8680,6 @@ static int ast_say_number_full_gr(struct ast_channel *chan, int num, const char 
 	}
 
 	while (!res && num ) {
-		i++;
 		if (num < 13) {
 			snprintf(fn, sizeof(fn), "digits/%d", num);
 			num = 0;

--- a/main/utils.c
+++ b/main/utils.c
@@ -298,14 +298,12 @@ int ast_base64decode(unsigned char *dst, const char *src, int max)
 	int cnt = 0;
 	unsigned int byte = 0;
 	unsigned int bits = 0;
-	int incnt = 0;
 	while(*src && *src != '=' && (cnt < max)) {
 		/* Shift in 6 bits of input */
 		byte <<= 6;
 		byte |= (b2a[(int)(*src)]) & 0x3f;
 		bits += 6;
 		src++;
-		incnt++;
 		/* If we have at least 8 bits left over, take that character
 		   off the top */
 		if (bits >= 8)  {

--- a/res/Makefile
+++ b/res/Makefile
@@ -32,7 +32,7 @@ ael/ael_lex.o: ael/ael_lex.c ../include/asterisk/ael_structs.h ael/ael.tab.h
 ael/ael_lex.o: _ASTCFLAGS+=-I. -Iael -Wno-unused $(AST_NO_FORMAT_TRUNCATION)
 
 ael/ael.tab.o: ael/ael.tab.c ael/ael.tab.h ../include/asterisk/ael_structs.h
-ael/ael.tab.o: _ASTCFLAGS+=-I. -Iael -DYYENABLE_NLS=0
+ael/ael.tab.o: _ASTCFLAGS+=-I. -Iael -Wno-unused -DYYENABLE_NLS=0
 
 ifneq ($(findstring REBUILD_PARSERS,$(MENUSELECT_CFLAGS)),)
 ael/ael_lex.c: ael/ael.flex
@@ -54,6 +54,7 @@ endif
 	$(CMD_PREFIX) (cd ael; $(BISON) -v -d ael.y)
 
 ael/pval.o: ael/pval.c
+ael/pval.o: _ASTCFLAGS+=-Wno-unused
 
 $(call MOD_ADD_C,res_ael_share,ael/ael_lex.c ael/ael.tab.c ael/pval.c)
 $(call MOD_ADD_C,res_stasis,$(wildcard stasis/*.c))

--- a/res/prometheus/bridges.c
+++ b/res/prometheus/bridges.c
@@ -84,7 +84,7 @@ static void bridges_scrape_cb(struct ast_str **response)
 	struct prometheus_metric *metrics;
 	struct prometheus_metric **bridge_metrics;
 	char eid_str[32];
-	int i, j, num_bridges, num_outputs = 0;
+	int j, num_bridges, num_outputs = 0;
 	struct prometheus_metric bridge_count = PROMETHEUS_METRIC_STATIC_INITIALIZATION(
 		PROMETHEUS_METRIC_GAUGE,
 		"asterisk_bridges_count",
@@ -132,7 +132,7 @@ static void bridges_scrape_cb(struct ast_str **response)
 
 	/* Bridge dependent values */
 	it_bridges = ao2_iterator_init(bridges, 0);
-	for (i = 0; (bridge = ao2_iterator_next(&it_bridges)); ao2_ref(bridge, -1), i++) {
+	for (; (bridge = ao2_iterator_next(&it_bridges)); ao2_ref(bridge, -1)) {
 		struct ast_bridge_snapshot *snapshot;
 
 		/* Invisible bridges don't get shown externally and have no snapshot */


### PR DESCRIPTION
Fix or remove a few variables that were being set but not actually used anywhere, causing warnings with gcc 16.

Resolves: #1783