### PR TITLE
app_record: Fix hangup handling before record loop

### DIFF
--- a/apps/app_record.c
+++ b/apps/app_record.c
@@ -511,6 +511,12 @@ static int record_exec(struct ast_channel *chan, const char *data)
 	if (maxduration <= 0)
 		maxduration = -1;
 
+	if (ast_test_flag(ast_channel_flags(chan), AST_FLAG_ZOMBIE) || ast_check_hangup(chan)) {
+		ast_debug(1, "Channel hangup detected before ast_waitfor().\n");
+		status_response = "HANGUP";
+		res = -1;
+		goto out;
+	}
 	start = ast_tvnow();
 	while ((ms = ast_remaining_ms(start, maxduration))) {
 		ms = ast_waitfor(chan, ms);


### PR DESCRIPTION
When a hangup is received while app_record is playing the
initial beep (or immediately after it), but before entering
the main recording loop, the application does not detect
the hangup and continues running until timeout.

This change adds an early hangup check before the
ast_waitfor() loop to ensure the application exits
immediately when the channel is already in a hung-up state.