### PR TITLE
res_rtp_asterisk.c: Fix DTLS packet drop when TURN loopback re-injection occurs before ICE candidate check

### DIFF
--- a/res/res_rtp_asterisk.c
+++ b/res/res_rtp_asterisk.c
@@ -3267,6 +3267,18 @@ static int __rtp_recvfrom(struct ast_rtp_instance *instance, void *buf, size_t s
 
 		ast_debug_dtls(3, "(%p) DTLS - __rtp_recvfrom rtp=%p - Got SSL packet '%d'\n", instance, rtp, *in);
 
+#ifdef HAVE_PJPROJECT
+		/* If this packet arrived via TURN/ICE loopback re-injection,
+		 * substitute the real remote address before the candidate check
+		 * otherwise the DTLS check will see 127.0.0.1 and drop the packet.
+		 */
+		if (!ast_sockaddr_isnull(&rtp->rtp_loop) && !ast_sockaddr_cmp(&rtp->rtp_loop, sa)) {
+			ast_rtp_instance_get_remote_address(instance, sa);
+		} else if (rtcp && !ast_sockaddr_isnull(&rtp->rtcp_loop) && !ast_sockaddr_cmp(&rtp->rtcp_loop, sa)) {
+			ast_sockaddr_copy(sa, &rtp->rtcp->them);
+		}
+#endif
+
 		/*
 		 * If ICE is in use, we can prevent a possible DOS attack
 		 * by allowing DTLS protocol messages (client hello, etc)


### PR DESCRIPTION
When TURN is configured in rtp.conf, pjproject re-injects TURN packets
via 127.0.0.1 (the loopback address). The DTLS packet handler checks the
source address against the ICE active candidate list before the loopback
address substitution runs, causing the packet to be silently dropped as
the source 127.0.0.1 is not in the candidate list.

Fix by performing the loopback address substitution before the ICE
candidate source check in the DTLS path, mirroring the logic already
present in the non-DTLS RTP path.

Fixes: #1795

UserNote: WebRTC calls using TURN configured in rtp.conf (turnaddr,
turnusername, turnpassword) will now correctly complete DTLS/SRTP
negotiation. Previously all DTLS packets were silently dropped due to
the loopback re-injection address not being in the ICE active candidate
list.