### PR TITLE
res_audiosocket: Fix header read loop to use correct buffer offset

### DIFF
--- a/res/res_audiosocket.c
+++ b/res/res_audiosocket.c
@@ -298,7 +298,7 @@ struct ast_frame *ast_audiosocket_receive_frame_with_hangup(const int svc,
 	}
 
 	while (i < 3) {
-		n = read(svc, header, 3);
+		n = read(svc, header + i, 3 - i);
 		if (n == -1) {
 			if (errno == EAGAIN || errno == EWOULDBLOCK) {
 				int poll_result = ast_wait_for_input(svc, 5);


### PR DESCRIPTION
The PR #1522 introduced the header read loop for audiosocket packets which does not handle partial header reads correctly. This commit adds the missing buffer offsets.