### PR TITLE
chan_pjsip: Require `inband_progress` and negotiated SDP before mapping RINGING to 183

### DIFF
--- a/channels/chan_pjsip.c
+++ b/channels/chan_pjsip.c
@@ -1648,7 +1648,7 @@ static int chan_pjsip_indicate(struct ast_channel *ast, int condition, const voi
 	switch (condition) {
 	case AST_CONTROL_RINGING:
 		if (ast_channel_state(ast) == AST_STATE_RING) {
-			if (channel->session->endpoint->inband_progress ||
+			if (channel->session->endpoint->inband_progress &&
 				(channel->session->inv_session && channel->session->inv_session->neg &&
 				pjmedia_sdp_neg_get_state(channel->session->inv_session->neg) == PJMEDIA_SDP_NEG_STATE_DONE)) {
 				res = -1;


### PR DESCRIPTION
Dear maintainers, we are proposing a change to narrow the conditions under which `AST_CONTROL_RINGING` is mapped to `183 Session Progress`.

Previously, the 183 path was selected when either `inband_progress` was enabled or SDP negotiation had already reached `PJMEDIA_SDP_NEG_STATE_DONE`. This could result in `183` being sent for early-offer calls where SDP was negotiated, even if the endpoint was not configured for in-band progress.

With this change, `183` is only selected when both conditions are met:

* `inband_progress` is enabled
* SDP negotiation is in `PJMEDIA_SDP_NEG_STATE_DONE`

In all other cases, `AST_CONTROL_RINGING` maps to `180 Ringing`.

This avoids using SDP negotiation state alone as a trigger for `183`, and instead ties the behavior to explicit endpoint configuration combined with confirmed media readiness.
