### PR TITLE
chan_iax2: Add another check to abort frame handling if datalen < 0.

### DIFF
--- a/channels/chan_iax2.c
+++ b/channels/chan_iax2.c
@@ -12157,6 +12157,13 @@ immediatedial:
 	} else
 		f.samples = 0;
 
+	if (f.datalen < 0) {
+		ast_log(LOG_ERROR, "Dropping malformed frame (datalen %d?)\n", f.datalen);
+		ast_variables_destroy(ies.vars);
+		ast_mutex_unlock(&iaxsl[fr->callno]);
+		return 1;
+	}
+
 	iax_frame_wrap(fr, &f);
 
 	/* If this is our most recent packet, use it as our basis for timestamping */


### PR DESCRIPTION
Commit 2da221e217cbff957af928e8df43ee25583232d1 added a missing abort
if datalen < 0 check on a code path and an assertion inside
iax_frame_wrap if we ever encountered a frame with a negative frame
length (which will eventually cause a crash).

Add another missing abort check for negative datalen, exposed by this
assertion. (Similar to the previous commit, this is a video frame with
a datalen of -1).

Resolves: #1865
