### PR TITLE
res_rtp_asterisk: Destroy ioqueue in rtp_ioqueue_thread_destroy.

### DIFF
--- a/res/res_rtp_asterisk.c
+++ b/res/res_rtp_asterisk.c
@@ -1537,6 +1537,7 @@ static void rtp_ioqueue_thread_destroy(struct ast_rtp_ioqueue_thread *ioqueue)
 		pj_pool_t *temp_pool = ioqueue->pool;
 
 		ioqueue->pool = NULL;
+		pj_ioqueue_destroy(ioqueue->ioqueue);
 		pj_pool_release(temp_pool);
 	}
 


### PR DESCRIPTION
The rtp_ioqueue_thread_destroy() function was destroying the the ioqueue
thread and releasing its pool but not destroying the ioqueue itself.  This
was causing the ioqueue's epoll file descriptor to leak.

Resolves: #1867
