### PR TITLE
chan_iax2: Add CHANNEL getter to retrieve auth method.

### DIFF
--- a/channels/chan_iax2.c
+++ b/channels/chan_iax2.c
@@ -224,11 +224,24 @@
 			<enum name="peername">
 				<para>R/O Get the peer's username.</para>
 			</enum>
+			<enum name="auth_method">
+				<para>R/O Get the authentication method used for the call.</para>
+				<enumlist>
+					<enum name="none"/>
+					<enum name="plaintext"/>
+					<enum name="MD5"/>
+					<enum name="RSA"/>
+				</enumlist>
+			</enum>
 			<enum name="secure_signaling">
-				<para>R/O Get the if the IAX channel is secured.</para>
+				<para>R/O Get if the IAX channel is secured (encryption used for the call).</para>
+				<para>Because IAX encryption applies to both signaling and media, this setting
+				provides the same value as <literal>secure_media</literal>.</para>
 			</enum>
 			<enum name="secure_media">
-				<para>R/O Get the if the IAX channel is secured.</para>
+				<para>R/O Get if the IAX channel is secured (encryption used for the call).</para>
+				<para>Because IAX encryption applies to both signaling and media, this setting
+				provides the same value as <literal>secure_signaling</literal>.</para>
 			</enum>
 		</enumlist>
 	</info>
@@ -14637,6 +14650,8 @@ static int acf_channel_read(struct ast_channel *chan, const char *funcname, char
 		ast_copy_string(buf, !ast_sockaddr_isnull(&pvt->addr) ? ast_sockaddr_stringify_addr(&pvt->addr) : "", buflen);
 	} else if (!strcasecmp(args, "peername")) {
 		ast_copy_string(buf, pvt->username, buflen);
+	} else if (!strcasecmp(args, "auth_method")) {
+		ast_copy_string(buf, auth_method_labels[pvt->eff_auth_method], buflen);
 	} else if (!strcasecmp(args, "secure_signaling") || !strcasecmp(args, "secure_media")) {
 		snprintf(buf, buflen, "%s", IAX_CALLENCRYPTED(pvt) ? "1" : "");
 	} else {


### PR DESCRIPTION
Add a property to the CHANNEL method to retrieve the auth method,
which can be used to retrieve the specific auth method actually
negotiated for a call (e.g. RSA, MD5, etc.).

Also clean up some of the documentation for the secure properties
to clarify how these relate to call encryption.

Resolves: #1878

UserNote: CHANNEL(auth_method) can now be used to retrieve the
auth method negotiated for a call on IAX2 channels.
