### PR TITLE
fix: backport pjproject stdatomic.h GCC 4.8 build failure patch

### DIFF
--- a/third-party/pjproject/patches/0060-fix-stdatomic-gcc48.patch
+++ b/third-party/pjproject/patches/0060-fix-stdatomic-gcc48.patch
@@ -1,0 +1,14 @@
+--- a/pjlib/src/pj/os_core_unix.c
++++ b/pjlib/src/pj/os_core_unix.c
+@@ -47,7 +47,10 @@
+ 
+ #if PJ_HAS_THREADS
+ #  if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L \
+-                                && !defined(__STDC_NO_ATOMICS__)
++                                && !defined(__STDC_NO_ATOMICS__)  \
++                                && (!defined(__GNUC__) || defined(__clang__) \
++                                || __GNUC__ > 4 \
++                                || (__GNUC__ == 4 && __GNUC_MINOR__ >= 9))
+ #    define HAS_STD_ATOMICS 1
+ #    include <stdatomic.h>
+ #  else


### PR DESCRIPTION
pjproject 2.16 (bundled) fails to build on GCC 4.8 (CentOS/RHEL 7) due to a false positive C11 atomics detection introduced in pjproject commit #4570. A fix has been submitted upstream to pjproject (#4933).

Adding a local patch to third-party/pjproject/patches/ until a fixed version of pjproject is bundled in Asterisk.

Fixes build error:
../src/pj/os_core_unix.c:52:27: fatal error: stdatomic.h: No such file or directory

Resolves: #1883