### PR TITLE
asterisk.c: Fix #if HAVE_LIBEDIT_IS_UNICODE.

### DIFF
--- a/main/asterisk.c
+++ b/main/asterisk.c
@@ -2726,7 +2726,7 @@ static int ast_el_read_char(EditLine *editline, CHAR_T_LIBEDIT *cp)
 		}
 
 		if (!ast_opt_exec && fds[1].revents) {
-#if HAVE_LIBEDIT_IS_UNICODE
+#ifdef HAVE_LIBEDIT_IS_UNICODE
 			num_read = editline_read_char(editline, cp);
 			if (num_read < 1) {
 				break;


### PR DESCRIPTION
Line 2729 has `#if HAVE_LIBEDIT_IS_UNICODE` instead if `#ifdef`.  Since
macros defined by autoconf are either set to `1` or not set at all,
older distros where libedit isn't unicode won't have that macro defined
and will fail to compile.

Resolves: #1896
