### PR TITLE
compat.h: Ensure check for `__STDC_VERSION__` is not attempted for c++.

### DIFF
--- a/include/asterisk/compat.h
+++ b/include/asterisk/compat.h
@@ -22,9 +22,11 @@
 
 #include "asterisk/compiler.h"
 
+#if !defined(__cplusplus) && !defined(c_plusplus)
 #ifndef __STDC_VERSION__
 /* flex output wants to find this defined. */
 #define	__STDC_VERSION__ 0
+#endif
 #endif
 
 #include <inttypes.h>


### PR DESCRIPTION
`__STDC_VERSION__` is specific to C but up until gcc 16, the g++ compiler
also defined it.  With g++ 16.0 it's no longer defined (which is the correct
behavior) so compiling channelstorage_cpp_map_name_id.cc fails.  The
check for `__STDC_VERSION__` in compat.h is now skipped if we're compiling
a C++ source file.

Resolves: #1903
