### PR TITLE
rtp: Use timestamp difference for video playback rate.

### DIFF
--- a/formats/format_h263.c
+++ b/formats/format_h263.c
@@ -45,89 +45,121 @@
  * theoretical limit is not much larger (32k = 15bits), we'll go for that
  * size to ensure we don't corrupt frames sent to us (unless they're
  * ridiculously large). */
-#define	BUF_SIZE	32768	/* Four real h.263 Frames */
-
-#define FRAME_ENDED 0x8000
+#define BUF_SIZE	32768	/* Four real h.263 Frames */
+#define FRAME_ENDED	0x8000
 
 struct h263_desc {
 	unsigned int lastts;
 };
 
-
-static int h263_open(struct ast_filestream *s)
+static int h263_open(struct ast_filestream *fs)
 {
 	unsigned int ts;
+	struct h263_desc *desc = (struct h263_desc *) fs->_private;
 
-	if (fread(&ts, 1, sizeof(ts), s->f) != sizeof(ts)) {
+	if (fread(&ts, 1, sizeof(ts), fs->f) != sizeof(ts)) {
 		ast_log(LOG_WARNING, "Empty file!\n");
 		return -1;
 	}
+
+	desc->lastts = ntohl(ts);
 	return 0;
 }
 
-static struct ast_frame *h263_read(struct ast_filestream *s, int *whennext)
+static struct ast_frame *h263_read(struct ast_filestream *fs, int *whennext)
 {
 	size_t res;
-	uint32_t mark;
-	unsigned short len;
 	unsigned int ts;
-	struct h263_desc *fs = (struct h263_desc *)s->_private;
+	unsigned short mark;
+	unsigned short len;
+	struct h263_desc *desc = (struct h263_desc *) fs->_private;
 
 	/* Send a frame from the file to the appropriate channel */
-	if ((res = fread(&len, 1, sizeof(len), s->f)) != sizeof(len))
+	if (fread(&len, 1, sizeof(len), fs->f) != sizeof(len)) {
 		return NULL;
+	}
+
 	len = ntohs(len);
-	mark = (len & FRAME_ENDED) ? 1 : 0;
-	len &= 0x7fff;
+	mark = len & FRAME_ENDED;
+	len &= ~FRAME_ENDED;
+
 	if (len > BUF_SIZE) {
 		ast_log(LOG_WARNING, "Length %d is too long\n", len);
 		return NULL;
 	}
-	AST_FRAME_SET_BUFFER(&s->fr, s->buf, AST_FRIENDLY_OFFSET, len);
-	if ((res = fread(s->fr.data.ptr, 1, s->fr.datalen, s->f)) != s->fr.datalen) {
-		if (res) {
-			ast_log(LOG_WARNING, "Short read of %s data (expected %d bytes, read %zu): %s\n",
-					ast_format_get_name(s->fr.subclass.format), s->fr.datalen, res,
-					strerror(errno));
-		}
+
+	fs->fr.datalen = len;
+	fs->fr.subclass.frame_ending = mark ? 1 : 0;
+	AST_FRAME_SET_BUFFER(&fs->fr, fs->buf, AST_FRIENDLY_OFFSET, len);
+
+	if ((res = fread(fs->fr.data.ptr, 1, fs->fr.datalen, fs->f)) != fs->fr.datalen) {
+		ast_log(LOG_WARNING, "Short read of %s data (expected %d bytes, read %zu): %s\n",
+			ast_format_get_name(fs->fr.subclass.format), fs->fr.datalen, res,
+			strerror(errno));
 		return NULL;
 	}
-	s->fr.samples = fs->lastts;	/* XXX what ? */
-	s->fr.datalen = len;
-	s->fr.subclass.frame_ending = mark;
-	if ((res = fread(&ts, 1, sizeof(ts), s->f)) == sizeof(ts)) {
-		fs->lastts = ntohl(ts);
-		*whennext = fs->lastts * 4/45;
-	} else
-		*whennext = 0;
-	return &s->fr;
+
+	fs->fr.ts = desc->lastts;
+	ast_set_flag(&fs->fr, AST_FRFLAG_HAS_TIMING_INFO);
+
+	if (fread(&ts, 1, sizeof(ts), fs->f) == sizeof(ts)) {
+		ts = ntohl(ts);
+
+		if (ts != desc->lastts) {
+			*whennext = ts - desc->lastts;
+
+			/* The timestamp probably won't exactly match the expected sample rate
+			 * increment due to scheduling jitter inside the phone and the use of
+			 * wall-clock time. If it looks roughly like 30fps adjust it to that. */
+			if (*whennext >= 27 && *whennext <= 40) {
+				*whennext = 33;
+			}
+
+			/* We want to be scheduled closest to just before the actual timeout */
+			*whennext -= 1;
+			desc->lastts = ts;
+		}
+	}
+
+	return &fs->fr;
 }
 
-static int h263_write(struct ast_filestream *fs, struct ast_frame *f)
+static int h263_write(struct ast_filestream *fs, struct ast_frame *fr)
 {
-	int res;
+	size_t res;
 	unsigned int ts;
+	unsigned short mark;
 	unsigned short len;
-	uint32_t mark = 0;
-	mark = f->subclass.frame_ending ? FRAME_ENDED : 0;
-	ts = htonl(f->samples);
+
+	if (fr->len > BUF_SIZE) {
+		ast_log(LOG_WARNING, "Length %ld is too long\n", fr->len);
+		return -1;
+	}
+
+	ts = htonl(fr->ts);
+
 	if ((res = fwrite(&ts, 1, sizeof(ts), fs->f)) != sizeof(ts)) {
-			ast_log(LOG_WARNING, "Bad write (%d/4): %s\n", res, strerror(errno));
-			return -1;
+		ast_log(LOG_WARNING, "Bad write (%zd/4): %s\n", res, strerror(errno));
+		return -1;
 	}
-	len = htons(f->datalen | mark);
+
+	mark = fr->subclass.frame_ending ? FRAME_ENDED : 0;
+	len = htons(fr->datalen | mark);
+
 	if ((res = fwrite(&len, 1, sizeof(len), fs->f)) != sizeof(len)) {
-			ast_log(LOG_WARNING, "Bad write (%d/2): %s\n", res, strerror(errno));
-			return -1;
+		ast_log(LOG_WARNING, "Bad write (%zd/2): %s\n", res, strerror(errno));
+		return -1;
 	}
-	if ((res = fwrite(f->data.ptr, 1, f->datalen, fs->f)) != f->datalen) {
-			ast_log(LOG_WARNING, "Bad write (%d/%d): %s\n", res, f->datalen, strerror(errno));
-			return -1;
+
+	if ((res = fwrite(fr->data.ptr, 1, fr->datalen, fs->f)) != fr->datalen) {
+		ast_log(LOG_WARNING, "Bad write (%zd/%d): %s\n", res, fr->datalen, strerror(errno));
+		return -1;
 	}
+
 	return 0;
 }
 
-static int h263_seek(struct ast_filestream *fs, off_t sample_offset, int whence)
+static int h263_seek(struct ast_filestream *fs, off_t off, int whence)
 {
 	/* No way Jose */
 	return -1;
@@ -142,18 +174,21 @@ static int h263_trunc(struct ast_filestream *fs)
 		ast_log(AST_LOG_WARNING, "Unable to determine file descriptor for h263 filestream %p: %s\n", fs, strerror(errno));
 		return -1;
 	}
+
 	if ((cur = ftello(fs->f)) < 0) {
 		ast_log(AST_LOG_WARNING, "Unable to determine current position in h263 filestream %p: %s\n", fs, strerror(errno));
 		return -1;
 	}
+
 	/* Truncate file to current length */
 	return ftruncate(fd, cur);
 }
 
 static off_t h263_tell(struct ast_filestream *fs)
 {
-	off_t offset = ftello(fs->f);
-	return offset;	/* XXX totally bogus, needs fixing */
+	off_t off = ftello(fs->f);
+
+	return off; /* XXX totally bogus, needs fixing */
 }
 
 static struct ast_format_def h263_f = {
@@ -172,8 +207,11 @@ static struct ast_format_def h263_f = {
 static int load_module(void)
 {
 	h263_f.format = ast_format_h263;
-	if (ast_format_def_register(&h263_f))
+
+	if (ast_format_def_register(&h263_f)) {
 		return AST_MODULE_LOAD_DECLINE;
+	}
+
 	return AST_MODULE_LOAD_SUCCESS;
 }
 

--- a/formats/format_h264.c
+++ b/formats/format_h264.c
@@ -40,83 +40,117 @@
 /* Portions of the conversion code are by guido@sienanet.it */
 /*! \todo Check this buf size estimate, it may be totally wrong for large frame video */
 
+#define BUF_SIZE	4096	/* Two Real h264 Frames */
 #define FRAME_ENDED	0x8000
 
-#define BUF_SIZE	4096	/* Two Real h264 Frames */
 struct h264_desc {
 	unsigned int lastts;
 };
 
-static int h264_open(struct ast_filestream *s)
+static int h264_open(struct ast_filestream *fs)
 {
 	unsigned int ts;
-	if (fread(&ts, 1, sizeof(ts), s->f) != sizeof(ts)) {
+	struct h264_desc *desc = (struct h264_desc *) fs->_private;
+
+	if (fread(&ts, 1, sizeof(ts), fs->f) != sizeof(ts)) {
 		ast_log(LOG_WARNING, "Empty file!\n");
 		return -1;
 	}
+
+	desc->lastts = ntohl(ts);
 	return 0;
 }
 
-static struct ast_frame *h264_read(struct ast_filestream *s, int *whennext)
+static struct ast_frame *h264_read(struct ast_filestream *fs, int *whennext)
 {
 	size_t res;
-	int mark = 0;
-	unsigned short len;
 	unsigned int ts;
-	struct h264_desc *fs = (struct h264_desc *)s->_private;
+	unsigned short mark;
+	unsigned short len;
+	struct h264_desc *desc = (struct h264_desc *) fs->_private;
 
 	/* Send a frame from the file to the appropriate channel */
-	if ((res = fread(&len, 1, sizeof(len), s->f)) != sizeof(len))
+	if (fread(&len, 1, sizeof(len), fs->f) != sizeof(len)) {
 		return NULL;
+	}
+
 	len = ntohs(len);
-	mark = (len & FRAME_ENDED) ? 1 : 0;
-	len &= 0x7fff;
+	mark = len & FRAME_ENDED;
+	len &= ~FRAME_ENDED;
+
 	if (len > BUF_SIZE) {
 		ast_log(LOG_WARNING, "Length %d is too long\n", len);
-		len = BUF_SIZE;	/* XXX truncate */
-	}
-	AST_FRAME_SET_BUFFER(&s->fr, s->buf, AST_FRIENDLY_OFFSET, len);
-	if ((res = fread(s->fr.data.ptr, 1, s->fr.datalen, s->f)) != s->fr.datalen) {
-		if (res) {
-			ast_log(LOG_WARNING, "Short read of %s data (expected %d bytes, read %zu): %s\n",
-					ast_format_get_name(s->fr.subclass.format), s->fr.datalen, res,
-					strerror(errno));
-		}
 		return NULL;
 	}
-	s->fr.samples = fs->lastts;
-	s->fr.datalen = len;
-	s->fr.subclass.frame_ending = mark;
-	if ((res = fread(&ts, 1, sizeof(ts), s->f)) == sizeof(ts)) {
-		fs->lastts = ntohl(ts);
-		*whennext = fs->lastts * 4/45;
-	} else
-		*whennext = 0;
-	return &s->fr;
+
+	fs->fr.datalen = len;
+	fs->fr.subclass.frame_ending = mark ? 1 : 0;
+	AST_FRAME_SET_BUFFER(&fs->fr, fs->buf, AST_FRIENDLY_OFFSET, len);
+
+	if ((res = fread(fs->fr.data.ptr, 1, fs->fr.datalen, fs->f)) != fs->fr.datalen) {
+		ast_log(LOG_WARNING, "Short read of %s data (expected %d bytes, read %zu): %s\n",
+			ast_format_get_name(fs->fr.subclass.format), fs->fr.datalen, res,
+			strerror(errno));
+		return NULL;
+	}
+
+	ast_set_flag(&fs->fr, AST_FRFLAG_HAS_TIMING_INFO);
+	fs->fr.ts = desc->lastts;
+
+	if (fread(&ts, 1, sizeof(ts), fs->f) == sizeof(ts)) {
+		ts = ntohl(ts);
+
+		if (ts != desc->lastts) {
+			*whennext = ts - desc->lastts;
+
+			/* The timestamp probably won't exactly match the expected sample rate
+			 * increment due to scheduling jitter inside the phone and the use of
+			 * wall-clock time. If it looks roughly like 30fps adjust it to that. */
+			if (*whennext >= 27 && *whennext <= 40) {
+				*whennext = 33;
+			}
+
+			/* We want to be scheduled to just before the actual timeout */
+			*whennext -= 1;
+			desc->lastts = ts;
+		}
+	}
+
+	return &fs->fr;
 }
 
-static int h264_write(struct ast_filestream *s, struct ast_frame *f)
+static int h264_write(struct ast_filestream *fs, struct ast_frame *fr)
 {
-	int res;
+	size_t res;
 	unsigned int ts;
+	unsigned short mark;
 	unsigned short len;
-	int mark;
 
-	mark = f->subclass.frame_ending ? FRAME_ENDED : 0;
-	ts = htonl(f->samples);
-	if ((res = fwrite(&ts, 1, sizeof(ts), s->f)) != sizeof(ts)) {
-		ast_log(LOG_WARNING, "Bad write (%d/4): %s\n", res, strerror(errno));
+	if (fr->len > BUF_SIZE) {
+		ast_log(LOG_WARNING, "Length %ld is too long\n", fr->len);
 		return -1;
 	}
-	len = htons(f->datalen | mark);
-	if ((res = fwrite(&len, 1, sizeof(len), s->f)) != sizeof(len)) {
-		ast_log(LOG_WARNING, "Bad write (%d/2): %s\n", res, strerror(errno));
+
+	ts = htonl(fr->ts);
+
+	if ((res = fwrite(&ts, 1, sizeof(ts), fs->f)) != sizeof(ts)) {
+		ast_log(LOG_WARNING, "Bad write (%zu/4): %s\n", res, strerror(errno));
 		return -1;
 	}
-	if ((res = fwrite(f->data.ptr, 1, f->datalen, s->f)) != f->datalen) {
-		ast_log(LOG_WARNING, "Bad write (%d/%d): %s\n", res, f->datalen, strerror(errno));
+
+	mark = fr->subclass.frame_ending ? FRAME_ENDED : 0;
+	len = htons(fr->datalen | mark);
+
+	if ((res = fwrite(&len, 1, sizeof(len), fs->f)) != sizeof(len)) {
+		ast_log(LOG_WARNING, "Bad write (%zu/2): %s\n", res, strerror(errno));
 		return -1;
 	}
+
+	if ((res = fwrite(fr->data.ptr, 1, fr->datalen, fs->f)) != fr->datalen) {
+		ast_log(LOG_WARNING, "Bad write (%zu/%d): %s\n", res, fr->datalen, strerror(errno));
+		return -1;
+	}
+
 	return 0;
 }
 
@@ -135,18 +169,21 @@ static int h264_trunc(struct ast_filestream *fs)
 		ast_log(AST_LOG_WARNING, "Unable to determine file descriptor for h264 filestream %p: %s\n", fs, strerror(errno));
 		return -1;
 	}
+
 	if ((cur = ftello(fs->f)) < 0) {
 		ast_log(AST_LOG_WARNING, "Unable to determine current position in h264 filestream %p: %s\n", fs, strerror(errno));
 		return -1;
 	}
+
 	/* Truncate file to current length */
 	return ftruncate(fd, cur);
 }
 
 static off_t h264_tell(struct ast_filestream *fs)
 {
-	off_t offset = ftell(fs->f);
-	return offset; /* XXX totally bogus, needs fixing */
+	off_t off = ftello(fs->f);
+
+	return off; /* XXX totally bogus, needs fixing */
 }
 
 static struct ast_format_def h264_f = {
@@ -165,8 +202,11 @@ static struct ast_format_def h264_f = {
 static int load_module(void)
 {
 	h264_f.format = ast_format_h264;
-	if (ast_format_def_register(&h264_f))
+
+	if (ast_format_def_register(&h264_f)) {
 		return AST_MODULE_LOAD_DECLINE;
+	}
+
 	return AST_MODULE_LOAD_SUCCESS;
 }
 

--- a/main/codec_builtin.c
+++ b/main/codec_builtin.c
@@ -796,56 +796,56 @@ static struct ast_codec h261 = {
 	.name = "h261",
 	.description = "H.261 video",
 	.type = AST_MEDIA_TYPE_VIDEO,
-	.sample_rate = 1000,
+	.sample_rate = 90000,
 };
 
 static struct ast_codec h263 = {
 	.name = "h263",
 	.description = "H.263 video",
 	.type = AST_MEDIA_TYPE_VIDEO,
-	.sample_rate = 1000,
+	.sample_rate = 90000,
 };
 
 static struct ast_codec h263p = {
 	.name = "h263p",
 	.description = "H.263+ video",
 	.type = AST_MEDIA_TYPE_VIDEO,
-	.sample_rate = 1000,
+	.sample_rate = 90000,
 };
 
 static struct ast_codec h264 = {
 	.name = "h264",
 	.description = "H.264 video",
 	.type = AST_MEDIA_TYPE_VIDEO,
-	.sample_rate = 1000,
+	.sample_rate = 90000,
 };
 
 static struct ast_codec h265 = {
 	.name = "h265",
 	.description = "H.265 video",
 	.type = AST_MEDIA_TYPE_VIDEO,
-	.sample_rate = 1000,
+	.sample_rate = 90000,
 };
 
 static struct ast_codec mpeg4 = {
 	.name = "mpeg4",
 	.description = "MPEG4 video",
 	.type = AST_MEDIA_TYPE_VIDEO,
-	.sample_rate = 1000,
+	.sample_rate = 90000,
 };
 
 static struct ast_codec vp8 = {
 	.name = "vp8",
 	.description = "VP8 video",
 	.type = AST_MEDIA_TYPE_VIDEO,
-	.sample_rate = 1000,
+	.sample_rate = 90000,
 };
 
 static struct ast_codec vp9 = {
 	.name = "vp9",
 	.description = "VP9 video",
 	.type = AST_MEDIA_TYPE_VIDEO,
-	.sample_rate = 1000,
+	.sample_rate = 90000,
 };
 
 static struct ast_codec t140red = {

--- a/main/file.c
+++ b/main/file.c
@@ -1052,7 +1052,7 @@ static enum fsread_res ast_readvideo_callback(struct ast_filestream *s)
 	}
 
 	if (whennext != s->lasttimeout) {
-		ast_channel_vstreamid_set(s->owner, ast_sched_add(ast_channel_sched(s->owner), whennext / (ast_format_get_sample_rate(s->fmt->format) / 1000), ast_fsread_video, s));
+		ast_channel_vstreamid_set(s->owner, ast_sched_add(ast_channel_sched(s->owner), whennext, ast_fsread_video, s));
 		s->lasttimeout = whennext;
 		return FSREAD_SUCCESS_NOSCHED;
 	}

--- a/res/res_rtp_asterisk.c
+++ b/res/res_rtp_asterisk.c
@@ -5226,22 +5226,23 @@ static int rtp_raw_write(struct ast_rtp_instance *instance, struct ast_frame *fr
 		}
 	} else if (frame->frametype == AST_FRAME_VIDEO) {
 		mark = frame->subclass.frame_ending;
-		pred = rtp->lastovidtimestamp + frame->samples;
+		pred = rtp->lastts + ((frame->ts - rtp->lastovidtimestamp) / rate);
+
 		/* Re-calculate last TS */
-		rtp->lastts = rtp->lastts + ms * 90;
+		rtp->lastts = rtp->lastts + ms * rate;
 		/* If it's close to our prediction, go for it */
 		if (ast_tvzero(frame->delivery)) {
 			if (abs((int)rtp->lastts - pred) < 7200) {
 				rtp->lastts = pred;
-				rtp->lastovidtimestamp += frame->samples;
 			} else {
-				ast_debug_rtp(3, "(%p) RTP video difference is %d, ms is %u (%u), pred/ts/samples %u/%d/%d\n",
-					instance, abs((int)rtp->lastts - pred), ms, ms * 90, rtp->lastts, pred, frame->samples);
-				rtp->lastovidtimestamp = rtp->lastts;
+				ast_debug_rtp(3, "(%p) RTP video difference is %d, ms is %u\n",
+					instance, abs((int)rtp->lastts - pred), ms);
 			}
+			rtp->lastovidtimestamp = frame->ts;
 		}
 	} else {
 		pred = rtp->lastotexttimestamp + frame->samples;
+
 		/* Re-calculate last TS */
 		rtp->lastts = rtp->lastts + ms;
 		/* If it's close to our prediction, go for it */
@@ -8108,8 +8109,7 @@ static struct ast_frame *ast_rtp_interpret(struct ast_rtp_instance *instance, st
 			rtp->lastividtimestamp = timestamp;
 		calc_rxstamp_and_jitter(&rtp->f.delivery, rtp, timestamp, mark);
 		ast_set_flag(&rtp->f, AST_FRFLAG_HAS_TIMING_INFO);
-		rtp->f.ts = timestamp / (ast_rtp_get_rate(rtp->f.subclass.format) / 1000);
-		rtp->f.samples = timestamp - rtp->lastividtimestamp;
+		rtp->f.ts = timestamp / (ast_format_get_sample_rate(rtp->f.subclass.format) / 1000);
 		rtp->lastividtimestamp = timestamp;
 		rtp->f.delivery.tv_sec = 0;
 		rtp->f.delivery.tv_usec = 0;


### PR DESCRIPTION
When playing an audio file that has an associated video file that stream will not finish at the correct time due to incorrect scheduling of ast_readvideo_callback.

Non-zero scheduling between frames now only occurs when the frame timestamp changes and when-next is now
calculated using the  difference in timestamps between frames.

Video frames were also sent out with an incorrectly calcuated timestamp because the flag AST_FRFLAG_HAS_TIMING_INFO was not set on frames read from a file.

UserNote: The on-disk format for H263 and H264 video streams has changed so any previous recordings are not be playable.