### PR TITLE
third-party/pjproject: backport CVE-2026-41415 and CVE-2026-32945 fixes

### DIFF
--- a/third-party/pjproject/patches/0080-multipart-cid-uri-length.patch
+++ b/third-party/pjproject/patches/0080-multipart-cid-uri-length.patch
@@ -1,0 +1,32 @@
+From 4225a93c16661538005017883fbc8f1ea1d5f4b0 Mon Sep 17 00:00:00 2001
+From: sauwming <ming@teluu.com>
+Date: Tue, 10 Mar 2026 13:14:45 +0800
+Subject: [PATCH] Fixed SIP Multipart CID URI length check (#4844)
+
+---
+ pjsip/src/pjsip/sip_multipart.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/pjsip/src/pjsip/sip_multipart.c b/pjsip/src/pjsip/sip_multipart.c
+index a6b66e2..0db8d11 100644
+--- a/pjsip/src/pjsip/sip_multipart.c
++++ b/pjsip/src/pjsip/sip_multipart.c
+@@ -549,12 +549,14 @@ static pj_str_t cid_uri_to_hdr_value(pj_pool_t *pool, pj_str_t *cid_uri)
+     pj_size_t cid_len = pj_strlen(cid_uri);
+     pj_size_t alloc_len = cid_len + 2 /* for the leading and trailing angle brackets */;
+     pj_str_t uri_overlay;
+-    pj_str_t cid_hdr;
++    pj_str_t cid_hdr = {0};
+     pj_str_t hdr_overlay;
+ 
+     pj_strassign(&uri_overlay, cid_uri);
+     /* If the URI is already enclosed in angle brackets, remove them. */
+     if (uri_overlay.ptr[0] == '<') {
++        if (uri_overlay.slen < 2)
++            return cid_hdr;
+         uri_overlay.ptr++;
+         uri_overlay.slen -= 2;
+     }
+-- 
+2.54.0
+

--- a/third-party/pjproject/patches/0090-pjlib-util-dns-bof.patch
+++ b/third-party/pjproject/patches/0090-pjlib-util-dns-bof.patch
@@ -1,0 +1,39 @@
+From 5311aee398ae9d623829a6bad7b679a193c9e199 Mon Sep 17 00:00:00 2001
+From: sauwming <ming@teluu.com>
+Date: Tue, 17 Mar 2026 07:58:29 +0800
+Subject: [PATCH] Merge commit from fork
+
+* Fixes potential heap buffer overflow in DNS parser
+
+* Add check in get_name() as well
+---
+ pjlib-util/src/pjlib-util/dns.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/pjlib-util/src/pjlib-util/dns.c b/pjlib-util/src/pjlib-util/dns.c
+index 56a54c9..8e042cb 100644
+--- a/pjlib-util/src/pjlib-util/dns.c
++++ b/pjlib-util/src/pjlib-util/dns.c
+@@ -139,6 +139,9 @@ static pj_status_t get_name_len(int rec_counter, const pj_uint8_t *pkt,
+             int dummy;
+             pj_uint16_t offset;
+ 
++            if (p + 1 >= max)
++                return PJLIB_UTIL_EDNSINNAMEPTR;
++
+             /* Get the 14bit offset */
+             pj_memcpy(&offset, p, 2);
+             offset ^= pj_htons((pj_uint16_t)(0xc0 << 8));
+@@ -211,6 +214,9 @@ static pj_status_t get_name(int rec_counter, const pj_uint8_t *pkt,
+             /* Compression is found! */
+             pj_uint16_t offset;
+ 
++            if (p + 1 >= max)
++                return PJLIB_UTIL_EDNSINNAMEPTR;
++
+             /* Get the 14bit offset */
+             pj_memcpy(&offset, p, 2);
+             offset ^= pj_htons((pj_uint16_t)(0xc0 << 8));
+-- 
+2.54.0
+


### PR DESCRIPTION
Two upstream pjproject fixes for CVEs unfixed in the pinned 2.16. Both target operator-opt-in code paths in current Asterisk default builds, neither is an emergency, both are small isolated diffs. Same form as the existing `0020/0030/0040/0050` series.

## `0080-multipart-cid-uri-length.patch`

Mirrors upstream commit [`4225a93`](https://github.com/pjsip/pjproject/commit/4225a93c16661538005017883fbc8f1ea1d5f4b0) ("Fixed SIP Multipart CID URI length check", PR pjsip/pjproject#4844). +3/-1 lines in `pjsip/src/pjsip/sip_multipart.c`.

Fixes [CVE-2026-41415 / GHSA-935m-fmf5-j4pm](https://github.com/pjsip/pjproject/security/advisories/GHSA-935m-fmf5-j4pm): length underflow in `cid_uri_to_hdr_value()` when a CID URI starts with `<` and has length < 2. Distinct from the `f0fa32a` multipart fix that `0050` already mirrors.

Reachable in Asterisk only via `res_pjsip_geolocation.c:77` → `pjsip_multipart_find_part_by_cid_str()` → `cid_uri_to_hdr_value()`. The geolocation handler short-circuits unless `endpoint->geoloc_incoming_call_profile` is configured, which is operator opt-in.

## `0090-pjlib-util-dns-bof.patch`

Mirrors upstream commit [`5311aee`](https://github.com/pjsip/pjproject/commit/5311aee398ae9d623829a6bad7b679a193c9e199). +6 lines in `pjlib-util/src/pjlib-util/dns.c`.

Fixes [CVE-2026-32945 / GHSA-jr2p-p2w4-rr9q](https://github.com/pjsip/pjproject/security/advisories/GHSA-jr2p-p2w4-rr9q): heap buffer overflow in `get_name()` and `get_name_len()` when parsing compressed DNS names without bounds-checking the offset pointer.

`configure.ac` sets `HAVE_PJSIP_EXTERNAL_RESOLVER=1` whenever pjproject exports `pjsip_endpt_set_ext_resolver` (which 2.16 does); `res/res_pjsip/pjsip_resolver.c:698` registers Asterisk's own DNS layer in default builds. The pjlib-util DNS path is engaged only when an operator configures `nameserver = X` under `[system]` in `pjsip.conf`.

## Files

```
third-party/pjproject/patches/0080-multipart-cid-uri-length.patch
third-party/pjproject/patches/0090-pjlib-util-dns-bof.patch
```

Patches preserve the original upstream author and commit metadata, same convention as the existing patch series.
