### PR TITLE
third-party: add CVE-APPLICABILITY.md for bundled deps

### DIFF
--- a/third-party/CVE-APPLICABILITY-FORMAT.md
+++ b/third-party/CVE-APPLICABILITY-FORMAT.md
@@ -1,0 +1,49 @@
+# CVE applicability log format
+
+Per-bundled-dep `CVE-APPLICABILITY.md` files in `third-party/<dep>/` use the format described here. Each file is per-dep, but the bucket vocabulary, OpenVEX justification mapping, and column conventions are shared across all bundled deps.
+
+## When to add a row
+
+* Open one row when an upstream GHSA is published against a bundled dep listed in `third-party/versions.mak`.
+* Add the row at any time. The `bundled-dep-cve-sync` workflow opens placeholder rows automatically on a weekly cron; rows added by hand follow the same shape.
+
+## Buckets
+
+| Bucket | Meaning | OpenVEX justification |
+|---|---|---|
+| 1 | Code excluded at compile time (configure flag, `#if` guard, or absent from source tree). | `vulnerable_code_not_present` |
+| 2 | Code present in the linked binary but no Asterisk source path calls it. | `vulnerable_code_cannot_be_controlled_by_adversary` |
+| 3 | Code reachable only after operator opt-in (AMI/ARI, authenticated SIP session, non-default config). | `vulnerable_code_not_in_execute_path` |
+| 4 | Pre-auth reachable in default or commonly-deployed configuration. | `affected` |
+
+## Suffix markers
+
+* `[patched]`: backport applied in `third-party/<dep>/patches/`.
+* `[open]`: applicability decision recorded; no backport in this repo.
+* `?`: row added by the sync bot, awaiting triage.
+
+## Scoping rule
+
+A CVE is *in-scope* iff its upstream fix is **not** present in the version pinned in `third-party/versions.mak`. A CVE is *out-of-scope* iff its upstream fix is present (the pinned source already contains the fix) or its vulnerable version range does not include the pinned version.
+
+When the pin is bumped, the maintainer re-evaluates each row: in-scope rows whose upstream fix is now in the new pin move to out-of-scope; new upstream CVEs since the previous pin need rows added.
+
+## Row schema (in-scope table)
+
+| Column | Content |
+|---|---|
+| Published | upstream GHSA publish date, ISO 8601 |
+| GHSA / CVE | linked GHSA ID + CVE ID |
+| Sev | upstream severity |
+| Title | upstream summary |
+| Bucket | one of `1` / `2` / `3` / `4`, optionally with `[patched]` or `[open]` suffix |
+| Justification | one-line evidence: build-flag citation, file guard, callgraph note, or patch reference |
+
+## Row schema (out-of-scope table)
+
+| Column | Content |
+|---|---|
+| CVE | CVE ID (or GHSA when no CVE assigned) |
+| Patched upstream in | upstream version that landed the fix |
+
+For deps where the pinned major is outside the vulnerable range, replace the second column with "Vulnerable range" and quote the upstream-stated range.

--- a/third-party/jansson/CVE-APPLICABILITY.md
+++ b/third-party/jansson/CVE-APPLICABILITY.md
@@ -1,0 +1,17 @@
+# jansson CVE applicability
+
+Per-CVE applicability decisions for the bundled `jansson` source pinned in [`third-party/versions.mak`](../versions.mak) (`JANSSON_VERSION`).
+
+Classifications are valid for the `jansson` pin at the same commit as this file.
+
+## Format
+
+See [`../CVE-APPLICABILITY-FORMAT.md`](../CVE-APPLICABILITY-FORMAT.md).
+
+## In-scope CVEs
+
+None. Upstream [`akheron/jansson`](https://github.com/akheron/jansson/security/advisories) has zero published GHSAs as of last sync.
+
+## Out-of-scope CVEs
+
+None.

--- a/third-party/libjwt/CVE-APPLICABILITY.md
+++ b/third-party/libjwt/CVE-APPLICABILITY.md
@@ -1,0 +1,20 @@
+# libjwt CVE applicability
+
+Per-CVE applicability decisions for the bundled `libjwt` source pinned in [`third-party/versions.mak`](../versions.mak) (`LIBJWT_VERSION`).
+
+Classifications are valid for the `libjwt` pin at the same commit as this file.
+
+## Format
+
+See [`../CVE-APPLICABILITY-FORMAT.md`](../CVE-APPLICABILITY-FORMAT.md).
+
+## In-scope CVEs
+
+None. Both published [benmcollins/libjwt](https://github.com/benmcollins/libjwt/security/advisories) GHSAs target the 3.x branch; the pinned major is outside the vulnerable range.
+
+## Out-of-scope CVEs (pinned major outside vulnerable range)
+
+| Published | GHSA / CVE | Sev | Title | Vulnerable range |
+|---|---|---|---|---|
+| 2026-05-04 | [GHSA-q843-6q5f-w55g](https://github.com/benmcollins/libjwt/security/advisories/GHSA-q843-6q5f-w55g) | critical | Algorithm confusion: JWT forgery via RSA JWK as empty-key HMAC | `>= 3.0.0, <= 3.3.2`; patched in `3.3.3` |
+| 2026-03-25 | [GHSA-ph96-hqpc-9f66](https://github.com/benmcollins/libjwt/security/advisories/GHSA-ph96-hqpc-9f66) / CVE-2026-33996 | medium | NULL/bounds validation in JWK octet and RSA PSS parsing | `>= 3.0.0, < 3.3.0`; patched in `>= 3.3.0` |

--- a/third-party/pjproject/CVE-APPLICABILITY.md
+++ b/third-party/pjproject/CVE-APPLICABILITY.md
@@ -1,0 +1,43 @@
+# pjproject CVE applicability
+
+Per-CVE applicability decisions for the bundled `pjproject` source pinned in [`third-party/versions.mak`](../versions.mak) (`PJPROJECT_VERSION`), against the Asterisk build configured by [`third-party/pjproject/Makefile.rules`](Makefile.rules) and [`third-party/pjproject/configure.m4`](configure.m4).
+
+Classifications are valid for the `pjproject` pin at the same commit as this file. When the pin is bumped, the maintainer re-evaluates rows: in-scope CVEs whose upstream fix is now in the pinned source move to out-of-scope; new upstream CVEs since the previous pin need rows added.
+
+## Format
+
+See [`../CVE-APPLICABILITY-FORMAT.md`](../CVE-APPLICABILITY-FORMAT.md) for buckets, OpenVEX justification mapping, suffix markers, and the scoping rule. `[patched]` rows have a corresponding entry in `third-party/pjproject/patches/`.
+
+## In-scope CVEs (upstream fix not in pinned source)
+
+| Published | GHSA / CVE | Sev | Title | Bucket | Justification |
+|---|---|---|---|---|---|
+| 2026-04-21 | [GHSA-x2fv-6j6c-pxmx](https://github.com/pjsip/pjproject/security/advisories/GHSA-x2fv-6j6c-pxmx) / CVE-2026-42225 | high | GnuTLS backend silently skips cert chain verification | **1** | Upstream fix `ef68425` in `pjlib/src/pj/ssl_sock_gtls.c`. pjproject's `aconfigure.ac` makes GnuTLS opt-in via `--with-gnutls`. `third-party/pjproject/configure.m4` only ever passes `--with-ssl` (OpenSSL). GnuTLS backend not compiled. |
+| 2026-04-15 | [GHSA-935m-fmf5-j4pm](https://github.com/pjsip/pjproject/security/advisories/GHSA-935m-fmf5-j4pm) / CVE-2026-41415 | medium | SIP Multipart CID URI Length Underflow | **2** | Upstream fix `4225a93` (PR #4844) in `cid_uri_to_hdr_value()` in `sip_multipart.c`. Bug requires the CID URI to start with `<` and have `slen < 2`. Asterisk's only caller is `res/res_pjsip_geolocation.c:44-58`, which does `local_uri = ast_strdupa(geoloc_uri); if (local_uri[0]=='<') local_uri++; if ((ra=strchr(local_uri,'>'))) *ra='\0';` before passing to `pjsip_multipart_find_part_by_cid_str()`. Asterisk strips the leading `<` (and trailing `>`), so the `uri_overlay.ptr[0] == '<'` branch in pjproject's buggy code never fires from Asterisk's path. Built into `libasteriskpj.so` but the buggy branch has no reachable Asterisk caller. |
+| 2026-04-15 | [GHSA-f33g-8hjq-62xr](https://github.com/pjsip/pjproject/security/advisories/GHSA-f33g-8hjq-62xr) / CVE-2026-41416 | high | Asymmetric ptime integer overflow in Media Stream | **2** | Upstream fix `66fe416` in `pjmedia/src/pjmedia/stream*.c`. Asterisk does not call `pjmedia_stream_*` / `pjmedia_session_*` / `pjmedia_endpt_create` (verified by grep across `res/` and `main/`). |
+| 2026-04-14 | [GHSA-2wcg-w3c4-48r7](https://github.com/pjsip/pjproject/security/advisories/GHSA-2wcg-w3c4-48r7) / CVE-2026-40892 | low | Stack BOF in `pjsip_auth_create_digest2()` | **3** | Upstream fix `c82123e` in `sip_auth_client.c`. Triggered when `cred_info->data_type == PJSIP_CRED_DATA_DIGEST` with operator-supplied pre-hashed digest exceeding 128 bytes. |
+| 2026-04-14 | [GHSA-j59p-4xrr-fp8g](https://github.com/pjsip/pjproject/security/advisories/GHSA-j59p-4xrr-fp8g) / CVE-2026-40614 | high | Heap BOF in Opus codec decoding | **1** | Upstream fix `17897e8` in `pjmedia/src/pjmedia-codec/opus.c`. File guarded by `PJMEDIA_HAS_OPUS_CODEC`. `Makefile.rules` passes `--disable-opus`. |
+| 2026-03-30 | [GHSA-pqrm-53pc-wx28](https://github.com/pjsip/pjproject/security/advisories/GHSA-pqrm-53pc-wx28) / CVE-2026-34235 | medium | Heap OOB read in VPX unpacketizer | **1** | Upstream fix `f4c7d08` in `vpx_packetizer.c`. File guarded by `PJMEDIA_HAS_VIDEO`. `Makefile.rules` passes `--disable-video`. |
+| 2026-03-17 | [GHSA-x5pq-qrp4-fmrj](https://github.com/pjsip/pjproject/security/advisories/GHSA-x5pq-qrp4-fmrj) / CVE-2026-33069 | medium | OOB read in SIP multipart parsing | **4 [patched]** | `0050-oob-read-sip-multipart.patch` (mirrors upstream `f0fa32a`). |
+| 2026-03-17 | [GHSA-jr2p-p2w4-rr9q](https://github.com/pjsip/pjproject/security/advisories/GHSA-jr2p-p2w4-rr9q) / CVE-2026-32945 | high | Heap BOF in DNS parser | **3** | Upstream fix `5311aee` in `pjlib-util/src/pjlib-util/dns.c` `get_name()` / `get_name_len()`. `configure.ac` sets `HAVE_PJSIP_EXTERNAL_RESOLVER=1` whenever pjproject exports `pjsip_endpt_set_ext_resolver` (the pinned source exports it); `pjsip_resolver.c:698` registers Asterisk's own DNS layer. The pjlib-util DNS path engages only when an operator configures `nameserver = X` under `[system]` in `pjsip.conf`, which is a path used by deployments still on extremely old unbundled PJSIP setups. Those deployments do not consume Asterisk's bundled patch series, so no Asterisk-side backport is carried. |
+| 2026-03-10 | [GHSA-g88q-c2hm-q7p7](https://github.com/pjsip/pjproject/security/advisories/GHSA-g88q-c2hm-q7p7) / CVE-2026-32942 | high | ICE session use-after-free race | **4 [patched]** | `0030-ice-sess-use-after-free.patch` (mirrors upstream `c9caced`). |
+| 2026-03-05 | [GHSA-pqww-jrxr-457f](https://github.com/pjsip/pjproject/security/advisories/GHSA-pqww-jrxr-457f) / CVE-2026-29068 | critical | Stack BOF in pjmedia-codec RTP payload parsing | **1** | Upstream fix `6c90245`, "Fix stack buffer overflow in Opus, SILK, and Speex codec parse". Affected files `opus.c`, `silk.c`, `speex` codec parse, all excluded by `--disable-opus`, `--disable-silk`, `--disable-speex-codec`. |
+| 2026-03-05 | [GHSA-8fj4-fv9f-hjpc](https://github.com/pjsip/pjproject/security/advisories/GHSA-8fj4-fv9f-hjpc) / CVE-2026-28799 | high | Heap UAF in PJSIP presence sub termination | **4 [patched]** | `0040-presence-sub-use-after-free.patch` (mirrors upstream `e06ff6c`). |
+| 2026-02-16 | [GHSA-x2hc-6969-g8v6](https://github.com/pjsip/pjproject/security/advisories/GHSA-x2hc-6969-g8v6) / CVE-2026-26967 | high | Heap BOF in H.264 unpacketizer | **1** | Upstream fix `5aee54f` in `h264_packetizer.c`. File guarded by `PJMEDIA_HAS_VIDEO`. |
+| 2026-02-15 | [GHSA-p965-mf7j-gwv8](https://github.com/pjsip/pjproject/security/advisories/GHSA-p965-mf7j-gwv8) / CVE-2026-26203 | medium | UAF in H264 packetizer for fragmented NAL | **1** | Upstream fix `f821c21` in `h264_packetizer.c`. Same guard. |
+| 2026-02-11 | [GHSA-j29p-pvh2-pvqp](https://github.com/pjsip/pjproject/security/advisories/GHSA-j29p-pvh2-pvqp) / CVE-2026-25994 | high | BOF in ICE with long username | **4 [patched]** | `0020-buf-overflow-ice-long-username.patch` (mirrors upstream `063b3a1`). |
+
+## Out-of-scope CVEs (upstream fix in or before pinned source)
+
+Each was patched in the upstream version shown; the pinned `pjproject` already contains the fix.
+
+| CVE | Patched upstream in |
+|---|---|
+| CVE-2025-65102 | 2.16 |
+| CVE-2023-38703 | 2.14 |
+| CVE-2023-27585, CVE-2022-23547, CVE-2022-23537 | 2.13.1 |
+| CVE-2022-39269, CVE-2022-39244, CVE-2022-31031 | 2.13 |
+| CVE-2022-24793, CVE-2022-24792, CVE-2022-24786, CVE-2022-24764, CVE-2022-24763, CVE-2022-24754 | 2.12.1 |
+| CVE-2022-23608, CVE-2022-21723, CVE-2022-21722, CVE-2021-43299, CVE-2021-43845, CVE-2021-43804, CVE-2021-41141, CVE-2021-37706 | 2.12 |
+| CVE-2021-32686 | 2.11.1 |
+| CVE-2021-21375, CVE-2020-15260 | 2.11 |


### PR DESCRIPTION
third-party: add CVE-APPLICABILITY.md for bundled deps

Per-CVE applicability decisions for each bundled dep listed in
third-party/versions.mak: pjproject, jansson, libjwt.

third-party/CVE-APPLICABILITY-FORMAT.md describes the shared format
(buckets, OpenVEX justification mapping, suffix markers, scoping rule,
row schema). Each per-dep file is per-dep content only and references
the format doc.

pjproject: 14 in-scope CVEs classified, 24 out-of-scope listed in an
appendix. Each row's bucket is backed by a build flag in
Makefile.rules, a #if guard in the affected file, a verified
Asterisk-source callgraph, or a patch filename in
third-party/pjproject/patches/.

jansson: zero published upstream GHSAs.

libjwt: two upstream GHSAs target the 3.x branch and do not affect
the pinned major.

Bucket vocabulary maps to OpenVEX justification codes
(vulnerable_code_not_present,
vulnerable_code_cannot_be_controlled_by_adversary,
vulnerable_code_not_in_execute_path, affected).

In-tree pattern follows what Erlang/OTP commits for vendored OpenSSL at
vex/otp-N.openvex.json.

The version pinned in third-party/versions.mak is referenced rather
than restated in each file, so the maintainer does not have to update
two places when bumping the pin. Classifications are valid for the
pin at the same commit as each file; on bump, in-scope rows whose
upstream fix is now in the new pin move to out-of-scope, and new
upstream CVEs since the previous pin need rows added.

