### PR TITLE
.github: weekly CVE applicability sync for bundled deps

### DIFF
--- a/.github/scripts/bundled-dep-cve-sync.py
+++ b/.github/scripts/bundled-dep-cve-sync.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Diff upstream GHSAs for a bundled dep against an in-tree applicability log.
+
+Used by .github/workflows/bundled-dep-cve-sync.yml. For each CVE the
+upstream has published but that has no row in the per-dep
+CVE-APPLICABILITY.md, the script appends a placeholder row containing as
+much pre-filled context as can be extracted from the GHSA metadata, so
+the maintainer's triage step is reduced to:
+
+  * For obvious in-scope rows: read the linked upstream commit, pick the
+    bucket, write the one-line justification.
+  * For obvious out-of-scope rows: confirm the auto-classification (the
+    script moves rows whose `patched_versions` is at-or-before the
+    pinned version into the out-of-scope appendix automatically).
+
+Exit code is always 0. Whether to open a PR is decided by the workflow
+based on the `has_missing` output set via $GITHUB_OUTPUT.
+"""
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def fetch_upstream_ghsas(repo: str) -> list[dict]:
+    out = subprocess.check_output(
+        ["gh", "api", f"repos/{repo}/security-advisories", "--paginate"],
+        text=True,
+    )
+    return json.loads(out)
+
+
+def parse_recorded_cves(applicability_log: Path) -> set[str]:
+    text = applicability_log.read_text()
+    return set(re.findall(r"CVE-\d{4}-\d{4,7}|GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}", text))
+
+
+def read_pinned_version(versions_mak: Path, version_var: str) -> str | None:
+    """Return the value of e.g. PJPROJECT_VERSION from third-party/versions.mak."""
+    if not versions_mak.exists():
+        return None
+    for line in versions_mak.read_text().splitlines():
+        m = re.match(rf"\s*{re.escape(version_var)}\s*=\s*(\S+)", line)
+        if m:
+            return m.group(1)
+    return None
+
+
+def parse_version(s: str) -> tuple[int, ...] | None:
+    """Best-effort parse of a SemVer-ish string into a comparable tuple."""
+    if not s:
+        return None
+    parts = re.findall(r"\d+", s)
+    return tuple(int(p) for p in parts) if parts else None
+
+
+def is_fixed_in_pinned(adv: dict, pinned: str | None) -> bool:
+    """Heuristic: if the upstream patched_versions is <= pinned, treat as out-of-scope.
+
+    Conservative: returns True only when both versions parse cleanly and the
+    advisory specifies a single concrete patched version (not a range string
+    like '>= 3.0.0' or 'or later').
+    """
+    if not pinned:
+        return False
+    vulns = adv.get("vulnerabilities") or []
+    for v in vulns:
+        patched = (v.get("patched_versions") or "").strip()
+        if not patched or any(c in patched for c in ("<", ">", "or", ",")):
+            continue
+        p_pin = parse_version(pinned)
+        p_fix = parse_version(patched)
+        if p_pin and p_fix and p_pin >= p_fix:
+            return True
+    return False
+
+
+def fetch_upstream_commit_meta(adv: dict, repo: str) -> dict:
+    """Look at advisory references for an upstream commit URL; pull file list."""
+    refs = [r.get("url", "") for r in (adv.get("references") or [])]
+    commit_re = re.compile(rf"https://github\.com/{re.escape(repo)}/commit/([0-9a-f]{{7,40}})")
+    for url in refs:
+        m = commit_re.match(url)
+        if not m:
+            continue
+        sha = m.group(1)
+        try:
+            out = subprocess.check_output(
+                ["gh", "api", f"repos/{repo}/commits/{sha}", "-q",
+                 "{sha: .sha, files: [.files[].filename]}"],
+                text=True, stderr=subprocess.DEVNULL,
+            )
+            return json.loads(out)
+        except subprocess.CalledProcessError:
+            continue
+    return {}
+
+
+def render_in_scope_row(adv: dict, repo: str, commit_meta: dict) -> str:
+    cve = adv.get("cve_id") or adv["ghsa_id"]
+    ghsa = adv["ghsa_id"]
+    date = adv.get("published_at", "")[:10]
+    sev = adv.get("severity", "?")
+    title = adv.get("summary", "").replace("|", "\\|")
+    just_parts = []
+    if commit_meta.get("sha"):
+        sha = commit_meta["sha"][:7]
+        files = commit_meta.get("files") or []
+        files_str = ", ".join(f"`{f}`" for f in files[:4])
+        if len(files) > 4:
+            files_str += f", +{len(files) - 4} more"
+        just_parts.append(f"Upstream fix `{sha}` touches {files_str}.")
+    just_parts.append("_Awaiting triage._")
+    justification = " ".join(just_parts)
+    return (
+        f"| {date} | [{ghsa}](https://github.com/{repo}/security/advisories/{ghsa}) / {cve} "
+        f"| {sev} | {title} | **?** | {justification} |"
+    )
+
+
+def render_out_of_scope_row(adv: dict) -> str:
+    cve = adv.get("cve_id") or adv["ghsa_id"]
+    vulns = adv.get("vulnerabilities") or []
+    patched = next(
+        (v.get("patched_versions") for v in vulns if v.get("patched_versions")),
+        "?",
+    )
+    return f"| {cve} | {patched} |"
+
+
+def insert_under_heading(text: str, heading: str, block: str) -> str:
+    """Insert `block` immediately after `heading`'s table header, or append at section end."""
+    if heading not in text:
+        return text.rstrip() + "\n\n" + heading + "\n\n" + block + "\n"
+    head, _, rest = text.partition(heading)
+    # find the next "## " (a sibling section) to delimit
+    next_heading_match = re.search(r"\n## ", rest)
+    if next_heading_match:
+        section = rest[: next_heading_match.start()]
+        tail = rest[next_heading_match.start() :]
+    else:
+        section = rest
+        tail = ""
+    section = section.rstrip() + "\n" + block + "\n"
+    return head + heading + section + tail
+
+
+def write_pr_body(in_scope: list[dict], out_of_scope: list[dict], output: Path,
+                  upstream_repo: str, applicability_log: Path) -> None:
+    lines = [
+        f"Automated sync. Upstream `{upstream_repo}` published the following GHSAs",
+        f"since the last run, none of which currently have a row in",
+        f"`{applicability_log}`. Placeholder rows have been added.",
+        "",
+    ]
+    if in_scope:
+        lines += ["## In-scope (need triage)", ""]
+        for adv in in_scope:
+            cve = adv.get("cve_id") or adv["ghsa_id"]
+            ghsa = adv["ghsa_id"]
+            sev = adv.get("severity", "?")
+            title = adv.get("summary", "")
+            lines.append(
+                f"* **{cve}** ({sev}) {title} "
+                f"([{ghsa}](https://github.com/{upstream_repo}/security/advisories/{ghsa}))"
+            )
+        lines.append("")
+    if out_of_scope:
+        lines += [
+            "## Out-of-scope (auto-classified, please confirm)",
+            "",
+            "Each row's `patched_versions` is at-or-before the version pinned in `third-party/versions.mak`.",
+            "",
+        ]
+        for adv in out_of_scope:
+            cve = adv.get("cve_id") or adv["ghsa_id"]
+            ghsa = adv["ghsa_id"]
+            vulns = adv.get("vulnerabilities") or []
+            patched = next(
+                (v.get("patched_versions") for v in vulns if v.get("patched_versions")),
+                "?",
+            )
+            lines.append(
+                f"* **{cve}** patched in `{patched}` "
+                f"([{ghsa}](https://github.com/{upstream_repo}/security/advisories/{ghsa}))"
+            )
+        lines.append("")
+    output.write_text("\n".join(lines))
+
+
+def set_action_output(name: str, value: str) -> None:
+    out_file = os.environ.get("GITHUB_OUTPUT")
+    if not out_file:
+        return
+    with open(out_file, "a") as f:
+        f.write(f"{name}={value}\n")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--applicability-log", type=Path, required=True)
+    ap.add_argument("--upstream-repo", required=True)
+    ap.add_argument("--output-diff", type=Path, required=True)
+    ap.add_argument("--versions-mak", type=Path,
+                    default=Path("third-party/versions.mak"),
+                    help="Path to third-party/versions.mak (for auto-classification)")
+    ap.add_argument("--version-var", required=True,
+                    help="Variable name in versions.mak (e.g. PJPROJECT_VERSION)")
+    args = ap.parse_args()
+
+    pinned = read_pinned_version(args.versions_mak, args.version_var)
+    advisories = fetch_upstream_ghsas(args.upstream_repo)
+    recorded = parse_recorded_cves(args.applicability_log)
+
+    in_scope_advs: list[dict] = []
+    out_of_scope_advs: list[dict] = []
+    for adv in advisories:
+        cve = adv.get("cve_id")
+        ghsa = adv.get("ghsa_id")
+        if (cve and cve in recorded) or (ghsa and ghsa in recorded):
+            continue
+        if is_fixed_in_pinned(adv, pinned):
+            out_of_scope_advs.append(adv)
+        else:
+            in_scope_advs.append(adv)
+
+    if not in_scope_advs and not out_of_scope_advs:
+        set_action_output("has_missing", "false")
+        print(f"{args.upstream_repo}: no missing entries.")
+        return 0
+
+    text = args.applicability_log.read_text()
+    if in_scope_advs:
+        in_scope_block = "\n".join(
+            render_in_scope_row(adv, args.upstream_repo, fetch_upstream_commit_meta(adv, args.upstream_repo))
+            for adv in in_scope_advs
+        )
+        text = insert_under_heading(text, "## In-scope CVEs", in_scope_block)
+    if out_of_scope_advs:
+        out_of_scope_block = "\n".join(render_out_of_scope_row(adv) for adv in out_of_scope_advs)
+        text = insert_under_heading(text, "## Out-of-scope CVEs", out_of_scope_block)
+    args.applicability_log.write_text(text)
+
+    write_pr_body(in_scope_advs, out_of_scope_advs, args.output_diff,
+                  args.upstream_repo, args.applicability_log)
+    set_action_output("has_missing", "true")
+    print(
+        f"{args.upstream_repo}: {len(in_scope_advs)} in-scope, "
+        f"{len(out_of_scope_advs)} out-of-scope auto-classified."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/bundled-dep-cve-sync.yml
+++ b/.github/workflows/bundled-dep-cve-sync.yml
@@ -1,0 +1,83 @@
+name: Bundled Dep CVE Applicability Sync
+
+# Periodically diffs published GHSAs from each bundled-dep upstream against
+# the per-dep CVE-APPLICABILITY.md files. If a published CVE has no row,
+# opens (or updates) a PR with a placeholder row for maintainer triage.
+# Same shape as Erlang/OTP's openvex-sync.yml.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 1 * * 0"  # weekly, Sunday 01:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: pjproject
+            repo: pjsip/pjproject
+            log: third-party/pjproject/CVE-APPLICABILITY.md
+            version_var: PJPROJECT_VERSION
+          - name: jansson
+            repo: akheron/jansson
+            log: third-party/jansson/CVE-APPLICABILITY.md
+            version_var: JANSSON_VERSION
+          - name: libjwt
+            repo: benmcollins/libjwt
+            log: third-party/libjwt/CVE-APPLICABILITY.md
+            version_var: LIBJWT_VERSION
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Diff upstream GHSAs vs in-tree applicability log
+        id: diff
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 .github/scripts/bundled-dep-cve-sync.py \
+            --applicability-log "${{ matrix.log }}" \
+            --upstream-repo "${{ matrix.repo }}" \
+            --version-var "${{ matrix.version_var }}" \
+            --output-diff /tmp/missing-cves.md
+
+      - name: Open or update PR if missing entries
+        if: steps.diff.outputs.has_missing == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="automated/${{ matrix.name }}-cve-applicability-sync"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git checkout -B "$BRANCH"
+          git add "${{ matrix.log }}"
+          git commit -m "third-party/${{ matrix.name }}: sync CVE applicability log
+
+          Automated update. New upstream ${{ matrix.repo }} GHSAs published
+          since the last sync had no entry in ${{ matrix.log }}. Placeholder
+          rows added for maintainer triage; bucket assignments need review."
+
+          git push --force origin "$BRANCH"
+
+          PR=$(gh pr list --head "$BRANCH" --json number -q '.[0].number')
+          if [ -z "$PR" ]; then
+            gh pr create --base master --head "$BRANCH" \
+              --title "third-party/${{ matrix.name }}: sync CVE applicability log" \
+              --body-file /tmp/missing-cves.md
+          else
+            gh pr edit "$PR" --body-file /tmp/missing-cves.md
+          fi


### PR DESCRIPTION
Adds an automated weekly job that diffs published upstream GHSAs against the in-tree CVE applicability logs for each bundled dep in `third-party/versions.mak` (`pjproject`, `jansson`, `libjwt`) and opens a PR with pre-populated placeholder rows for any CVE that has no recorded applicability decision.

Same shape as Erlang/OTP's [`openvex-sync.yml`](https://github.com/erlang/otp/blob/master/.github/workflows/openvex-sync.yml) + [`create-openvex-pr.sh`](https://github.com/erlang/otp/blob/master/.github/scripts/create-openvex-pr.sh) running against their vendored OpenSSL. Depends on the per-dep `CVE-APPLICABILITY.md` files landing first.

## Files

```
.github/workflows/bundled-dep-cve-sync.yml
.github/scripts/bundled-dep-cve-sync.py
```

## How dev effort is minimised on each new CVE

For every newly-published upstream GHSA the bot adds a row to the applicability log. The script does as much of the triage homework as is safely automatable, so the maintainer's manual step shrinks to a confirm-and-justify:

* **Auto-classify out-of-scope rows.** If the GHSA's `patched_versions` is at-or-before the version pinned in `versions.mak`, the bot puts the row in the out-of-scope appendix directly. Range-style entries (`>= 3.0.0`, etc.) stay conservative and land in-scope for manual triage.
* **Pre-fill upstream commit metadata.** When the GHSA references a fix commit, the bot pulls the commit's changed-file list via `gh api repos/<upstream>/commits/<sha>` and inlines `Upstream fix <sha> touches <files>` into the placeholder row. Maintainer doesn't have to hunt for the fix.
* **Group the PR body.** The PR description separates `## In-scope (need triage)` from `## Out-of-scope (auto-classified, please confirm)` so review attention goes to the rows that need it.

## Behaviour

* No missing entries → workflow exits clean. No commit, no PR.
* Missing entries → script appends rows to the applicability log, opens (or updates) a PR on branch `automated/<dep>-cve-applicability-sync` with the body from the run.
* Three matrix jobs run independently (`fail-fast: false`); a transient API failure for one dep does not block the others.

## Permissions

Job-level: `contents: write`, `pull-requests: write` (required so the bot can push the `automated/<dep>-cve-applicability-sync` branch and open the PR via `gh`). Workflow-level: `contents: read`. The elevated permissions are scoped to the single job.

## Dependencies

Stock GitHub-hosted Ubuntu runner. Python 3.12 via `actions/setup-python@v5`; the script uses stdlib only. `gh` CLI is preinstalled on GitHub runners.

## Future work (not in this PR)

* Auto-propose bucket 1 when the upstream fix only touches files matched by `--disable-*` flags in `Makefile.rules`.
* Auto-stage a backport candidate (`git format-patch` of the upstream fix) alongside the row update for bucket-4 candidates.
