### PR TITLE
res_rtp_asterisk: Set ICE trickle mode to half.

### DIFF
--- a/res/res_rtp_asterisk.c
+++ b/res/res_rtp_asterisk.c
@@ -3992,6 +3992,7 @@ static int ice_create(struct ast_rtp_instance *instance, struct ast_sockaddr *ad
 	struct ice_wrap *ice;
 	pj_ice_sess *real_ice = NULL;
 	struct ast_rtp *rtp = ast_rtp_instance_get_data(instance);
+	pj_ice_sess_options ice_opt;
 
 	ao2_cleanup(rtp->ice_local_candidates);
 	rtp->ice_local_candidates = NULL;
@@ -4019,6 +4020,10 @@ static int ice_create(struct ast_rtp_instance *instance, struct ast_sockaddr *ad
 	/* Create an ICE session for ICE negotiation */
 	status = pj_ice_sess_create(&stun_config, NULL, PJ_ICE_SESS_ROLE_UNKNOWN,
 		rtp->ice_num_components, &ast_rtp_ice_sess_cb, &ufrag, &passwd, NULL, &real_ice);
+	pj_memcpy(&ice_opt, &real_ice->opt, sizeof(ice_opt));
+	ice_opt.trickle = PJ_ICE_SESS_TRICKLE_HALF;
+	pj_ice_sess_set_options(real_ice, &ice_opt);
+
 	ao2_lock(instance);
 	if (status == PJ_SUCCESS) {
 		/* Safely complete linking the ICE session into the instance */


### PR DESCRIPTION
This allows establishment of ICE based sessions even if TX to all remote candidates fails (eg, if remote side ONLY has IPv4 RFC1918 candidates that are being failed locally).

This should likely be configurable with an option like

ice_trickle = {no|half|yes}

Where the default is no (to retain existing behaviour).  This is a race condition that we managed to trigger by having prohibit routes towards RFC1918 addresses on the local hosts, and even though we have IPv6 on our end, the remote side does not, resulting in all local transmissions failing failing immediately with ENOPERM, marking all candidate pairs as failed, and due to lack of trickle failing immediately.

Cherry-pick: 20
Cherry-pick: 22
Cherry-pick: 23