### PR TITLE
abstract_jb.c: Remove timerfd from channel when disabling jitter buffer

### DIFF
--- a/main/abstract_jb.c
+++ b/main/abstract_jb.c
@@ -1284,6 +1284,7 @@ void ast_jb_create_framehook(struct ast_channel *chan, struct ast_jb_conf *jb_co
 			ast_framehook_detach(chan, *id);
 			ast_channel_datastore_remove(chan, datastore);
 			ast_datastore_free(datastore);
+			ast_channel_set_fd(chan, AST_JITTERBUFFER_FD, -1);
 		}
 		ast_channel_unlock(chan);
 		return;


### PR DESCRIPTION
Previously, the lingering timerfd would cause a tight loop if the
channel enters a BridgeWait after the jitter buffer was disabled.

Fixes: #1762