### PR TITLE
app_record: Fix hangup handling during beep playback

### DIFF
--- a/apps/app_record.c
+++ b/apps/app_record.c
@@ -457,15 +457,11 @@ static int record_exec(struct ast_channel *chan, const char *data)
 	}
 
 	if (!ast_test_flag(&flags, OPTION_QUIET)) {
-		/* Some code to play a nice little beep to signify the start of the record operation */
-		res = ast_streamfile(chan, "beep", ast_channel_language(chan));
-		if (!res) {
-			res = ast_waitstream(chan, "");
-		} else {
-			ast_log(LOG_WARNING, "ast_streamfile(beep) failed on %s\n", ast_channel_name(chan));
-			res = 0;
+		/* Play a beep to signify the start of the record operation */
+		if (ast_stream_and_wait(chan, "beep", "")) {
+			status_response = "HANGUP";
+			goto out;
 		}
-		ast_stopstream(chan);
 	}
 
 	/* The end of beep code.  Now the recording starts */


### PR DESCRIPTION
When a hangup occurs while app_record is playing the initial beep,
the application does not detect the hangup and continues running
until the maxduration timeout expires.

Replace the manual ast_streamfile() + ast_waitstream() sequence with
ast_stream_and_wait(), which properly detects hangup and returns
non-zero, allowing the application to exit immediately with
RECORD_STATUS set to HANGUP.

Resolves: #1950
