### PR TITLE
res_pjsip: Don't allow a leading period when wildcard matching

### DIFF
--- a/res/res_pjsip/pjsip_transport_events.c
+++ b/res/res_pjsip/pjsip_transport_events.c
@@ -212,7 +212,7 @@ static int verify_cert_name(const pj_str_t *local, const pj_str_t *remote)
 	}
 
 	p = pj_strchr(local, '.');
-	if (!p) {
+	if (!p || p == pj_strbuf(local)) {
 		return 0;
 	}
 


### PR DESCRIPTION
The reference identifier (what the client provides - in this case a hostname) must start with a domain label, not a `.`.

The current implementation will match `.seanbright.com` against `*.seanbright.com` which is incorrect.