### PR TITLE
chan_local: Update chan_local references for Local channels.

### DIFF
--- a/configs/samples/features.conf.sample
+++ b/configs/samples/features.conf.sample
@@ -40,7 +40,7 @@
 
 ; Note that the DTMF features listed below only work when two channels have answered and are bridged together.
 ; They can not be used while the remote party is ringing or in progress. If you require this feature you can use
-; chan_local in combination with Answer to accomplish it.
+; a Local channel in combination with Answer to accomplish it.
 
 [featuremap]
 ;blindxfer => #1                ; Blind transfer  (default is #) -- Make sure to set the T and/or t option in the Dial() or Queue() app call!

--- a/configs/samples/queues.conf.sample
+++ b/configs/samples/queues.conf.sample
@@ -584,7 +584,7 @@ monitor-type = MixMonitor
 ; before app_queue.so itself or they may be marked invalid until reload. This
 ; can be accomplished by explicitly listing them in modules.conf before
 ; app_queue.so.  Additionally, if you use Local channels as queue members, you
-; must also preload pbx_config.so and chan_local.so (or pbx_ael.so, pbx_lua.so,
+; must also preload pbx_config.so (or pbx_ael.so, pbx_lua.so,
 ; or pbx_realtime.so, depending on how your dialplan is configured).
 ;
 ; syntax: member => interface,[,penalty][,membername][,state_interface][,ringinuse][,wrapuptime][,paused]

--- a/menuselect/example_menuselect-tree
+++ b/menuselect/example_menuselect-tree
@@ -200,16 +200,14 @@
 		<member name="chan_jingle" displayname="Jingle Channel Driver" remove_on_change="channels/chan_jingle.o channels/chan_jingle.so">
 	<depend>iksemel</depend>
 		</member>
-		<member name="chan_local" displayname="Local Proxy Channel" remove_on_change="channels/chan_local.o channels/chan_local.so">
-		</member>
 		<member name="chan_mgcp" displayname="Media Gateway Control Protocol (MGCP)" remove_on_change="channels/chan_mgcp.o channels/chan_mgcp.so">
 		</member>
 		<member name="chan_sip" displayname="Session Initiation Protocol (SIP)" remove_on_change="channels/chan_sip.o channels/chan_sip.so">
 		</member>
 		<member name="chan_skinny" displayname="Skinny Client Control Protocol (Skinny)" remove_on_change="channels/chan_skinny.o channels/chan_skinny.so">
 		</member>
-		<member name="chan_zap" displayname="Zapata Telephony" remove_on_change="channels/chan_zap.o channels/chan_zap.so">
-	<depend>zaptel</depend>
+		<member name="chan_dahdi" displayname="DAHDI Telephony" remove_on_change="channels/chan_dahdi.o channels/chan_dahdi.so">
+	<depend>dahdi</depend>
 		</member>
 	</category>
 	<category name="MENUSELECT_CODECS" displayname="Codec Translators">

--- a/menuselect/test/menuselect-tree
+++ b/menuselect/test/menuselect-tree
@@ -34,7 +34,6 @@
 <member name="app_db" displayname="Database Access Functions" remove_on_change="apps/app_db.o apps/app_db.so">
 </member>
 <member name="app_dial" displayname="Dialing Application" remove_on_change="apps/app_dial.o apps/app_dial.so">
-	<depend>chan_local</depend>
 </member>
 <member name="app_dictate" displayname="Virtual Dictation Machine" remove_on_change="apps/app_dictate.o apps/app_dictate.so">
 </member>
@@ -59,7 +58,6 @@
 	<depend name="dahdi">DAHDI</depend>
 </member>
 <member name="app_followme" displayname="Find-Me/Follow-Me Application" remove_on_change="apps/app_followme.o apps/app_followme.so">
-	<depend>chan_local</depend>
 </member>
 <member name="app_forkcdr" displayname="Fork The CDR into 2 separate entities" remove_on_change="apps/app_forkcdr.o apps/app_forkcdr.so">
 </member>
@@ -195,7 +193,6 @@
 </category>
 <category name="MENUSELECT_CHANNELS" displayname="Channel Drivers" remove_on_change="channels/modules.link">
 <member name="chan_agent" displayname="Agent Proxy Channel" remove_on_change="channels/chan_agent.o channels/chan_agent.so">
-        <depend>chan_local</depend>
 </member>
 <member name="chan_alsa" displayname="ALSA Console Channel Driver" remove_on_change="channels/chan_alsa.o channels/chan_alsa.so">
 	<depend>asound</depend>
@@ -230,12 +227,9 @@
 	<depend>res_jabber</depend>
 	<use>openssl</use>
 </member>
-<member name="chan_local" displayname="Local Proxy Channel (Note: used internally by other modules)" remove_on_change="channels/chan_local.o channels/chan_local.so">
-</member>
 <member name="chan_mgcp" displayname="Media Gateway Control Protocol (MGCP)" remove_on_change="channels/chan_mgcp.o channels/chan_mgcp.so">
 </member>
 <member name="chan_sip" displayname="Session Initiation Protocol (SIP)" remove_on_change="channels/chan_sip.o channels/chan_sip.so">
-        <depend>chan_local</depend>
 </member>
 <member name="chan_skinny" displayname="Skinny Client Control Protocol (Skinny)" remove_on_change="channels/chan_skinny.o channels/chan_skinny.so">
 </member>

--- a/res/parking/parking_bridge_features.c
+++ b/res/parking/parking_bridge_features.c
@@ -254,7 +254,7 @@ static struct ast_channel *park_local_transfer(struct ast_channel *parker, const
 	/* Fill the variable with the extension and context we want to call */
 	snprintf(destination, sizeof(destination), "%s@%s", exten, context);
 
-	/* Now we request that chan_local prepare to call the destination */
+	/* Now we request a Local channel to prepare to call the destination */
 	parkee = ast_request("Local", ast_channel_nativeformats(parker), NULL, parker, destination,
 		&cause);
 	if (!parkee) {


### PR DESCRIPTION
chan_local no longer exists since Local channels are built into the core (core_local), but there are still comments which reference it, including in the configs. Update these to avoid confusion.

Resolves: https://github.com/asterisk/asterisk/issues/1849