### PR TITLE
res_ari: Add res_ari_model as an optional_module.

### DIFF
--- a/res/res_ari.c
+++ b/res/res_ari.c
@@ -1236,5 +1236,6 @@ AST_MODULE_INFO(ASTERISK_GPL_KEY, AST_MODFLAG_GLOBAL_SYMBOLS | AST_MODFLAG_LOAD_
 	.unload = unload_module,
 	.reload = reload_module,
 	.requires = "http,res_stasis,res_http_websocket,res_websocket_client",
+	.optional_modules = "res_ari_model",
 	.load_pri = AST_MODPRI_APP_DEPEND,
 );


### PR DESCRIPTION
Under certain timing/load conditions, res_ari_model may not load until after
res_ari on startup or it might unload before res_ari on shutdown. This can
cause a segfault when DEVMODE is enabled and there are persistent outbound
websocket connections because DEVMODE forces validation of outgoing events
against the models.  To prevent this, res_ari_model has been added as an
"optional_module" to res_ari's NODULE_INFO.  This will enforce load/unload
order but not make res_ari dependent on res_ari_model.  However, if
Asterisk is configured with --enable-dev-mode, res_ari will fail to
load if res_ari_model isn't available.

Resolves: #1970
