### PR TITLE
res_pjsip_registrar: Resolve AOR for identified endpoints

### DIFF
--- a/res/res_pjsip_registrar.c
+++ b/res/res_pjsip_registrar.c
@@ -1179,55 +1179,54 @@ static struct ast_sip_aor *find_registrar_aor(struct pjsip_rx_data *rdata, struc
 {
 	struct ast_sip_aor *aor = NULL;
 	char *aor_name = NULL;
+	pjsip_sip_uri *uri;
+	pj_str_t username;
 	int i;
 
-	for (i = 0; i < AST_VECTOR_SIZE(&endpoint->ident_method_order); ++i) {
-		pj_str_t username;
-		pjsip_sip_uri *uri;
-		pjsip_authorization_hdr *header = NULL;
+	/*
+	 * RFC 3261: The To header contains the Address-of-Record
+	 * whose registration is being created, queried, or modified.
+	 */
+	uri = pjsip_uri_get_uri(rdata->msg_info.to->uri);
+	pj_strassign(&username, &uri->user);
 
-		switch (AST_VECTOR_GET(&endpoint->ident_method_order, i)) {
-		case AST_SIP_ENDPOINT_IDENTIFY_BY_USERNAME:
-			uri = pjsip_uri_get_uri(rdata->msg_info.to->uri);
+	if (ast_sip_get_ignore_uri_user_options()) {
+		pj_ssize_t semi = pj_strcspn2(&username, ";");
 
-			pj_strassign(&username, &uri->user);
-
-			/*
-			 * We may want to match without any user options getting
-			 * in the way.
-			 *
-			 * Logic adapted from AST_SIP_USER_OPTIONS_TRUNCATE_CHECK for pj_str_t.
-			 */
-			if (ast_sip_get_ignore_uri_user_options()) {
-				pj_ssize_t semi = pj_strcspn2(&username, ";");
-				if (semi < pj_strlen(&username)) {
-					username.slen = semi;
-				}
-			}
-
-			aor_name = find_aor_name(&username, &uri->host, endpoint->aors);
-			if (aor_name) {
-				ast_debug(3, "Matched aor '%s' by To username\n", aor_name);
-			}
-			break;
-		case AST_SIP_ENDPOINT_IDENTIFY_BY_AUTH_USERNAME:
-			while ((header = pjsip_msg_find_hdr(rdata->msg_info.msg, PJSIP_H_AUTHORIZATION,
-				header ? header->next : NULL))) {
-				if (header && !pj_stricmp2(&header->scheme, "digest")) {
-					aor_name = find_aor_name(&header->credential.digest.username,
-						&header->credential.digest.realm, endpoint->aors);
-					if (aor_name) {
-						ast_debug(3, "Matched aor '%s' by Authentication username\n", aor_name);
-						break;
-					}
-				}
-			}
-			break;
-		default:
-			continue;
+		if (semi < pj_strlen(&username)) {
+			username.slen = semi;
 		}
+	}
 
-		if (aor_name) {
+	aor_name = find_aor_name(&username, &uri->host, endpoint->aors);
+	if (aor_name) {
+		ast_debug(3, "Matched aor '%s' by REGISTER To URI\n", aor_name);
+	}
+
+	if (!aor_name) {
+		for (i = 0; i < AST_VECTOR_SIZE(&endpoint->ident_method_order); ++i) {
+			pjsip_authorization_hdr *header = NULL;
+
+			if (AST_VECTOR_GET(&endpoint->ident_method_order, i)
+				!= AST_SIP_ENDPOINT_IDENTIFY_BY_AUTH_USERNAME) {
+				continue;
+			}
+
+			while ((header = pjsip_msg_find_hdr(rdata->msg_info.msg,
+				PJSIP_H_AUTHORIZATION, header ? header->next : NULL))) {
+				if (pj_stricmp2(&header->scheme, "digest")) {
+					continue;
+				}
+
+				aor_name = find_aor_name(&header->credential.digest.username,
+					&header->credential.digest.realm, endpoint->aors);
+				if (aor_name) {
+					ast_debug(3, "Matched aor '%s' by Authentication username\n",
+						aor_name);
+					break;
+				}
+			}
+
 			break;
 		}
 	}


### PR DESCRIPTION
When an inbound REGISTER is matched to an endpoint using an
identification method such as IP, header, or request URI, the endpoint can
be identified and authenticated successfully while registrar AOR
resolution still fails.

find_registrar_aor() only resolved AOR names for username and
auth_username identify methods. A header-only endpoint therefore left
aor_name unset and failed registration with "AOR '' not found" even when
the REGISTER To URI matched one of the endpoint's configured AORs.

Resolve the REGISTER AOR from the To URI for endpoint identification
methods that do not directly provide an AOR name, while still
constraining the match to the already-identified endpoint's configured AOR
list.

Fixes: #1398

