### PR TITLE
configs: Comment out `values` setting to avoid parse error

### DIFF
--- a/configs/samples/cel_sqlite3_custom.conf.sample
+++ b/configs/samples/cel_sqlite3_custom.conf.sample
@@ -61,7 +61,7 @@
     ; MUST match the existing columns or the config will fail to load.
     ; The column names do NOT have to match the field names however.
 
-values = '${eventtype}','${eventtime}','${CALLERID(name)}','${CALLERID(num)}','${CALLERID(ANI)}','${CALLERID(RDNIS)}','${CALLERID(DNID)}','${CHANNEL(context)}','${CHANNEL(exten)}','${CHANNEL(channame)}','${CHANNEL(appname)}','${CHANNEL(appdata)}','${CHANNEL(amaflags)}','${CHANNEL(accountcode)}','${CHANNEL(uniqueid)}','${CHANNEL(userfield)}','${BRIDGEPEER}','${userdeftype}','${eventextra}'
+;values = '${eventtype}','${eventtime}','${CALLERID(name)}','${CALLERID(num)}','${CALLERID(ANI)}','${CALLERID(RDNIS)}','${CALLERID(DNID)}','${CHANNEL(context)}','${CHANNEL(exten)}','${CHANNEL(channame)}','${CHANNEL(appname)}','${CHANNEL(appdata)}','${CHANNEL(amaflags)}','${CHANNEL(accountcode)}','${CHANNEL(uniqueid)}','${CHANNEL(userfield)}','${BRIDGEPEER}','${userdeftype}','${eventextra}'
     ; The list of fields to write into the columns.
     ; Each field MUST be enclosed in single-quotes and the fields separated
     ; by commas.  Additionally, the number of fields specified MUST match the


### PR DESCRIPTION
Fixes the following after a `make samples`:

```
config.c:2281 process_text_line: parse error: No category context for line 64 of ...
```