### PR TITLE
Security Release 2026-2 21

### DIFF
--- a/addons/ooh323c/src/ooq931.c
+++ b/addons/ooh323c/src/ooq931.c
@@ -226,11 +226,13 @@ EXTERN int ooQ931Decode
          screening indicators ;-) */
       if(ie->discriminator == Q931CallingPartyNumberIE)
       {
+         int numoffset=1;
          OOTRACEDBGB1("   CallingPartyNumber IE = {\n");
-         if(ie->length < OO_MAX_NUMBER_LENGTH)
+         if(!(0x80 & ie->data[0])) numoffset = 2;
+
+         if( (ie->length >= numoffset) &&
+             (ie->length < OO_MAX_NUMBER_LENGTH) )
          {
-            int numoffset=1;
-            if(!(0x80 & ie->data[0])) numoffset = 2;
             memcpy(number, ie->data+numoffset,ie->length-numoffset);
             number[ie->length-numoffset]='\0';
             OOTRACEDBGB2("      %s\n", number);
@@ -238,7 +240,7 @@ EXTERN int ooQ931Decode
                ooCallSetCallingPartyNumber(call, number);
          }
          else{
-            OOTRACEERR3("Error:Calling party number too long. (%s, %s)\n",
+            OOTRACEERR3("Error:Calling party number outside range. (%s, %s)\n",
                            call->callType, call->callToken);
          }
          OOTRACEDBGB1("   }\n");
@@ -248,7 +250,8 @@ EXTERN int ooQ931Decode
       if(ie->discriminator == Q931CalledPartyNumberIE)
       {
          OOTRACEDBGB1("   CalledPartyNumber IE = {\n");
-         if(ie->length < OO_MAX_NUMBER_LENGTH)
+         if( (ie->length >= 1) &&
+             (ie->length < OO_MAX_NUMBER_LENGTH) )
          {
             memcpy(number, ie->data+1,ie->length-1);
             number[ie->length-1]='\0';
@@ -257,7 +260,7 @@ EXTERN int ooQ931Decode
                ooCallSetCalledPartyNumber(call, number);
          }
          else{
-            OOTRACEERR3("Error:Calling party number too long. (%s, %s)\n",
+            OOTRACEERR3("Error:Calling party number outside range. (%s, %s)\n",
                            call->callType, call->callToken);
          }
          OOTRACEDBGB1("   }\n");

--- a/addons/ooh323c/src/ooq931.c
+++ b/addons/ooh323c/src/ooq931.c
@@ -89,12 +89,21 @@ EXTERN int ooQ931Decode
    while (offset < length) {
       Q931InformationElement *ie;
       int ieOff = offset;
-      /* Get field discriminator */
+      /*
+       * Get field discriminator and advance offset to what should be
+       * the first (or only) byte of the IE length.
+       */
       int discriminator = data[offset++];
 
-      /* For discriminator with high bit set there is no data */
-      if ((discriminator & 0x80) == 0) {
-         int len = data[offset++], alen;
+      /*
+       * For discriminator with high bit == 0 there must be data.  The
+       * data length could be in the next 8 or 16 bits so there must be
+       * at least 1 byte after the discriminator.
+       *
+       * Make sure offset is still in-bounds.
+       */
+      if ((discriminator & 0x80) == 0 && offset < length) {
+         int len = data[offset], alen;
 
          if (discriminator == Q931UserUserIE) {
             /* Special case of User-user field, there is some confusion here as
@@ -106,13 +115,38 @@ EXTERN int ooQ931Decode
                However, at present we assume it is always 2 bytes until we find
                something that breaks it.
             */
-            len <<= 8;
-            len |= data[offset++];
 
-            /* we also have a protocol discriminator, which we ignore */
-            offset++;
+            /*
+             * Advance offset to point to the second byte of the length
+             * and make sure it's still in-bounds.
+             */
+            if (++offset >= length) {
+                return Q931_E_INVLENGTH;
+            }
+            /*
+             * Swap the bytes.
+             * Yes, this assumes we're running on a little-endian system but this is
+             * the original code from Objective Systems.
+             */
+            len <<= 8;
+            len |= data[offset];
+
+            /*
+             * We also have a nested protocol discriminator, which we ignore.
+             * Advance offset to point to the nested discriminator
+             * and make sure it's still in-bounds.
+             */
+            if (++offset >= length) {
+                return Q931_E_INVLENGTH;
+            }
             len--;
          }
+
+         /*
+          * Advance offset to point to the first data byte.
+          * We check bounds below.
+          */
+         ++offset;
 
          /* watch out for negative lengths! (ED, 11/5/03) */
          if (len < 0) {

--- a/addons/ooh323c/src/ootrace.c
+++ b/addons/ooh323c/src/ootrace.c
@@ -43,13 +43,17 @@ void ooTrace(OOUINT32 traceLevel, const char * fmtspec, ...) __attribute__((form
 
 void ooTrace(OOUINT32 traceLevel, const char * fmtspec, ...) {
    va_list arglist;
-   char logMessage[MAXLOGMSGLEN];
+   char *logMessage = NULL;
+   int res = 0;
    if(traceLevel > gs_traceLevel) return;
    va_start (arglist, fmtspec);
-   /*   memset(logMessage, 0, MAXLOGMSGLEN);*/
-   vsprintf(logMessage, fmtspec, arglist);
+   res = ast_vasprintf(&logMessage, fmtspec, arglist);
    va_end(arglist);
+   if (res < 0 || !logMessage) {
+      return;
+   }
    ooTraceLogMessage(logMessage);
+   ast_free(logMessage);
 }
 
 void ooTraceLogMessage(const char * logMessage)

--- a/apps/app_sms.c
+++ b/apps/app_sms.c
@@ -605,20 +605,28 @@ static struct timeval unpackdate(unsigned char *i)
 /*! \brief unpacks bytes (7 bit encoding) at i, len l septets,
 	and places in udh and ud setting udhl and udl. udh not used
 	if udhi not set */
-static void unpacksms7(unsigned char *i, unsigned char l, unsigned char *udh, int *udhl, unsigned short *ud, int *udl, char udhi)
+static void unpacksms7(unsigned char *i, unsigned char l, unsigned char *udh, size_t udh_size,
+	int *udhl, unsigned short *ud, size_t ud_size, int *udl, char udhi)
 {
 	unsigned char b = 0, p = 0;
 	unsigned short *o = ud;
+	unsigned short *o_end = ud + ud_size;
+	unsigned char *h = udh;
+	unsigned char *h_end = udh + udh_size;
+	size_t stored_udhl = 0;
 	*udhl = 0;
 	if (udhi && l) {                        /* header */
-		int h = i[p];
-		*udhl = h;
-		if (h) {
+		int hlen = i[p];
+		if (hlen) {
 			b = 1;
 			p++;
 			l--;
-			while (h-- && l) {
-				*udh++ = i[p++];
+			while (hlen-- && l) {
+				if (h < h_end) {
+					*h++ = i[p];
+					stored_udhl++;
+				}
+				p++;
 				b += 8;
 				while (b >= 7) {
 					b -= 7;
@@ -650,57 +658,78 @@ static void unpacksms7(unsigned char *i, unsigned char l, unsigned char *udh, in
 		/* 0x00A0 is the encoding of ESC (27) in defaultalphabet */
 		if (o > ud && o[-1] == 0x00A0 && escapes[v]) {
 			o[-1] = escapes[v];
-		} else {
+		} else if (o < o_end) {
 			*o++ = defaultalphabet[v];
 		}
 	}
-	*udl = (o - ud);
+	*udl = o - ud;
+	*udhl = stored_udhl;
 }
 
 /*! \brief unpacks bytes (8 bit encoding) at i, len l septets,
  *  and places in udh and ud setting udhl and udl. udh not used
  *  if udhi not set.
  */
-static void unpacksms8(unsigned char *i, unsigned char l, unsigned char *udh, int *udhl, unsigned short *ud, int *udl, char udhi)
+static void unpacksms8(unsigned char *i, unsigned char l, unsigned char *udh, size_t udh_size,
+	int *udhl, unsigned short *ud, size_t ud_size, int *udl, char udhi)
 {
 	unsigned short *o = ud;
+	unsigned short *o_end = ud + ud_size;
+	unsigned char *h = udh;
+	unsigned char *h_end = udh + udh_size;
+	size_t stored_udhl = 0;
 	*udhl = 0;
 	if (udhi) {
 		int n = *i;
-		*udhl = n;
 		if (n) {
 			i++;
 			l--;
 			while (l && n) {
 				l--;
 				n--;
-				*udh++ = *i++;
+				if (h < h_end) {
+					*h++ = *i;
+					stored_udhl++;
+				}
+				i++;
 			}
 		}
 	}
 	while (l--) {
-		*o++ = *i++;                        /* not to UTF-8 as explicitly 8 bit coding in DCS */
+		if (o < o_end) {
+			*o++ = *i;               /* not to UTF-8 as explicitly 8 bit coding in DCS */
+		}
+		i++;
 	}
-	*udl = (o - ud);
+	*udl = o - ud;
+	*udhl = stored_udhl;
 }
 
 /*! \brief unpacks bytes (16 bit encoding) at i, len l septets,
-	 and places in udh and ud setting udhl and udl.
+	and places in udh and ud setting udhl and udl.
 	udh not used if udhi not set */
-static void unpacksms16(unsigned char *i, unsigned char l, unsigned char *udh, int *udhl, unsigned short *ud, int *udl, char udhi)
+static void unpacksms16(unsigned char *i, unsigned char l, unsigned char *udh, size_t udh_size,
+	int *udhl, unsigned short *ud, size_t ud_size, int *udl, char udhi)
 {
 	unsigned short *o = ud;
+	unsigned short *o_end = ud + ud_size;
+	unsigned char *h = udh;
+	unsigned char *h_end = udh + udh_size;
+	size_t stored_udhl = 0;
 	*udhl = 0;
 	if (udhi) {
 		int n = *i;
-		*udhl = n;
 		if (n) {
 			i++;
 			l--;
 			while (l && n) {
 				l--;
 				n--;
-				*udh++ = *i++;
+				if (h < h_end) {
+					*h++ = *i;
+					stored_udhl++;
+				}
+				i++;
 			}
 		}
 	}
@@ -709,39 +738,54 @@ static void unpacksms16(unsigned char *i, unsigned char l, unsigned char *udh, i
 		if (l && l--) {
 			v = (v << 8) + *i++;
 		}
-		*o++ = v;
+		if (o < o_end) {
+			*o++ = v;
+		}
 	}
-	*udl = (o - ud);
+	*udl = o - ud;
+	*udhl = stored_udhl;
 }
 
 /*! \brief general unpack - starts with length byte (octet or septet) and returns number of bytes used, inc length */
-static int unpacksms(unsigned char dcs, unsigned char *i, unsigned char *udh, int *udhl, unsigned short *ud, int *udl, char udhi)
+static int unpacksms(unsigned char dcs, unsigned char *i, unsigned char *udh, size_t udh_size,
+	int *udhl, unsigned short *ud, size_t ud_size, int *udl, char udhi)
 {
 	int l = *i++;
 	if (is7bit(dcs)) {
-		unpacksms7(i, l, udh, udhl, ud, udl, udhi);
+		unpacksms7(i, l, udh, udh_size, udhl, ud, ud_size, udl, udhi);
 		l = (l * 7 + 7) / 8;                /* adjust length to return */
 	} else if (is8bit(dcs)) {
-		unpacksms8(i, l, udh, udhl, ud, udl, udhi);
+		unpacksms8(i, l, udh, udh_size, udhl, ud, ud_size, udl, udhi);
 	} else {
 		l += l % 2;
-		unpacksms16(i, l, udh, udhl, ud, udl, udhi);
+		unpacksms16(i, l, udh, udh_size, udhl, ud, ud_size, udl, udhi);
 	}
 	return l + 1;
 }
 
 /*! \brief unpack an address from i, return byte length, unpack to o */
-static unsigned char unpackaddress(char *o, unsigned char *i)
+static unsigned char unpackaddress(char *o, size_t o_size, unsigned char *i)
 {
 	unsigned char l = i[0], p;
+	char *o_end;
+
+	if (!o_size) {
+		return (l + 5) / 2;
+	}
+
+	o_end = o + o_size - 1;
 	if (i[1] == 0x91) {
-		*o++ = '+';
+		if (o < o_end) {
+			*o++ = '+';
+		}
 	}
 	for (p = 0; p < l; p++) {
-		if (p & 1) {
-			*o++ = (i[2 + p / 2] >> 4) + '0';
-		} else {
-			*o++ = (i[2 + p / 2] & 0xF) + '0';
+		if (o < o_end) {
+			if (p & 1) {
+				*o++ = (i[2 + p / 2] >> 4) + '0';
+			} else {
+				*o++ = (i[2 + p / 2] & 0xF) + '0';
+			}
 		}
 	}
 	*o = 0;
@@ -1129,7 +1173,7 @@ static unsigned char sms_handleincoming (sms_t * h)
 			ast_copy_string(h->oa, h->cli, sizeof(h->oa));
 			h->scts = ast_tvnow();
 			h->mr = h->imsg[p++];
-			p += unpackaddress(h->da, h->imsg + p);
+			p += unpackaddress(h->da, ARRAY_LEN(h->da), h->imsg + p);
 			h->pid = h->imsg[p++];
 			h->dcs = h->imsg[p++];
 			if ((h->imsg[2] & 0x18) == 0x10) {       /* relative VP */
@@ -1146,7 +1190,7 @@ static unsigned char sms_handleincoming (sms_t * h)
 			} else if (h->imsg[2] & 0x18) {
 				p += 7;                     /* ignore enhanced / absolute VP */
 			}
-			p += unpacksms(h->dcs, h->imsg + p, h->udh, &h->udhl, h->ud, &h->udl, h->udhi);
+			p += unpacksms(h->dcs, h->imsg + p, h->udh, ARRAY_LEN(h->udh), &h->udhl, h->ud, ARRAY_LEN(h->ud), &h->udl, h->udhi);
 			h->rx = 1;                      /* received message */
 			sms_writefile(h);               /* write the file */
 			if (p != h->imsg[1] + 2) {
@@ -1164,12 +1208,12 @@ static unsigned char sms_handleincoming (sms_t * h)
 			h->udhi = ((h->imsg[2] & 0x40) ? 1 : 0);
 			h->rp = ((h->imsg[2] & 0x80) ? 1 : 0);
 			h->mr = -1;
-			p += unpackaddress(h->oa, h->imsg + p);
+			p += unpackaddress(h->oa, ARRAY_LEN(h->oa), h->imsg + p);
 			h->pid = h->imsg[p++];
 			h->dcs = h->imsg[p++];
 			h->scts = unpackdate(h->imsg + p);
 			p += 7;
-			p += unpacksms(h->dcs, h->imsg + p, h->udh, &h->udhl, h->ud, &h->udl, h->udhi);
+			p += unpacksms(h->dcs, h->imsg + p, h->udh, ARRAY_LEN(h->udh), &h->udhl, h->ud, ARRAY_LEN(h->ud), &h->udl, h->udhi);
 			h->rx = 1;                      /* received message */
 			sms_writefile(h);               /* write the file */
 			if (p != h->imsg[1] + 2) {

--- a/cel/cel_pgsql.c
+++ b/cel/cel_pgsql.c
@@ -224,12 +224,25 @@ static void pgsql_log(struct ast_event *event)
 				} else {
 					/* Char field, probably */
 					const char *event_name;
+					size_t required_size;
 
 					event_name = (!cel_show_user_def
 						&& record.event_type == AST_CEL_USER_DEFINED)
 						? record.user_defined_name : record.event_name;
-					LENGTHEN_BUF2(strlen(event_name) + 1);
-					ast_str_append(&sql2, 0, "%s'%s'", SEP, event_name);
+					required_size = strlen(event_name) * 2 + 1;
+					if (required_size > bufsize) {
+						char *tmpbuf = ast_realloc(escapebuf, required_size);
+						if (!tmpbuf) {
+							AST_RWLIST_UNLOCK(&psql_columns);
+							goto ast_log_cleanup;
+						}
+						escapebuf = tmpbuf;
+						bufsize = required_size;
+					}
+					PQescapeStringConn(conn, escapebuf, event_name,
+						strlen(event_name), NULL);
+					LENGTHEN_BUF2(strlen(escapebuf) + 3);
+					ast_str_append(&sql2, 0, "%s'%s'", SEP, escapebuf);
 				}
 			} else if (strcmp(cur->name, "amaflags") == 0) {
 				if (strncmp(cur->type, "int", 3) == 0) {

--- a/cel/cel_tds.c
+++ b/cel/cel_tds.c
@@ -110,7 +110,7 @@ static int mssql_disconnect(void);
 static void tds_log(struct ast_event *event)
 {
 	char start[80];
-	char *accountcode_ai, *clidnum_ai, *exten_ai, *context_ai, *clid_ai, *channel_ai, *app_ai, *appdata_ai, *uniqueid_ai, *linkedid_ai, *cidani_ai, *cidrdnis_ai, *ciddnid_ai, *peer_ai, *userfield_ai;
+	char *accountcode_ai, *clidnum_ai, *exten_ai, *context_ai, *clid_ai, *channel_ai, *app_ai, *appdata_ai, *uniqueid_ai, *linkedid_ai, *cidani_ai, *cidrdnis_ai, *ciddnid_ai, *peer_ai, *userfield_ai, *eventtype_ai;
 	RETCODE erc;
 	int attempt = 1;
 	struct ast_cel_event_record record = {
@@ -138,6 +138,9 @@ static void tds_log(struct ast_event *event)
 	linkedid_ai    = anti_injection(record.linked_id, 32);
 	userfield_ai   = anti_injection(record.user_field, 32);
 	peer_ai        = anti_injection(record.peer, 32);
+	eventtype_ai   = anti_injection(
+		(record.event_type == AST_CEL_USER_DEFINED)
+			? record.user_defined_name : record.event_name, 32);
 
 	get_date(start, sizeof(start), record.event_time);
 
@@ -199,8 +202,7 @@ retry:
 		")",
 		settings->table, accountcode_ai, clidnum_ai, clid_ai, cidani_ai, cidrdnis_ai,
 		ciddnid_ai, exten_ai, context_ai, channel_ai, app_ai, appdata_ai, start,
-		(record.event_type == AST_CEL_USER_DEFINED)
-			? record.user_defined_name : record.event_name,
+		eventtype_ai,
 					ast_channel_amaflags2string(record.amaflag), uniqueid_ai, linkedid_ai,
 		userfield_ai, peer_ai);
 
@@ -250,6 +252,7 @@ done:
 	ast_free(linkedid_ai);
 	ast_free(userfield_ai);
 	ast_free(peer_ai);
+	ast_free(eventtype_ai);
 
 	return;
 }

--- a/channels/chan_unistim.c
+++ b/channels/chan_unistim.c
@@ -455,6 +455,8 @@ static struct unistim_device {
 	struct unistim_device *next;
 } *devices = NULL;
 
+#define MAX_PHONE_NUMBER_LENGTH (AST_MAX_EXTENSION - 1)
+
 static struct unistimsession {
 	ast_mutex_t lock;
 	struct sockaddr_in sin;	 /*!< IP address of the phone */
@@ -3577,6 +3579,12 @@ static void key_dial_page(struct unistimsession *pte, char keycode)
 	if ((keycode >= KEY_0) && (keycode <= KEY_SHARP)) {
 		int i = pte->device->size_phone_number;
 
+		/*
+		 * If the phone_number buffer is already full, bail now to prevent an overrun.
+		 */
+		if (pte->device->size_phone_number >= MAX_PHONE_NUMBER_LENGTH) {
+			return;
+		}
 		if (pte->device->size_phone_number == 0) {
 			send_tone(pte, 0, 0);
 		}

--- a/codecs/codec_codec2.c
+++ b/codecs/codec_codec2.c
@@ -77,7 +77,7 @@ static int codec2tolin_framein(struct ast_trans_pvt *pvt, struct ast_frame *f)
 	struct codec2_translator_pvt *tmp = pvt->pvt;
 	int x;
 
-	for (x = 0; x < f->datalen; x += CODEC2_FRAME_LEN) {
+	for (x = 0; x + CODEC2_FRAME_LEN <= f->datalen; x += CODEC2_FRAME_LEN) {
 		unsigned char *src = f->data.ptr + x;
 		int16_t *dst = pvt->outbuf.i16 + pvt->samples;
 

--- a/contrib/scripts/ast_loggrabber
+++ b/contrib/scripts/ast_loggrabber
@@ -216,17 +216,18 @@ fi
 # Timestamp to use for output files
 df=${tarball_uniqueid:-$(${DATEFORMAT})}
 
-# Extract the Python timestamp conver script from the end of this
-# script and save it to /tmp/.ast_tsconvert.py
-
-install -m 0600 /dev/stdin /tmp/.ast_tsconvert.py < <(sed '1,/^#@@@SCRIPTSTART@@@/ d' "$0")
-
 tmpdir=$(mktemp -d)
 if [ -z "$tmpdir" ] ; then
 	echo "${prog}: Unable to create temporary directory."
 	exit 1
 fi
-trap "rm -rf $tmpdir /tmp/.ast_tsconvert.py" EXIT
+
+# Extract the Python timestamp conver script from the end of this
+# script and save it to the temporary directory
+
+install -m 0600 /dev/stdin "$tmpdir/.ast_tsconvert.py" < <(sed '1,/^#@@@SCRIPTSTART@@@/ d' "$0")
+
+trap "rm -rf $tmpdir" EXIT
 tardir=asterisk-${df}.logfiles
 
 # Now iterate over the logfiles
@@ -237,7 +238,7 @@ for i in ${!LOGFILES[@]} ; do
 	mkdir -p "$destdir" 2>/dev/null || :
 	if [ -n "$LOG_DATEFORMAT" ] ; then
 		echo "Converting $lf"
-		cat "$lf" | python /tmp/.ast_tsconvert.py --format="$LOG_DATEFORMAT" --timezone="$LOG_TIMEZONE" > "${destfile}"
+		cat "$lf" | python "$tmpdir/.ast_tsconvert.py" --format="$LOG_DATEFORMAT" --timezone="$LOG_TIMEZONE" > "${destfile}"
 	else
 		echo "Copying $lf"
 		cp "$lf" "${destfile}"

--- a/formats/format_ogg_speex.c
+++ b/formats/format_ogg_speex.c
@@ -234,6 +234,12 @@ static struct ast_frame *ogg_speex_read(struct ast_filestream *fs,
 		return NULL;
 	}
 
+	if (s->op.bytes < 0 || s->op.bytes > BUF_SIZE) {
+		ast_log(LOG_WARNING, "OGG/Speex packet too large (%ld > %d), skipping\n",
+			s->op.bytes, BUF_SIZE);
+		return NULL;
+	}
+
 	AST_FRAME_SET_BUFFER(&fs->fr, fs->buf, AST_FRIENDLY_OFFSET, BUF_SIZE);
 	memcpy(fs->fr.data.ptr, s->op.packet, s->op.bytes);
 	fs->fr.datalen = s->op.bytes;

--- a/include/asterisk/stasis_app.h
+++ b/include/asterisk/stasis_app.h
@@ -631,6 +631,11 @@ int stasis_app_control_answer(struct stasis_app_control *control);
  * \param variable The name of the variable
  * \param value The value to set the variable to
  *
+ * \note The thread that actually does the set will have the inhibit_escalations
+ * flag set before the call to pbx_builtin_setvar_helper to prevent dangerous
+ * dialplan function execution from ARI.  The flag will be reset to its original
+ * state when pbx_builtin_setvar_helper returns.
+ *
  * \return 0 for success.
  * \return -1 for error.
  */

--- a/main/http.c
+++ b/main/http.c
@@ -634,6 +634,7 @@ void ast_http_create_response(struct ast_tcptls_session_instance *ser, int statu
 	const char *status_title, struct ast_str *http_header_data, const char *text)
 {
 	char server_name[MAX_SERVER_NAME_LENGTH];
+	char escaped_text[512];
 	struct ast_str *server_address = ast_str_create(MAX_SERVER_NAME_LENGTH);
 	struct ast_str *out = ast_str_create(INITIAL_RESPONSE_BODY_BUFFER);
 
@@ -656,6 +657,13 @@ void ast_http_create_response(struct ast_tcptls_session_instance *ser, int statu
 	                server_name);
 	}
 
+	/* Escape text to prevent reflected XSS in error pages */
+	if (!ast_strlen_zero(text)) {
+		ast_xml_escape(text, escaped_text, sizeof(escaped_text));
+	} else {
+		escaped_text[0] = '\0';
+	}
+
 	ast_str_set(&out,
 	            0,
 	            "<!DOCTYPE HTML PUBLIC \"-//IETF//DTD HTML 2.0//EN\">\r\n"
@@ -670,7 +678,7 @@ void ast_http_create_response(struct ast_tcptls_session_instance *ser, int statu
 	            status_code,
 	            status_title,
 	            status_title,
-	            text ? text : "",
+	            escaped_text,
 	            ast_str_buffer(server_address));
 
 	ast_free(server_address);

--- a/main/manager.c
+++ b/main/manager.c
@@ -8645,7 +8645,7 @@ static int auth_http_callback(struct ast_tcptls_session_instance *ser,
 	user = get_manager_by_name_locked(d.username);
 	if(!user) {
 		AST_RWLIST_UNLOCK(&users);
-		ast_log(LOG_NOTICE, "%s tried to authenticate with nonexistent user '%s'\n", ast_sockaddr_stringify_addr(&session->addr), d.username);
+		ast_log(LOG_NOTICE, "%s tried to authenticate with nonexistent user '%s'\n", ast_sockaddr_stringify_addr(remote_address), d.username);
 		nonce = 0;
 		goto out_401;
 	}
@@ -8653,7 +8653,7 @@ static int auth_http_callback(struct ast_tcptls_session_instance *ser,
 	/* --- We have User for this auth, now check ACL */
 	if (user->acl && !ast_apply_acl(user->acl, remote_address, "Manager User ACL:")) {
 		AST_RWLIST_UNLOCK(&users);
-		ast_log(LOG_NOTICE, "%s failed to pass IP ACL as '%s'\n", ast_sockaddr_stringify_addr(&session->addr), d.username);
+		ast_log(LOG_NOTICE, "%s failed to pass IP ACL as '%s'\n", ast_sockaddr_stringify_addr(remote_address), d.username);
 		ast_http_request_close_on_completion(ser);
 		ast_http_error(ser, 403, "Permission denied", "Permission denied");
 		return 0;

--- a/res/ari/ari_websocket_requests.c
+++ b/res/ari/ari_websocket_requests.c
@@ -71,7 +71,7 @@ static void request_destroy(struct rest_request_msg *request)
 })
 
 static struct rest_request_msg *parse_rest_request_msg(
-	const char *remote_addr, struct ast_json *request_msg,
+	const char *remote_addr, struct ast_json *request_msg, struct ast_variable *get_params,
 	struct ast_ari_response *response, int debug_app)
 {
 	struct rest_request_msg *request = NULL;
@@ -152,6 +152,25 @@ static struct rest_request_msg *parse_rest_request_msg(
 		SET_RESPONSE_AND_EXIT(400,
 			"Bad request","Unable to parse 'query_strings' array.",
 			remote_addr, request, request_msg);
+	}
+
+	/*
+	 * If there were get_params on the original HTTP GET request that created
+	 * the websocket, we need to append any api_key parameter to the request->query_strings
+	 * to properly authenticate and authorize the request.
+	 */
+	if (get_params) {
+		struct ast_variable *v;
+		ast_trace(-1, "%s: Websocket query params:\n", remote_addr);
+		for (v = get_params; v; v = v->next) {
+			if (ast_strings_equal(v->name, "api_key")) {
+				struct ast_variable *api_key = ast_variable_new(v->name, v->value, __FILE__);
+				if (api_key) {
+					ast_variable_list_append_hint(&request->query_strings, NULL, api_key);
+				}
+				break;
+			}
+		}
 	}
 
 	request->body = ast_json_null();
@@ -259,7 +278,8 @@ static void send_rest_response(
 }
 
 int ari_websocket_process_request(struct ari_ws_session *ari_ws_session,
-		const char *remote_addr, struct ast_variable *upgrade_headers,
+		const char *remote_addr, struct ast_variable *get_params,
+		struct ast_variable *upgrade_headers,
 		const char *app_name, struct ast_json *request_msg)
 {
 	int debug_app = stasis_app_get_debug_by_name(app_name);
@@ -281,7 +301,7 @@ int ari_websocket_process_request(struct ari_ws_session *ari_ws_session,
 	}
 
 	request = SCOPE_CALL_WITH_RESULT(-1, struct rest_request_msg *,
-		parse_rest_request_msg, remote_addr, request_msg, &response, debug_app);
+		parse_rest_request_msg, remote_addr, request_msg, get_params, &response, debug_app);
 
 	if (!request || response.response_code != 200) {
 		SCOPE_CALL(-1, send_rest_response, ari_ws_session,

--- a/res/ari/ari_websockets.c
+++ b/res/ari/ari_websockets.c
@@ -815,6 +815,11 @@ static void websocket_established_cb(struct ast_websocket *ast_ws_session,
 		for (v = upgrade_headers; v; v = v->next) {
 			ast_trace(3, "--> %s: %s\n", v->name, v->value);
 		}
+
+		ast_trace(2, "%s: Websocket query params:\n", remote_addr);
+		for (v = get_params; v; v = v->next) {
+			ast_trace(3, "--> %s: %s\n", v->name, v->value);
+		}
 	}
 
 	/*
@@ -838,7 +843,7 @@ static void websocket_established_cb(struct ast_websocket *ast_ws_session,
 	ari_ws_session->connected = 1;
 	ast_trace(-1, "%s: Waiting for messages\n", remote_addr);
 	while ((msg = session_read(ari_ws_session))) {
-		ari_websocket_process_request(ari_ws_session, remote_addr,
+		ari_websocket_process_request(ari_ws_session, remote_addr, get_params,
 			upgrade_headers, ari_ws_session->app_name, msg);
 		ast_json_unref(msg);
 	}
@@ -1007,7 +1012,7 @@ static void *outbound_session_handler_thread(void *obj)
 		 */
 		while ((msg = session_read(session))) {
 			ari_websocket_process_request(session, session->remote_addr,
-				upgrade_headers, session->app_name, msg);
+				NULL, upgrade_headers, session->app_name, msg);
 			ast_json_unref(msg);
 		}
 

--- a/res/ari/ari_websockets.h
+++ b/res/ari/ari_websockets.h
@@ -99,7 +99,8 @@ void ari_websocket_send_event(struct ari_ws_session *ari_ws_session,
  * \retval 0 on success, -1 on failure
  */
 int ari_websocket_process_request(struct ari_ws_session *ast_ws_session,
-		const char *remote_addr, struct ast_variable *upgrade_headers,
+		const char *remote_addr, struct ast_variable *get_params,
+		struct ast_variable *upgrade_headers,
 		const char *app_name, struct ast_json *msg);
 
 /*!

--- a/res/res_ari.c
+++ b/res/res_ari.c
@@ -441,32 +441,74 @@ static void handle_options(struct stasis_rest_handlers *handler,
 	}
 }
 
-/*!
- * \brief Authenticate a <code>?api_key=userid:password</code>
- *
- * \param api_key API key query parameter
- * \return User object for the authenticated user.
- * \retval NULL if authentication failed.
+/*
+ * This function is actually copied from http.c.  Didn't see a need to make
+ * that function public just for this one use case.
  */
-static struct ari_conf_user *authenticate_api_key(const char *api_key)
+static struct ast_http_auth *create_http_auth(const char *userid, const char *password)
 {
-	RAII_VAR(char *, copy, NULL, ast_free);
-	char *username;
-	char *password;
+	struct ast_http_auth *auth;
+	size_t userid_len;
+	size_t password_len;
 
-	password = copy = ast_strdup(api_key);
-	if (!copy) {
+	if (!userid || !password) {
+		ast_log(LOG_ERROR, "Invalid userid/password\n");
 		return NULL;
 	}
 
-	username = strsep(&password, ":");
-	if (!password) {
-		ast_log(LOG_WARNING, "Invalid api_key\n");
+	userid_len = strlen(userid) + 1;
+	password_len = strlen(password) + 1;
+
+	/* Allocate enough room to store everything in one memory block */
+	auth = ao2_alloc_options(sizeof(*auth) + userid_len + password_len, NULL, AO2_ALLOC_OPT_LOCK_NOLOCK);
+	if (!auth) {
 		return NULL;
 	}
 
-	return ari_conf_validate_user(username, password);
+	/* Put the userid right after the struct */
+	auth->userid = (char *)(auth + 1);
+	strcpy(auth->userid, userid);
+
+	/* Put the password right after the userid */
+	auth->password = auth->userid + userid_len;
+	strcpy(auth->password, password);
+
+	return auth;
 }
+
+/*!
+ * \brief Parse an api_key parameter from the query parameters into an ast_http_auth structure.
+ *
+ * \param get_params query string parameters
+ * \return ast_http_user object for the api_key.
+ * \retval NULL if api_key wasn't found or is had no password.
+ */
+static struct ast_http_auth *parse_api_keys(struct ast_variable *get_params)
+{
+	struct ast_variable *v;
+
+	for (v = get_params; v; v = v->next) {
+		if (ast_strings_equal(v->name, "api_key")) {
+			if (!ast_strlen_zero(v->value)) {
+				char *password = ast_strdupa(v->value);
+				char *username = strsep(&password, ":");
+				if (!ast_strlen_zero(password)) {
+					return create_http_auth(username, password);
+				}
+			}
+			break;
+		}
+	}
+	return NULL;
+}
+
+#if AST_DEVMODE
+static void test_ari_user_destructor(void *obj)
+{
+	struct ari_conf_user *ari_user = obj;
+	ast_string_field_free_memory(ari_user);
+}
+#endif
 
 /*!
  * \brief Authenticate an HTTP request.
@@ -477,26 +519,68 @@ static struct ari_conf_user *authenticate_api_key(const char *api_key)
  * \retval NULL if authentication failed.
  */
 static struct ari_conf_user *authenticate_user(struct ast_variable *get_params,
-	struct ast_variable *headers)
+	struct ast_variable *headers, enum ast_ari_invoke_source source)
 {
 	RAII_VAR(struct ast_http_auth *, http_auth, NULL, ao2_cleanup);
-	struct ast_variable *v;
+	struct ari_conf_user *ari_user = NULL;
+	SCOPE_ENTER(3, "\n");
 
 	/* HTTP Basic authentication */
 	http_auth = ast_http_get_auth(headers);
-	if (http_auth) {
-		return ari_conf_validate_user(http_auth->userid,
-			http_auth->password);
+	if (!http_auth) {
+		/* ?api_key authentication */
+		http_auth = parse_api_keys(get_params);
+	}
+	if (!http_auth) {
+		SCOPE_EXIT_RTN_VALUE(NULL, "No credentials found in HTTP headers or api_key\n");
 	}
 
-	/* ?api_key authentication */
-	for (v = get_params; v; v = v->next) {
-		if (strcasecmp("api_key", v->name) == 0) {
-			return authenticate_api_key(v->value);
+	if (source != ARI_INVOKE_SOURCE_TEST) {
+		ast_trace(-1, "Validating user %s\n", http_auth->userid);
+		ari_user = ari_conf_validate_user(http_auth->userid, http_auth->password);
+		if (!ari_user) {
+			SCOPE_EXIT_RTN_VALUE(NULL, "User %s failed to validate\n", http_auth->userid);
 		}
+		SCOPE_EXIT_RTN_VALUE(ari_user, "User %s validated. Read only: %s\n",
+			http_auth->userid, AST_YESNO(ari_user->read_only));
+	}
+#if AST_DEVMODE
+	/*
+	 * ARI_INVOKE_SOURCE_TEST should only be set by the tests in test_ari.c but
+	 * as a safety precaution, only check against the test usernames and passwords
+	 * if we're in DEVMODE.
+	 */
+	else {
+		int readonly = 0;
+
+		if (ast_strings_equal(http_auth->userid, "aritest")) {
+			if (!ast_strings_equal(http_auth->password, "aritestpw")) {
+				SCOPE_EXIT_RTN_VALUE(NULL, "User %s failed to validate\n", http_auth->userid);
+			}
+		} else if (ast_strings_equal(http_auth->userid, "aritestro")) {
+			if (!ast_strings_equal(http_auth->password, "aritestropw")) {
+				SCOPE_EXIT_RTN_VALUE(NULL, "User %s failed to validate\n", http_auth->userid);
+			}
+			readonly = 1;
+		}
+
+		ari_user = ao2_alloc(sizeof(*ari_user), test_ari_user_destructor);
+		if (!ari_user) {
+			SCOPE_EXIT_RTN_VALUE(NULL, "alloc failed\n");
+		}
+		if (ast_string_field_init(ari_user, 256) != 0) {
+			SCOPE_EXIT_RTN_VALUE(NULL, "alloc failed\n");
+		}
+		ast_string_field_set(ari_user, password, http_auth->password);
+		ari_user->read_only = readonly;
+
+		SCOPE_EXIT_RTN_VALUE(ari_user, "User %s validated. Read only: %s\n",
+			http_auth->userid, AST_YESNO(ari_user->read_only));
 	}
 
+#else
 	return NULL;
+#endif
 }
 
 static void remove_trailing_slash(const char *uri,
@@ -553,29 +637,32 @@ enum ast_ari_invoke_result ast_ari_invoke(struct ast_tcptls_session_instance *se
 			response->response_code, response->response_text);
 	}
 
-	user = authenticate_user(get_params, headers);
-
-	if (!user && source == ARI_INVOKE_SOURCE_REST) {
-		/* Per RFC 2617, section 1.2: The 401 (Unauthorized) response
-		 * message is used by an origin server to challenge the
-		 * authorization of a user agent. This response MUST include a
-		 * WWW-Authenticate header field containing at least one
-		 * challenge applicable to the requested resource.
-		 */
+	user = authenticate_user(get_params, headers, source);
+	if (!user) {
 		ast_ari_response_error(response, 401, "Unauthorized", "Authentication required");
+		if (source == ARI_INVOKE_SOURCE_REST) {
+			/* Per RFC 2617, section 1.2: The 401 (Unauthorized) response
+			 * message is used by an origin server to challenge the
+			 * authorization of a user agent. This response MUST include a
+			 * WWW-Authenticate header field containing at least one
+			 * challenge applicable to the requested resource.
+			 */
 
-		/* Section 1.2:
-		 *   realm       = "realm" "=" realm-value
-		 *   realm-value = quoted-string
-		 * Section 2:
-		 *   challenge   = "Basic" realm
-		 */
-		ast_str_append(&response->headers, 0,
-			"WWW-Authenticate: Basic realm=\"%s\"\r\n",
-			general->auth_realm);
+			/* Section 1.2:
+			 *   realm       = "realm" "=" realm-value
+			 *   realm-value = quoted-string
+			 * Section 2:
+			 *   challenge   = "Basic" realm
+			 */
+			ast_str_append(&response->headers, 0,
+				"WWW-Authenticate: Basic realm=\"%s\"\r\n",
+				general->auth_realm);
+		}
 		SCOPE_EXIT_RTN_VALUE(ARI_INVOKE_RESULT_ERROR_CONTINUE, "Response: %d : %s\n",
 			response->response_code, response->response_text);
-	} else if (user && user->acl && !ast_acl_list_is_empty(user->acl) &&
+	}
+
+	if (source == ARI_INVOKE_SOURCE_REST && ser && user->acl && !ast_acl_list_is_empty(user->acl) &&
 		   ast_apply_acl(user->acl, &ser->remote_address, "ARI User ACL") == AST_SENSE_DENY) {
 		ast_ari_response_error(response, 403, "Forbidden", "Access denied by ACL");
 		SCOPE_EXIT_RTN_VALUE(ARI_INVOKE_RESULT_ERROR_CONTINUE, "Response: %d : %s\n",
@@ -584,7 +671,7 @@ enum ast_ari_invoke_result ast_ari_invoke(struct ast_tcptls_session_instance *se
 		ast_ari_response_error(response, 503, "Service Unavailable", "Asterisk not booted");
 		SCOPE_EXIT_RTN_VALUE(ARI_INVOKE_RESULT_ERROR_CLOSE, "Response: %d : %s\n",
 			response->response_code, response->response_text);
-	} else if (user && user->read_only && method != AST_HTTP_GET && method != AST_HTTP_OPTIONS) {
+	} else if (user->read_only && method != AST_HTTP_GET && method != AST_HTTP_OPTIONS) {
 		ast_ari_response_error(response, 403, "Forbidden", "Write access denied");
 		SCOPE_EXIT_RTN_VALUE(ARI_INVOKE_RESULT_ERROR_CONTINUE, "Response: %d : %s\n",
 			response->response_code, response->response_text);

--- a/res/res_config_ldap.c
+++ b/res/res_config_ldap.c
@@ -733,6 +733,40 @@ static int replace_string_in_string(char *string, const char *search, const char
 	return replaced;
 }
 
+/*!
+ * \internal
+ * \brief Escape a value for safe inclusion in an LDAP filter per RFC 4515.
+ *
+ * Characters that have special meaning in LDAP filters are escaped
+ * to their \\HH hex representation: * ( ) \\ and NUL.
+ *
+ * \param value The raw value to escape
+ * \param escaped Output buffer (caller-allocated ast_str)
+ */
+static void ldap_filter_escape_value(const char *value, struct ast_str **escaped)
+{
+	ast_str_reset(*escaped);
+	for (; *value; value++) {
+		switch (*value) {
+		case '*':
+			ast_str_append(escaped, 0, "\\2a");
+			break;
+		case '(':
+			ast_str_append(escaped, 0, "\\28");
+			break;
+		case ')':
+			ast_str_append(escaped, 0, "\\29");
+			break;
+		case '\\':
+			ast_str_append(escaped, 0, "\\5c");
+			break;
+		default:
+			ast_str_append(escaped, 0, "%c", *value);
+			break;
+		}
+	}
+}
+
 /*! \brief Append a name=value filter string. The filter string can grow.
  */
 static void append_var_and_value_to_filter(struct ast_str **filter,
@@ -742,8 +776,14 @@ static void append_var_and_value_to_filter(struct ast_str **filter,
 	char *new_name = NULL;
 	char *new_value = NULL;
 	const char *like_pos = strstr(name, " LIKE");
+	struct ast_str *escaped_value;
 
 	ast_debug(2, "name='%s' value='%s'\n", name, value);
+
+	escaped_value = ast_str_create(256);
+	if (!escaped_value) {
+		return;
+	}
 
 	if (like_pos) {
 		int len = like_pos - name;
@@ -753,11 +793,20 @@ static void append_var_and_value_to_filter(struct ast_str **filter,
 		value = new_value = ast_strdupa(value);
 		replace_string_in_string(new_value, "\\_", "_");
 		replace_string_in_string(new_value, "%", "*");
+		name = convert_attribute_name_to_ldap(table_config, name);
+		/* Note: The LIKE path preserves original wildcard behavior.
+		 * A more comprehensive escaping of the LIKE path is left
+		 * to the maintainers familiar with the query semantics.
+		 */
+		ast_str_append(filter, 0, "(%s=%s)", name, value);
+	} else {
+		name = convert_attribute_name_to_ldap(table_config, name);
+		ldap_filter_escape_value(value, &escaped_value);
+		ast_str_append(filter, 0, "(%s=%s)", name,
+			ast_str_buffer(escaped_value));
 	}
 
-	name = convert_attribute_name_to_ldap(table_config, name);
-
-	ast_str_append(filter, 0, "(%s=%s)", name, value);
+	ast_free(escaped_value);
 }
 
 /*!

--- a/res/res_pjsip/pjsip_message_filter.c
+++ b/res/res_pjsip/pjsip_message_filter.c
@@ -277,11 +277,11 @@ static pj_status_t filter_on_tx_message(pjsip_tx_data *tdata)
 
 		/* If the chosen transport is not bound to any we can't use the source address as it won't get back to us */
 		if (!is_bound_any(tdata->tp_info.transport)) {
-			pj_strassign(&prm.ret_addr, &tdata->tp_info.transport->local_name.host);
+			pj_strdup(tdata->pool, &prm.ret_addr, &tdata->tp_info.transport->local_name.host);
 		}
 	} else {
 		/* The transport chosen will deliver this but ensure it is updated with the right information */
-		pj_strassign(&prm.ret_addr, &tdata->tp_info.transport->local_name.host);
+		pj_strdup(tdata->pool, &prm.ret_addr, &tdata->tp_info.transport->local_name.host);
 	}
 
 	/* If the message needs to be updated with new address do so */

--- a/res/res_pjsip_pubsub.c
+++ b/res/res_pjsip_pubsub.c
@@ -3894,6 +3894,7 @@ static pj_bool_t pubsub_on_rx_mwi_notify_request(pjsip_rx_data *rdata)
 	char *context;
 	char *body;
 	char *mailbox;
+	int body_len;
 	int rc;
 
 	endpoint = ast_pjsip_rdata_get_endpoint(rdata);
@@ -3926,8 +3927,15 @@ static pj_bool_t pubsub_on_rx_mwi_notify_request(pjsip_rx_data *rdata)
 	context = atsign + 1;
 
 	body = ast_alloca(rdata->msg_info.msg->body->len + 1);
-	rdata->msg_info.msg->body->print_body(rdata->msg_info.msg->body, body,
+	body_len = rdata->msg_info.msg->body->print_body(rdata->msg_info.msg->body, body,
 		rdata->msg_info.msg->body->len + 1);
+
+	if (body_len < 0 || body_len > rdata->msg_info.msg->body->len) {
+		ast_debug(1, "Incoming MWI: Endpoint: '%s' Unable to print request body\n", endpoint_name);
+		rc = 404;
+		goto error;
+	}
+	body[body_len] = '\0';
 
 	if (parse_simple_message_summary(body, &summary) != 0) {
 		ast_debug(1, "Incoming MWI: Endpoint: '%s' There was an issue getting message info from body '%s'\n",

--- a/res/res_pjsip_pubsub.c
+++ b/res/res_pjsip_pubsub.c
@@ -3878,7 +3878,7 @@ static int parse_simple_message_summary(char *body,
 			&summary->voice_messages_urgent_new, &summary->voice_messages_urgent_old)) {
 			found_counts = 1;
 		} else {
-			sscanf(line, "message-account: %s", summary->message_account);
+			sscanf(line, "message-account: %511s", summary->message_account);
 		}
 	}
 

--- a/res/res_rtp_asterisk.c
+++ b/res/res_rtp_asterisk.c
@@ -5400,6 +5400,17 @@ static struct ast_frame *red_t140_to_red(struct rtp_red *red)
 	/* Store length of each generation and primary data length*/
 	for (i = 0; i < red->num_gen; i++)
 		red->len[i] = red->len[i+1];
+
+	/*
+	 * RED generation payload sizes are limited to 255 (UCHAR_MAX) bytes by virtue of
+	 * red->len being an array of usigned chars.  If the new primary payload exceeds that,
+	 * we're going to truncate it to 255.
+	 */
+	if (red->t140.datalen > UCHAR_MAX) {
+		ast_log(LOG_WARNING, "New T.140 frame of %d bytes exceeds max of %u. Discarding %d bytes.\n",
+			red->t140.datalen, UCHAR_MAX, red->t140.datalen - UCHAR_MAX);
+		red->t140.datalen = UCHAR_MAX;
+	}
 	red->len[i] = red->t140.datalen;
 
 	/* write each generation length in red header */
@@ -9189,7 +9200,13 @@ static int rtp_red_init(struct ast_rtp_instance *instance, int buffer_time, int 
 	return 0;
 }
 
-/*! \pre instance is locked */
+/*! \pre instance is locked
+ *
+ * \warning This code was written many years ago and it's unclear why we actually
+ * buffer OUTGOING T.140 text frames until a command is encountered but we do.
+ *
+ * This may change in the future.
+ */
 static int rtp_red_buffer(struct ast_rtp_instance *instance, struct ast_frame *frame)
 {
 	struct ast_rtp *rtp = ast_rtp_instance_get_data(instance);
@@ -9200,6 +9217,8 @@ static int rtp_red_buffer(struct ast_rtp_instance *instance, struct ast_frame *f
 	}
 
 	if (frame->datalen > 0) {
+		int space_available = 0;
+
 		if (red->t140.datalen > 0) {
 			const unsigned char *primary = red->buf_data;
 
@@ -9214,6 +9233,31 @@ static int rtp_red_buffer(struct ast_rtp_instance *instance, struct ast_frame *f
 					ast_rtp_write(instance, &rtp->red->t140);
 				}
 			}
+		}
+
+		/*
+		 * RED generation payload sizes are limited to 255 (UCHAR_MAX) bytes by virtue of
+		 * red->len being an array of usigned chars.  If adding the current frame will
+		 * exceed that, we're going to flush the saved frame then try again. If the new
+		 * frame fits, great otherwise we're going to toss it.  Without understanding
+		 * the purpose of the buffering, that's all we can do now.
+		 */
+		space_available = UCHAR_MAX - red->t140.datalen;
+
+		if (frame->datalen > space_available) {
+			ast_rtp_write(instance, &rtp->red->t140);
+			/*
+			 * ast_rtp_write() calls red_t140_to_red() which resets red->t140.datalen
+			 * back to 0 so we now have UCHAR_MAX space available.
+			 */
+			space_available = UCHAR_MAX;
+		}
+
+		if (frame->datalen > space_available) {
+			ast_log(LOG_WARNING, "%s: T.140 frame of %d bytes exceeds max of %u. Discarding.\n",
+				ast_rtp_instance_get_channel_id(instance),
+				frame->datalen, UCHAR_MAX);
+			return -1;
 		}
 
 		memcpy(&red->buf_data[red->t140.datalen], frame->data.ptr, frame->datalen);

--- a/res/res_xmpp.c
+++ b/res/res_xmpp.c
@@ -3612,8 +3612,9 @@ static int xmpp_action_hook(void *data, int type, iks *node)
 		char *node_ns = NULL;
 		char attr[XMPP_MAX_ATTRLEN];
 		char *node_name = iks_name(iks_child(node));
-		char *aux = strchr(node_name, ':') + 1;
-		snprintf(attr, strlen("xmlns:") + (strlen(node_name) - strlen(aux)), "xmlns:%s", node_name);
+		char *colon = strchr(node_name, ':');
+		snprintf(attr, sizeof(attr), "xmlns:%.*s",
+			(int)(colon - node_name), node_name);
 		node_ns = iks_find_attrib(iks_child(node), attr);
 		if (node_ns) {
 			pak->ns = node_ns;

--- a/res/stasis/control.c
+++ b/res/stasis/control.c
@@ -743,8 +743,18 @@ static int app_control_set_channel_var(struct stasis_app_control *control,
 	struct ast_channel *chan, void *data)
 {
 	struct chanvar *var = data;
+	/*
+	 * Save the current inhibit state then enable it.
+	 */
+	int inhibited = ast_thread_inhibit_escalations_swap(1);
 
 	pbx_builtin_setvar_helper(control->channel, var->name, var->value);
+	/*
+	 * Re-enable it if it was originally enabled.
+	 */
+	if (inhibited > 0) {
+		ast_thread_inhibit_escalations();
+	}
 
 	return 0;
 }

--- a/tests/test_ari.c
+++ b/tests/test_ari.c
@@ -309,8 +309,9 @@ AST_TEST_DEFINE(invoke_get)
 	RAII_VAR(void *, fixture, NULL, tear_down_invocation_test);
 	RAII_VAR(struct ast_ari_response *, response, NULL, response_free);
 	RAII_VAR(struct ast_json *, expected, NULL, ast_json_unref);
-	struct ast_variable *get_params = NULL;
-	struct ast_variable *headers = NULL;
+	struct ast_variable *tail = NULL;
+	RAII_VAR(struct ast_variable *, get_params, NULL, ast_variables_destroy);
+	RAII_VAR(struct ast_variable *, headers, NULL, ast_variables_destroy);
 
 	switch (cmd) {
 	case TEST_INIT:
@@ -325,21 +326,24 @@ AST_TEST_DEFINE(invoke_get)
 
 	fixture = setup_invocation_test();
 	response = response_alloc();
-	get_params = ast_variable_new("get1", "get-one", __FILE__);
-	ast_assert(get_params != NULL);
-	get_params->next = ast_variable_new("get2", "get-two", __FILE__);
-	ast_assert(get_params->next != NULL);
+	tail = ast_variable_list_append_hint(&get_params, NULL, ast_variable_new("get1", "get-one", __FILE__));
+	ast_assert(tail != NULL);
+	tail = ast_variable_list_append_hint(&get_params, NULL, ast_variable_new("get2", "get-two", __FILE__));
+	ast_assert(tail != NULL);
+	tail = ast_variable_list_append_hint(&get_params, NULL, ast_variable_new("api_key", "aritestro:aritestropw", __FILE__));
+	ast_assert(tail != NULL);
 
-	headers = ast_variable_new("head1", "head-one", __FILE__);
-	ast_assert(headers != NULL);
-	headers->next = ast_variable_new("head2", "head-two", __FILE__);
-	ast_assert(headers->next != NULL);
+	tail = ast_variable_list_append_hint(&headers, NULL, ast_variable_new("head1", "head-one", __FILE__));
+	ast_assert(tail != NULL);
+	tail = ast_variable_list_append_hint(&headers, NULL, ast_variable_new("head2", "head-two", __FILE__));
+	ast_assert(tail != NULL);
 
-	expected = ast_json_pack("{s: s, s: {s: s, s: s}, s: {s: s, s: s}, s: {}}",
+	expected = ast_json_pack("{s: s, s: {s: s, s: s, s: s}, s: {s: s, s: s}, s: {}}",
 				 "name", "foo_get",
 				 "get_params",
 				 "get1", "get-one",
 				 "get2", "get-two",
+				 "api_key", "aritestro:aritestropw",
 				 "headers",
 				 "head1", "head-one",
 				 "head2", "head-two",
@@ -360,7 +364,8 @@ AST_TEST_DEFINE(invoke_wildcard)
 	RAII_VAR(void *, fixture, NULL, tear_down_invocation_test);
 	RAII_VAR(struct ast_ari_response *, response, NULL, response_free);
 	RAII_VAR(struct ast_json *, expected, NULL, ast_json_unref);
-	struct ast_variable *get_params = NULL;
+	struct ast_variable *tail = NULL;
+	RAII_VAR(struct ast_variable *, get_params, NULL, ast_variables_destroy);
 	struct ast_variable *headers = NULL;
 
 	switch (cmd) {
@@ -376,9 +381,13 @@ AST_TEST_DEFINE(invoke_wildcard)
 
 	fixture = setup_invocation_test();
 	response = response_alloc();
-	expected = ast_json_pack("{s: s, s: {}, s: {}, s: {s: s}}",
+	tail = ast_variable_list_append_hint(&get_params, NULL, ast_variable_new("api_key", "aritestro:aritestropw", __FILE__));
+	ast_assert(tail != NULL);
+
+	expected = ast_json_pack("{s: s, s: {s: s}, s: {}, s: {s: s}}",
 				 "name", "bam_get",
 				 "get_params",
+				 "api_key", "aritestro:aritestropw",
 				 "headers",
 				 "path_vars",
 				 "bam", "foshizzle");
@@ -393,14 +402,41 @@ AST_TEST_DEFINE(invoke_wildcard)
 	return AST_TEST_PASS;
 }
 
-AST_TEST_DEFINE(invoke_delete)
+static enum ast_test_result_state invoke_delete_common(struct ast_test_info *info, enum ast_test_command cmd,
+	struct ast_test *test, const char *creds, int expect_pass, int expect_rc)
 {
 	RAII_VAR(void *, fixture, NULL, tear_down_invocation_test);
 	RAII_VAR(struct ast_ari_response *, response, NULL, response_free);
 	RAII_VAR(struct ast_json *, expected, NULL, ast_json_unref);
-	struct ast_variable *get_params = NULL;
+	struct ast_variable *tail = NULL;
+	RAII_VAR(struct ast_variable *, get_params, NULL, ast_variables_destroy);
 	struct ast_variable *headers = NULL;
 
+	fixture = setup_invocation_test();
+	response = response_alloc();
+	tail = ast_variable_list_append_hint(&get_params, NULL, ast_variable_new("api_key", creds, __FILE__));
+	ast_assert(tail != NULL);
+
+	expected = ast_json_pack("{s: s, s: {s: s}, s: {}, s: {s: s}}",
+				 "name", "bang_delete",
+				 "get_params",
+				 "api_key", creds,
+				 "headers",
+				 "path_vars",
+				 "bam", "foshizzle");
+
+	ast_ari_invoke(NULL, ARI_INVOKE_SOURCE_TEST, NULL, "foo/foshizzle/bang", AST_HTTP_DELETE, get_params, headers,
+		ast_json_null(), response);
+
+	ast_test_validate(test, expect_pass == invocation_count);
+	ast_test_validate(test, expect_rc == response->response_code);
+	ast_test_validate(test, ast_json_equal(expected, response->message) == expect_pass);
+
+	return AST_TEST_PASS;
+}
+
+AST_TEST_DEFINE(invoke_delete)
+{
 	switch (cmd) {
 	case TEST_INIT:
 		info->name = __func__;
@@ -412,23 +448,23 @@ AST_TEST_DEFINE(invoke_delete)
 		break;
 	}
 
-	fixture = setup_invocation_test();
-	response = response_alloc();
-	expected = ast_json_pack("{s: s, s: {}, s: {}, s: {s: s}}",
-				 "name", "bang_delete",
-				 "get_params",
-				 "headers",
-				 "path_vars",
-				 "bam", "foshizzle");
+	return invoke_delete_common(info, cmd, test, "aritest:aritestpw", 1, 204);
+}
 
-	ast_ari_invoke(NULL, ARI_INVOKE_SOURCE_TEST, NULL, "foo/foshizzle/bang", AST_HTTP_DELETE, get_params, headers,
-		ast_json_null(), response);
+AST_TEST_DEFINE(invoke_delete_forbidden)
+{
+	switch (cmd) {
+	case TEST_INIT:
+		info->name = __func__;
+		info->category = "/res/ari/";
+		info->summary = "Test forbidden DELETE of an HTTP resource.";
+		info->description = "Test ARI binding logic.";
+		return AST_TEST_NOT_RUN;
+	case TEST_EXECUTE:
+		break;
+	}
 
-	ast_test_validate(test, 1 == invocation_count);
-	ast_test_validate(test, 204 == response->response_code);
-	ast_test_validate(test, ast_json_equal(expected, response->message));
-
-	return AST_TEST_PASS;
+	return invoke_delete_common(info, cmd, test, "aritestro:aritestropw", 0, 403);
 }
 
 AST_TEST_DEFINE(invoke_post)
@@ -436,8 +472,9 @@ AST_TEST_DEFINE(invoke_post)
 	RAII_VAR(void *, fixture, NULL, tear_down_invocation_test);
 	RAII_VAR(struct ast_ari_response *, response, NULL, response_free);
 	RAII_VAR(struct ast_json *, expected, NULL, ast_json_unref);
-	struct ast_variable *get_params = NULL;
-	struct ast_variable *headers = NULL;
+	struct ast_variable *tail = NULL;
+	RAII_VAR(struct ast_variable *, get_params, NULL, ast_variables_destroy);
+	RAII_VAR(struct ast_variable *, headers, NULL, ast_variables_destroy);
 
 	switch (cmd) {
 	case TEST_INIT:
@@ -452,21 +489,24 @@ AST_TEST_DEFINE(invoke_post)
 
 	fixture = setup_invocation_test();
 	response = response_alloc();
-	get_params = ast_variable_new("get1", "get-one", __FILE__);
-	ast_assert(get_params != NULL);
-	get_params->next = ast_variable_new("get2", "get-two", __FILE__);
-	ast_assert(get_params->next != NULL);
+	tail = ast_variable_list_append_hint(&get_params, NULL, ast_variable_new("get1", "get-one", __FILE__));
+	ast_assert(tail != NULL);
+	tail = ast_variable_list_append_hint(&get_params, NULL, ast_variable_new("get2", "get-two", __FILE__));
+	ast_assert(tail != NULL);
+	tail = ast_variable_list_append_hint(&get_params, NULL, ast_variable_new("api_key", "aritest:aritestpw", __FILE__));
+	ast_assert(tail != NULL);
 
-	headers = ast_variable_new("head1", "head-one", __FILE__);
-	ast_assert(headers != NULL);
-	headers->next = ast_variable_new("head2", "head-two", __FILE__);
-	ast_assert(headers->next != NULL);
+	tail = ast_variable_list_append_hint(&headers, NULL, ast_variable_new("head1", "head-one", __FILE__));
+	ast_assert(tail != NULL);
+	tail = ast_variable_list_append_hint(&headers, NULL, ast_variable_new("head2", "head-two", __FILE__));
+	ast_assert(tail != NULL);
 
-	expected = ast_json_pack("{s: s, s: {s: s, s: s}, s: {s: s, s: s}, s: {}}",
+	expected = ast_json_pack("{s: s, s: {s: s, s: s, s: s}, s: {s: s, s: s}, s: {}}",
 				 "name", "bar_post",
 				 "get_params",
 				 "get1", "get-one",
 				 "get2", "get-two",
+				 "api_key", "aritest:aritestpw",
 				 "headers",
 				 "head1", "head-one",
 				 "head2", "head-two",
@@ -483,6 +523,40 @@ AST_TEST_DEFINE(invoke_post)
 }
 
 AST_TEST_DEFINE(invoke_bad_post)
+{
+	RAII_VAR(void *, fixture, NULL, tear_down_invocation_test);
+	RAII_VAR(struct ast_ari_response *, response, NULL, response_free);
+	struct ast_variable *tail = NULL;
+	RAII_VAR(struct ast_variable *, get_params, NULL, ast_variables_destroy);
+	struct ast_variable *headers = NULL;
+
+	switch (cmd) {
+	case TEST_INIT:
+		info->name = __func__;
+		info->category = "/res/ari/";
+		info->summary = "Test POST on a resource that doesn't support it.";
+		info->description = "Test ARI binding logic.";
+		return AST_TEST_NOT_RUN;
+	case TEST_EXECUTE:
+		break;
+	}
+
+	fixture = setup_invocation_test();
+	response = response_alloc();
+
+	tail = ast_variable_list_append_hint(&get_params, NULL, ast_variable_new("api_key", "aritest:aritestpw", __FILE__));
+	ast_assert(tail != NULL);
+
+	ast_ari_invoke(NULL, ARI_INVOKE_SOURCE_TEST, NULL, "foo", AST_HTTP_POST, get_params, headers,
+		ast_json_null(), response);
+
+	ast_test_validate(test, 0 == invocation_count);
+	ast_test_validate(test, 405 == response->response_code);
+
+	return AST_TEST_PASS;
+}
+
+AST_TEST_DEFINE(invoke_no_user)
 {
 	RAII_VAR(void *, fixture, NULL, tear_down_invocation_test);
 	RAII_VAR(struct ast_ari_response *, response, NULL, response_free);
@@ -506,7 +580,7 @@ AST_TEST_DEFINE(invoke_bad_post)
 		ast_json_null(), response);
 
 	ast_test_validate(test, 0 == invocation_count);
-	ast_test_validate(test, 405 == response->response_code);
+	ast_test_validate(test, 401 == response->response_code);
 
 	return AST_TEST_PASS;
 }
@@ -515,7 +589,8 @@ AST_TEST_DEFINE(invoke_not_found)
 {
 	RAII_VAR(void *, fixture, NULL, tear_down_invocation_test);
 	RAII_VAR(struct ast_ari_response *, response, NULL, response_free);
-	struct ast_variable *get_params = NULL;
+	struct ast_variable *tail = NULL;
+	RAII_VAR(struct ast_variable *, get_params, NULL, ast_variables_destroy);
 	struct ast_variable *headers = NULL;
 
 	switch (cmd) {
@@ -531,6 +606,10 @@ AST_TEST_DEFINE(invoke_not_found)
 
 	fixture = setup_invocation_test();
 	response = response_alloc();
+
+	tail = ast_variable_list_append_hint(&get_params, NULL, ast_variable_new("api_key", "aritest:aritestpw", __FILE__));
+	ast_assert(tail != NULL);
+
 	ast_ari_invoke(NULL, ARI_INVOKE_SOURCE_TEST, NULL, "foo/fizzle/i-am-not-a-resource", AST_HTTP_GET, get_params, headers,
 		ast_json_null(), response);
 
@@ -549,8 +628,10 @@ static int unload_module(void)
 	AST_TEST_UNREGISTER(invoke_get);
 	AST_TEST_UNREGISTER(invoke_wildcard);
 	AST_TEST_UNREGISTER(invoke_delete);
+	AST_TEST_UNREGISTER(invoke_delete_forbidden);
 	AST_TEST_UNREGISTER(invoke_post);
 	AST_TEST_UNREGISTER(invoke_bad_post);
+	AST_TEST_UNREGISTER(invoke_no_user);
 	AST_TEST_UNREGISTER(invoke_not_found);
 	return 0;
 }
@@ -564,8 +645,10 @@ static int load_module(void)
 	AST_TEST_REGISTER(invoke_get);
 	AST_TEST_REGISTER(invoke_wildcard);
 	AST_TEST_REGISTER(invoke_delete);
+	AST_TEST_REGISTER(invoke_delete_forbidden);
 	AST_TEST_REGISTER(invoke_post);
 	AST_TEST_REGISTER(invoke_bad_post);
+	AST_TEST_REGISTER(invoke_no_user);
 	AST_TEST_REGISTER(invoke_not_found);
 	return AST_MODULE_LOAD_SUCCESS;
 }


### PR DESCRIPTION
- **format_ogg_speex: Add bounds check to prevent heap buffer overflow**
- **codec_codec2: Only process complete Codec2 frames in decoder**
- **http: Escape error page text to prevent reflected XSS**
- **cel_pgsql, cel_tds: Escape eventtype field to prevent SQL injection**
- **res_config_ldap: Escape LDAP filter values per RFC 4515**
- **res_pjsip_pubsub: Add width limit to sscanf in MWI NOTIFY parser**
- **res_xmpp: Fix stack buffer overflow in namespace prefix handling**
- **app_sms: Bound protocol 1 SMS unpacking to fixed-size buffers**
- **ooh323: Prevent potential buffer overflow in trace logging**
- **manager: Use remote address in user error logging**
- **res/res_pjsip_pubsub.c: Fix buffer over-read in MWI body parser**
- **res_rtp_asterisk.c: Address 2 potential T.140 RED buffer overruns.**
- **ARI: Make ARI applications respect live_dangerously.**
- **ooh323c/ooq931.c: Ensure ooQ931Decode doesn't run out-of-bounds.**
- **pjsip_message_filter: Use pj_strdup instead of pj_strassign to save local address.**
- **res_ari: Ensure read-only users are properly authorized via REST Over WebSocket.**
- **ooh323c: not checking for IE minimum length**
- **chan_unistim.c: Prevent overrun of phone_number field.**
- **ast_loggrabber: Install the ast_tsconvert.py script to a secure temp directory.**
