### PR TITLE
Security Release 2026-2 cert-20.7

### DIFF
--- a/addons/ooh323c/src/ooq931.c
+++ b/addons/ooh323c/src/ooq931.c
@@ -89,12 +89,21 @@ EXTERN int ooQ931Decode
    while (offset < length) {
       Q931InformationElement *ie;
       int ieOff = offset;
-      /* Get field discriminator */
+      /*
+       * Get field discriminator and advance offset to what should be
+       * the first (or only) byte of the IE length.
+       */
       int discriminator = data[offset++];
 
-      /* For discriminator with high bit set there is no data */
-      if ((discriminator & 0x80) == 0) {
-         int len = data[offset++], alen;
+      /*
+       * For discriminator with high bit == 0 there must be data.  The
+       * data length could be in the next 8 or 16 bits so there must be
+       * at least 1 byte after the discriminator.
+       *
+       * Make sure offset is still in-bounds.
+       */
+      if ((discriminator & 0x80) == 0 && offset < length) {
+         int len = data[offset], alen;
 
          if (discriminator == Q931UserUserIE) {
             /* Special case of User-user field, there is some confusion here as
@@ -106,13 +115,38 @@ EXTERN int ooQ931Decode
                However, at present we assume it is always 2 bytes until we find
                something that breaks it.
             */
-            len <<= 8;
-            len |= data[offset++];
 
-            /* we also have a protocol discriminator, which we ignore */
-            offset++;
+            /*
+             * Advance offset to point to the second byte of the length
+             * and make sure it's still in-bounds.
+             */
+            if (++offset >= length) {
+                return Q931_E_INVLENGTH;
+            }
+            /*
+             * Swap the bytes.
+             * Yes, this assumes we're running on a little-endian system but this is
+             * the original code from Objective Systems.
+             */
+            len <<= 8;
+            len |= data[offset];
+
+            /*
+             * We also have a nested protocol discriminator, which we ignore.
+             * Advance offset to point to the nested discriminator
+             * and make sure it's still in-bounds.
+             */
+            if (++offset >= length) {
+                return Q931_E_INVLENGTH;
+            }
             len--;
          }
+
+         /*
+          * Advance offset to point to the first data byte.
+          * We check bounds below.
+          */
+         ++offset;
 
          /* watch out for negative lengths! (ED, 11/5/03) */
          if (len < 0) {

--- a/addons/ooh323c/src/ootrace.c
+++ b/addons/ooh323c/src/ootrace.c
@@ -43,13 +43,17 @@ void ooTrace(OOUINT32 traceLevel, const char * fmtspec, ...) __attribute__((form
 
 void ooTrace(OOUINT32 traceLevel, const char * fmtspec, ...) {
    va_list arglist;
-   char logMessage[MAXLOGMSGLEN];
+   char *logMessage = NULL;
+   int res = 0;
    if(traceLevel > gs_traceLevel) return;
    va_start (arglist, fmtspec);
-   /*   memset(logMessage, 0, MAXLOGMSGLEN);*/
-   vsprintf(logMessage, fmtspec, arglist);
+   res = ast_vasprintf(&logMessage, fmtspec, arglist);
    va_end(arglist);
+   if (res < 0 || !logMessage) {
+      return;
+   }
    ooTraceLogMessage(logMessage);
+   ast_free(logMessage);
 }
 
 void ooTraceLogMessage(const char * logMessage)

--- a/apps/app_sms.c
+++ b/apps/app_sms.c
@@ -600,20 +600,28 @@ static struct timeval unpackdate(unsigned char *i)
 /*! \brief unpacks bytes (7 bit encoding) at i, len l septets,
 	and places in udh and ud setting udhl and udl. udh not used
 	if udhi not set */
-static void unpacksms7(unsigned char *i, unsigned char l, unsigned char *udh, int *udhl, unsigned short *ud, int *udl, char udhi)
+static void unpacksms7(unsigned char *i, unsigned char l, unsigned char *udh, size_t udh_size,
+	int *udhl, unsigned short *ud, size_t ud_size, int *udl, char udhi)
 {
 	unsigned char b = 0, p = 0;
 	unsigned short *o = ud;
+	unsigned short *o_end = ud + ud_size;
+	unsigned char *h = udh;
+	unsigned char *h_end = udh + udh_size;
+	size_t stored_udhl = 0;
 	*udhl = 0;
 	if (udhi && l) {                        /* header */
-		int h = i[p];
-		*udhl = h;
-		if (h) {
+		int hlen = i[p];
+		if (hlen) {
 			b = 1;
 			p++;
 			l--;
-			while (h-- && l) {
-				*udh++ = i[p++];
+			while (hlen-- && l) {
+				if (h < h_end) {
+					*h++ = i[p];
+					stored_udhl++;
+				}
+				p++;
 				b += 8;
 				while (b >= 7) {
 					b -= 7;
@@ -645,57 +653,78 @@ static void unpacksms7(unsigned char *i, unsigned char l, unsigned char *udh, in
 		/* 0x00A0 is the encoding of ESC (27) in defaultalphabet */
 		if (o > ud && o[-1] == 0x00A0 && escapes[v]) {
 			o[-1] = escapes[v];
-		} else {
+		} else if (o < o_end) {
 			*o++ = defaultalphabet[v];
 		}
 	}
-	*udl = (o - ud);
+	*udl = o - ud;
+	*udhl = stored_udhl;
 }
 
 /*! \brief unpacks bytes (8 bit encoding) at i, len l septets,
  *  and places in udh and ud setting udhl and udl. udh not used
  *  if udhi not set.
  */
-static void unpacksms8(unsigned char *i, unsigned char l, unsigned char *udh, int *udhl, unsigned short *ud, int *udl, char udhi)
+static void unpacksms8(unsigned char *i, unsigned char l, unsigned char *udh, size_t udh_size,
+	int *udhl, unsigned short *ud, size_t ud_size, int *udl, char udhi)
 {
 	unsigned short *o = ud;
+	unsigned short *o_end = ud + ud_size;
+	unsigned char *h = udh;
+	unsigned char *h_end = udh + udh_size;
+	size_t stored_udhl = 0;
 	*udhl = 0;
 	if (udhi) {
 		int n = *i;
-		*udhl = n;
 		if (n) {
 			i++;
 			l--;
 			while (l && n) {
 				l--;
 				n--;
-				*udh++ = *i++;
+				if (h < h_end) {
+					*h++ = *i;
+					stored_udhl++;
+				}
+				i++;
 			}
 		}
 	}
 	while (l--) {
-		*o++ = *i++;                        /* not to UTF-8 as explicitly 8 bit coding in DCS */
+		if (o < o_end) {
+			*o++ = *i;               /* not to UTF-8 as explicitly 8 bit coding in DCS */
+		}
+		i++;
 	}
-	*udl = (o - ud);
+	*udl = o - ud;
+	*udhl = stored_udhl;
 }
 
 /*! \brief unpacks bytes (16 bit encoding) at i, len l septets,
-	 and places in udh and ud setting udhl and udl.
+	and places in udh and ud setting udhl and udl.
 	udh not used if udhi not set */
-static void unpacksms16(unsigned char *i, unsigned char l, unsigned char *udh, int *udhl, unsigned short *ud, int *udl, char udhi)
+static void unpacksms16(unsigned char *i, unsigned char l, unsigned char *udh, size_t udh_size,
+	int *udhl, unsigned short *ud, size_t ud_size, int *udl, char udhi)
 {
 	unsigned short *o = ud;
+	unsigned short *o_end = ud + ud_size;
+	unsigned char *h = udh;
+	unsigned char *h_end = udh + udh_size;
+	size_t stored_udhl = 0;
 	*udhl = 0;
 	if (udhi) {
 		int n = *i;
-		*udhl = n;
 		if (n) {
 			i++;
 			l--;
 			while (l && n) {
 				l--;
 				n--;
-				*udh++ = *i++;
+				if (h < h_end) {
+					*h++ = *i;
+					stored_udhl++;
+				}
+				i++;
 			}
 		}
 	}
@@ -704,39 +733,54 @@ static void unpacksms16(unsigned char *i, unsigned char l, unsigned char *udh, i
 		if (l && l--) {
 			v = (v << 8) + *i++;
 		}
-		*o++ = v;
+		if (o < o_end) {
+			*o++ = v;
+		}
 	}
-	*udl = (o - ud);
+	*udl = o - ud;
+	*udhl = stored_udhl;
 }
 
 /*! \brief general unpack - starts with length byte (octet or septet) and returns number of bytes used, inc length */
-static int unpacksms(unsigned char dcs, unsigned char *i, unsigned char *udh, int *udhl, unsigned short *ud, int *udl, char udhi)
+static int unpacksms(unsigned char dcs, unsigned char *i, unsigned char *udh, size_t udh_size,
+	int *udhl, unsigned short *ud, size_t ud_size, int *udl, char udhi)
 {
 	int l = *i++;
 	if (is7bit(dcs)) {
-		unpacksms7(i, l, udh, udhl, ud, udl, udhi);
+		unpacksms7(i, l, udh, udh_size, udhl, ud, ud_size, udl, udhi);
 		l = (l * 7 + 7) / 8;                /* adjust length to return */
 	} else if (is8bit(dcs)) {
-		unpacksms8(i, l, udh, udhl, ud, udl, udhi);
+		unpacksms8(i, l, udh, udh_size, udhl, ud, ud_size, udl, udhi);
 	} else {
 		l += l % 2;
-		unpacksms16(i, l, udh, udhl, ud, udl, udhi);
+		unpacksms16(i, l, udh, udh_size, udhl, ud, ud_size, udl, udhi);
 	}
 	return l + 1;
 }
 
 /*! \brief unpack an address from i, return byte length, unpack to o */
-static unsigned char unpackaddress(char *o, unsigned char *i)
+static unsigned char unpackaddress(char *o, size_t o_size, unsigned char *i)
 {
 	unsigned char l = i[0], p;
+	char *o_end;
+
+	if (!o_size) {
+		return (l + 5) / 2;
+	}
+
+	o_end = o + o_size - 1;
 	if (i[1] == 0x91) {
-		*o++ = '+';
+		if (o < o_end) {
+			*o++ = '+';
+		}
 	}
 	for (p = 0; p < l; p++) {
-		if (p & 1) {
-			*o++ = (i[2 + p / 2] >> 4) + '0';
-		} else {
-			*o++ = (i[2 + p / 2] & 0xF) + '0';
+		if (o < o_end) {
+			if (p & 1) {
+				*o++ = (i[2 + p / 2] >> 4) + '0';
+			} else {
+				*o++ = (i[2 + p / 2] & 0xF) + '0';
+			}
 		}
 	}
 	*o = 0;
@@ -1123,7 +1167,7 @@ static unsigned char sms_handleincoming (sms_t * h)
 			ast_copy_string(h->oa, h->cli, sizeof(h->oa));
 			h->scts = ast_tvnow();
 			h->mr = h->imsg[p++];
-			p += unpackaddress(h->da, h->imsg + p);
+			p += unpackaddress(h->da, ARRAY_LEN(h->da), h->imsg + p);
 			h->pid = h->imsg[p++];
 			h->dcs = h->imsg[p++];
 			if ((h->imsg[2] & 0x18) == 0x10) {       /* relative VP */
@@ -1140,7 +1184,7 @@ static unsigned char sms_handleincoming (sms_t * h)
 			} else if (h->imsg[2] & 0x18) {
 				p += 7;                     /* ignore enhanced / absolute VP */
 			}
-			p += unpacksms(h->dcs, h->imsg + p, h->udh, &h->udhl, h->ud, &h->udl, h->udhi);
+			p += unpacksms(h->dcs, h->imsg + p, h->udh, ARRAY_LEN(h->udh), &h->udhl, h->ud, ARRAY_LEN(h->ud), &h->udl, h->udhi);
 			h->rx = 1;                      /* received message */
 			sms_writefile(h);               /* write the file */
 			if (p != h->imsg[1] + 2) {
@@ -1158,12 +1202,12 @@ static unsigned char sms_handleincoming (sms_t * h)
 			h->udhi = ((h->imsg[2] & 0x40) ? 1 : 0);
 			h->rp = ((h->imsg[2] & 0x80) ? 1 : 0);
 			h->mr = -1;
-			p += unpackaddress(h->oa, h->imsg + p);
+			p += unpackaddress(h->oa, ARRAY_LEN(h->oa), h->imsg + p);
 			h->pid = h->imsg[p++];
 			h->dcs = h->imsg[p++];
 			h->scts = unpackdate(h->imsg + p);
 			p += 7;
-			p += unpacksms(h->dcs, h->imsg + p, h->udh, &h->udhl, h->ud, &h->udl, h->udhi);
+			p += unpacksms(h->dcs, h->imsg + p, h->udh, ARRAY_LEN(h->udh), &h->udhl, h->ud, ARRAY_LEN(h->ud), &h->udl, h->udhi);
 			h->rx = 1;                      /* received message */
 			sms_writefile(h);               /* write the file */
 			if (p != h->imsg[1] + 2) {

--- a/cel/cel_pgsql.c
+++ b/cel/cel_pgsql.c
@@ -225,12 +225,25 @@ static void pgsql_log(struct ast_event *event)
 				} else {
 					/* Char field, probably */
 					const char *event_name;
+					size_t required_size;
 
 					event_name = (!cel_show_user_def
 						&& record.event_type == AST_CEL_USER_DEFINED)
 						? record.user_defined_name : record.event_name;
-					LENGTHEN_BUF2(strlen(event_name) + 1);
-					ast_str_append(&sql2, 0, "%s'%s'", SEP, event_name);
+					required_size = strlen(event_name) * 2 + 1;
+					if (required_size > bufsize) {
+						char *tmpbuf = ast_realloc(escapebuf, required_size);
+						if (!tmpbuf) {
+							AST_RWLIST_UNLOCK(&psql_columns);
+							goto ast_log_cleanup;
+						}
+						escapebuf = tmpbuf;
+						bufsize = required_size;
+					}
+					PQescapeStringConn(conn, escapebuf, event_name,
+						strlen(event_name), NULL);
+					LENGTHEN_BUF2(strlen(escapebuf) + 3);
+					ast_str_append(&sql2, 0, "%s'%s'", SEP, escapebuf);
 				}
 			} else if (strcmp(cur->name, "amaflags") == 0) {
 				if (strncmp(cur->type, "int", 3) == 0) {

--- a/cel/cel_tds.c
+++ b/cel/cel_tds.c
@@ -111,7 +111,7 @@ static int mssql_disconnect(void);
 static void tds_log(struct ast_event *event)
 {
 	char start[80];
-	char *accountcode_ai, *clidnum_ai, *exten_ai, *context_ai, *clid_ai, *channel_ai, *app_ai, *appdata_ai, *uniqueid_ai, *linkedid_ai, *cidani_ai, *cidrdnis_ai, *ciddnid_ai, *peer_ai, *userfield_ai;
+	char *accountcode_ai, *clidnum_ai, *exten_ai, *context_ai, *clid_ai, *channel_ai, *app_ai, *appdata_ai, *uniqueid_ai, *linkedid_ai, *cidani_ai, *cidrdnis_ai, *ciddnid_ai, *peer_ai, *userfield_ai, *eventtype_ai;
 	RETCODE erc;
 	int attempt = 1;
 	struct ast_cel_event_record record = {
@@ -139,6 +139,9 @@ static void tds_log(struct ast_event *event)
 	linkedid_ai    = anti_injection(record.linked_id, 32);
 	userfield_ai   = anti_injection(record.user_field, 32);
 	peer_ai        = anti_injection(record.peer, 32);
+	eventtype_ai   = anti_injection(
+		(record.event_type == AST_CEL_USER_DEFINED)
+			? record.user_defined_name : record.event_name, 32);
 
 	get_date(start, sizeof(start), record.event_time);
 
@@ -200,8 +203,7 @@ retry:
 		")",
 		settings->table, accountcode_ai, clidnum_ai, clid_ai, cidani_ai, cidrdnis_ai,
 		ciddnid_ai, exten_ai, context_ai, channel_ai, app_ai, appdata_ai, start,
-		(record.event_type == AST_CEL_USER_DEFINED)
-			? record.user_defined_name : record.event_name,
+		eventtype_ai,
 					ast_channel_amaflags2string(record.amaflag), uniqueid_ai, linkedid_ai,
 		userfield_ai, peer_ai);
 
@@ -251,6 +253,7 @@ done:
 	ast_free(linkedid_ai);
 	ast_free(userfield_ai);
 	ast_free(peer_ai);
+	ast_free(eventtype_ai);
 
 	return;
 }

--- a/channels/chan_unistim.c
+++ b/channels/chan_unistim.c
@@ -456,6 +456,8 @@ static struct unistim_device {
 	struct unistim_device *next;
 } *devices = NULL;
 
+#define MAX_PHONE_NUMBER_LENGTH (AST_MAX_EXTENSION - 1)
+
 static struct unistimsession {
 	ast_mutex_t lock;
 	struct sockaddr_in sin;	 /*!< IP address of the phone */
@@ -3578,6 +3580,12 @@ static void key_dial_page(struct unistimsession *pte, char keycode)
 	if ((keycode >= KEY_0) && (keycode <= KEY_SHARP)) {
 		int i = pte->device->size_phone_number;
 
+		/*
+		 * If the phone_number buffer is already full, bail now to prevent an overrun.
+		 */
+		if (pte->device->size_phone_number >= MAX_PHONE_NUMBER_LENGTH) {
+			return;
+		}
 		if (pte->device->size_phone_number == 0) {
 			send_tone(pte, 0, 0);
 		}

--- a/codecs/codec_codec2.c
+++ b/codecs/codec_codec2.c
@@ -77,7 +77,7 @@ static int codec2tolin_framein(struct ast_trans_pvt *pvt, struct ast_frame *f)
 	struct codec2_translator_pvt *tmp = pvt->pvt;
 	int x;
 
-	for (x = 0; x < f->datalen; x += CODEC2_FRAME_LEN) {
+	for (x = 0; x + CODEC2_FRAME_LEN <= f->datalen; x += CODEC2_FRAME_LEN) {
 		unsigned char *src = f->data.ptr + x;
 		int16_t *dst = pvt->outbuf.i16 + pvt->samples;
 

--- a/contrib/scripts/ast_loggrabber
+++ b/contrib/scripts/ast_loggrabber
@@ -216,17 +216,18 @@ fi
 # Timestamp to use for output files
 df=${tarball_uniqueid:-$(${DATEFORMAT})}
 
-# Extract the Python timestamp conver script from the end of this
-# script and save it to /tmp/.ast_tsconvert.py
-
-install -m 0600 /dev/stdin /tmp/.ast_tsconvert.py < <(sed '1,/^#@@@SCRIPTSTART@@@/ d' "$0")
-
 tmpdir=$(mktemp -d)
 if [ -z "$tmpdir" ] ; then
 	echo "${prog}: Unable to create temporary directory."
 	exit 1
 fi
-trap "rm -rf $tmpdir /tmp/.ast_tsconvert.py" EXIT
+
+# Extract the Python timestamp conver script from the end of this
+# script and save it to the temporary directory
+
+install -m 0600 /dev/stdin "$tmpdir/.ast_tsconvert.py" < <(sed '1,/^#@@@SCRIPTSTART@@@/ d' "$0")
+
+trap "rm -rf $tmpdir" EXIT
 tardir=asterisk-${df}.logfiles
 
 # Now iterate over the logfiles
@@ -237,7 +238,7 @@ for i in ${!LOGFILES[@]} ; do
 	mkdir -p "$destdir" 2>/dev/null || :
 	if [ -n "$LOG_DATEFORMAT" ] ; then
 		echo "Converting $lf"
-		cat "$lf" | python /tmp/.ast_tsconvert.py --format="$LOG_DATEFORMAT" --timezone="$LOG_TIMEZONE" > "${destfile}"
+		cat "$lf" | python "$tmpdir/.ast_tsconvert.py" --format="$LOG_DATEFORMAT" --timezone="$LOG_TIMEZONE" > "${destfile}"
 	else
 		echo "Copying $lf"
 		cp "$lf" "${destfile}"

--- a/formats/format_ogg_speex.c
+++ b/formats/format_ogg_speex.c
@@ -235,6 +235,12 @@ static struct ast_frame *ogg_speex_read(struct ast_filestream *fs,
 		return NULL;
 	}
 
+	if (s->op.bytes < 0 || s->op.bytes > BUF_SIZE) {
+		ast_log(LOG_WARNING, "OGG/Speex packet too large (%ld > %d), skipping\n",
+			s->op.bytes, BUF_SIZE);
+		return NULL;
+	}
+
 	AST_FRAME_SET_BUFFER(&fs->fr, fs->buf, AST_FRIENDLY_OFFSET, BUF_SIZE);
 	memcpy(fs->fr.data.ptr, s->op.packet, s->op.bytes);
 	fs->fr.datalen = s->op.bytes;

--- a/include/asterisk/stasis_app.h
+++ b/include/asterisk/stasis_app.h
@@ -597,6 +597,11 @@ int stasis_app_control_answer(struct stasis_app_control *control);
  * \param variable The name of the variable
  * \param value The value to set the variable to
  *
+ * \note The thread that actually does the set will have the inhibit_escalations
+ * flag set before the call to pbx_builtin_setvar_helper to prevent dangerous
+ * dialplan function execution from ARI.  The flag will be reset to its original
+ * state when pbx_builtin_setvar_helper returns.
+ *
  * \return 0 for success.
  * \return -1 for error.
  */

--- a/main/http.c
+++ b/main/http.c
@@ -609,6 +609,7 @@ void ast_http_create_response(struct ast_tcptls_session_instance *ser, int statu
 	const char *status_title, struct ast_str *http_header_data, const char *text)
 {
 	char server_name[MAX_SERVER_NAME_LENGTH];
+	char escaped_text[512];
 	struct ast_str *server_address = ast_str_create(MAX_SERVER_NAME_LENGTH);
 	struct ast_str *out = ast_str_create(INITIAL_RESPONSE_BODY_BUFFER);
 
@@ -631,6 +632,13 @@ void ast_http_create_response(struct ast_tcptls_session_instance *ser, int statu
 	                server_name);
 	}
 
+	/* Escape text to prevent reflected XSS in error pages */
+	if (!ast_strlen_zero(text)) {
+		ast_xml_escape(text, escaped_text, sizeof(escaped_text));
+	} else {
+		escaped_text[0] = '\0';
+	}
+
 	ast_str_set(&out,
 	            0,
 	            "<!DOCTYPE HTML PUBLIC \"-//IETF//DTD HTML 2.0//EN\">\r\n"
@@ -645,7 +653,7 @@ void ast_http_create_response(struct ast_tcptls_session_instance *ser, int statu
 	            status_code,
 	            status_title,
 	            status_title,
-	            text ? text : "",
+	            escaped_text,
 	            ast_str_buffer(server_address));
 
 	ast_free(server_address);

--- a/main/manager.c
+++ b/main/manager.c
@@ -7759,7 +7759,7 @@ static int auth_http_callback(struct ast_tcptls_session_instance *ser,
 	user = get_manager_by_name_locked(d.username);
 	if(!user) {
 		AST_RWLIST_UNLOCK(&users);
-		ast_log(LOG_NOTICE, "%s tried to authenticate with nonexistent user '%s'\n", ast_sockaddr_stringify_addr(&session->addr), d.username);
+		ast_log(LOG_NOTICE, "%s tried to authenticate with nonexistent user '%s'\n", ast_sockaddr_stringify_addr(remote_address), d.username);
 		nonce = 0;
 		goto out_401;
 	}
@@ -7767,7 +7767,7 @@ static int auth_http_callback(struct ast_tcptls_session_instance *ser,
 	/* --- We have User for this auth, now check ACL */
 	if (user->acl && !ast_apply_acl(user->acl, remote_address, "Manager User ACL:")) {
 		AST_RWLIST_UNLOCK(&users);
-		ast_log(LOG_NOTICE, "%s failed to pass IP ACL as '%s'\n", ast_sockaddr_stringify_addr(&session->addr), d.username);
+		ast_log(LOG_NOTICE, "%s failed to pass IP ACL as '%s'\n", ast_sockaddr_stringify_addr(remote_address), d.username);
 		ast_http_request_close_on_completion(ser);
 		ast_http_error(ser, 403, "Permission denied", "Permission denied");
 		return 0;

--- a/res/res_config_ldap.c
+++ b/res/res_config_ldap.c
@@ -734,6 +734,40 @@ static int replace_string_in_string(char *string, const char *search, const char
 	return replaced;
 }
 
+/*!
+ * \internal
+ * \brief Escape a value for safe inclusion in an LDAP filter per RFC 4515.
+ *
+ * Characters that have special meaning in LDAP filters are escaped
+ * to their \\HH hex representation: * ( ) \\ and NUL.
+ *
+ * \param value The raw value to escape
+ * \param escaped Output buffer (caller-allocated ast_str)
+ */
+static void ldap_filter_escape_value(const char *value, struct ast_str **escaped)
+{
+	ast_str_reset(*escaped);
+	for (; *value; value++) {
+		switch (*value) {
+		case '*':
+			ast_str_append(escaped, 0, "\\2a");
+			break;
+		case '(':
+			ast_str_append(escaped, 0, "\\28");
+			break;
+		case ')':
+			ast_str_append(escaped, 0, "\\29");
+			break;
+		case '\\':
+			ast_str_append(escaped, 0, "\\5c");
+			break;
+		default:
+			ast_str_append(escaped, 0, "%c", *value);
+			break;
+		}
+	}
+}
+
 /*! \brief Append a name=value filter string. The filter string can grow.
  */
 static void append_var_and_value_to_filter(struct ast_str **filter,
@@ -743,8 +777,14 @@ static void append_var_and_value_to_filter(struct ast_str **filter,
 	char *new_name = NULL;
 	char *new_value = NULL;
 	const char *like_pos = strstr(name, " LIKE");
+	struct ast_str *escaped_value;
 
 	ast_debug(2, "name='%s' value='%s'\n", name, value);
+
+	escaped_value = ast_str_create(256);
+	if (!escaped_value) {
+		return;
+	}
 
 	if (like_pos) {
 		int len = like_pos - name;
@@ -754,11 +794,20 @@ static void append_var_and_value_to_filter(struct ast_str **filter,
 		value = new_value = ast_strdupa(value);
 		replace_string_in_string(new_value, "\\_", "_");
 		replace_string_in_string(new_value, "%", "*");
+		name = convert_attribute_name_to_ldap(table_config, name);
+		/* Note: The LIKE path preserves original wildcard behavior.
+		 * A more comprehensive escaping of the LIKE path is left
+		 * to the maintainers familiar with the query semantics.
+		 */
+		ast_str_append(filter, 0, "(%s=%s)", name, value);
+	} else {
+		name = convert_attribute_name_to_ldap(table_config, name);
+		ldap_filter_escape_value(value, &escaped_value);
+		ast_str_append(filter, 0, "(%s=%s)", name,
+			ast_str_buffer(escaped_value));
 	}
 
-	name = convert_attribute_name_to_ldap(table_config, name);
-
-	ast_str_append(filter, 0, "(%s=%s)", name, value);
+	ast_free(escaped_value);
 }
 
 /*!

--- a/res/res_pjsip/pjsip_message_filter.c
+++ b/res/res_pjsip/pjsip_message_filter.c
@@ -277,11 +277,11 @@ static pj_status_t filter_on_tx_message(pjsip_tx_data *tdata)
 
 		/* If the chosen transport is not bound to any we can't use the source address as it won't get back to us */
 		if (!is_bound_any(tdata->tp_info.transport)) {
-			pj_strassign(&prm.ret_addr, &tdata->tp_info.transport->local_name.host);
+			pj_strdup(tdata->pool, &prm.ret_addr, &tdata->tp_info.transport->local_name.host);
 		}
 	} else {
 		/* The transport chosen will deliver this but ensure it is updated with the right information */
-		pj_strassign(&prm.ret_addr, &tdata->tp_info.transport->local_name.host);
+		pj_strdup(tdata->pool, &prm.ret_addr, &tdata->tp_info.transport->local_name.host);
 	}
 
 	/* If the message needs to be updated with new address do so */

--- a/res/res_pjsip_pubsub.c
+++ b/res/res_pjsip_pubsub.c
@@ -3672,6 +3672,7 @@ static pj_bool_t pubsub_on_rx_mwi_notify_request(pjsip_rx_data *rdata)
 	char *context;
 	char *body;
 	char *mailbox;
+	int body_len;
 	int rc;
 
 	endpoint = ast_pjsip_rdata_get_endpoint(rdata);
@@ -3704,8 +3705,15 @@ static pj_bool_t pubsub_on_rx_mwi_notify_request(pjsip_rx_data *rdata)
 	context = atsign + 1;
 
 	body = ast_alloca(rdata->msg_info.msg->body->len + 1);
-	rdata->msg_info.msg->body->print_body(rdata->msg_info.msg->body, body,
+	body_len = rdata->msg_info.msg->body->print_body(rdata->msg_info.msg->body, body,
 		rdata->msg_info.msg->body->len + 1);
+
+	if (body_len < 0 || body_len > rdata->msg_info.msg->body->len) {
+		ast_debug(1, "Incoming MWI: Endpoint: '%s' Unable to print request body\n", endpoint_name);
+		rc = 404;
+		goto error;
+	}
+	body[body_len] = '\0';
 
 	if (parse_simple_message_summary(body, &summary) != 0) {
 		ast_debug(1, "Incoming MWI: Endpoint: '%s' There was an issue getting message info from body '%s'\n",

--- a/res/res_pjsip_pubsub.c
+++ b/res/res_pjsip_pubsub.c
@@ -3656,7 +3656,7 @@ static int parse_simple_message_summary(char *body,
 			&summary->voice_messages_urgent_new, &summary->voice_messages_urgent_old)) {
 			found_counts = 1;
 		} else {
-			sscanf(line, "message-account: %s", summary->message_account);
+			sscanf(line, "message-account: %511s", summary->message_account);
 		}
 	}
 

--- a/res/res_rtp_asterisk.c
+++ b/res/res_rtp_asterisk.c
@@ -5293,6 +5293,17 @@ static struct ast_frame *red_t140_to_red(struct rtp_red *red)
 	/* Store length of each generation and primary data length*/
 	for (i = 0; i < red->num_gen; i++)
 		red->len[i] = red->len[i+1];
+
+	/*
+	 * RED generation payload sizes are limited to 255 (UCHAR_MAX) bytes by virtue of
+	 * red->len being an array of usigned chars.  If the new primary payload exceeds that,
+	 * we're going to truncate it to 255.
+	 */
+	if (red->t140.datalen > UCHAR_MAX) {
+		ast_log(LOG_WARNING, "New T.140 frame of %d bytes exceeds max of %u. Discarding %d bytes.\n",
+			red->t140.datalen, UCHAR_MAX, red->t140.datalen - UCHAR_MAX);
+		red->t140.datalen = UCHAR_MAX;
+	}
 	red->len[i] = red->t140.datalen;
 
 	/* write each generation length in red header */
@@ -9083,7 +9094,13 @@ static int rtp_red_init(struct ast_rtp_instance *instance, int buffer_time, int 
 	return 0;
 }
 
-/*! \pre instance is locked */
+/*! \pre instance is locked
+ *
+ * \warning This code was written many years ago and it's unclear why we actually
+ * buffer OUTGOING T.140 text frames until a command is encountered but we do.
+ *
+ * This may change in the future.
+ */
 static int rtp_red_buffer(struct ast_rtp_instance *instance, struct ast_frame *frame)
 {
 	struct ast_rtp *rtp = ast_rtp_instance_get_data(instance);
@@ -9094,6 +9111,8 @@ static int rtp_red_buffer(struct ast_rtp_instance *instance, struct ast_frame *f
 	}
 
 	if (frame->datalen > 0) {
+		int space_available = 0;
+
 		if (red->t140.datalen > 0) {
 			const unsigned char *primary = red->buf_data;
 
@@ -9108,6 +9127,31 @@ static int rtp_red_buffer(struct ast_rtp_instance *instance, struct ast_frame *f
 					ast_rtp_write(instance, &rtp->red->t140);
 				}
 			}
+		}
+
+		/*
+		 * RED generation payload sizes are limited to 255 (UCHAR_MAX) bytes by virtue of
+		 * red->len being an array of usigned chars.  If adding the current frame will
+		 * exceed that, we're going to flush the saved frame then try again. If the new
+		 * frame fits, great otherwise we're going to toss it.  Without understanding
+		 * the purpose of the buffering, that's all we can do now.
+		 */
+		space_available = UCHAR_MAX - red->t140.datalen;
+
+		if (frame->datalen > space_available) {
+			ast_rtp_write(instance, &rtp->red->t140);
+			/*
+			 * ast_rtp_write() calls red_t140_to_red() which resets red->t140.datalen
+			 * back to 0 so we now have UCHAR_MAX space available.
+			 */
+			space_available = UCHAR_MAX;
+		}
+
+		if (frame->datalen > space_available) {
+			ast_log(LOG_WARNING, "%s: T.140 frame of %d bytes exceeds max of %u. Discarding.\n",
+				ast_rtp_instance_get_channel_id(instance),
+				frame->datalen, UCHAR_MAX);
+			return -1;
 		}
 
 		memcpy(&red->buf_data[red->t140.datalen], frame->data.ptr, frame->datalen);

--- a/res/res_xmpp.c
+++ b/res/res_xmpp.c
@@ -3486,8 +3486,9 @@ static int xmpp_action_hook(void *data, int type, iks *node)
 		char *node_ns = NULL;
 		char attr[XMPP_MAX_ATTRLEN];
 		char *node_name = iks_name(iks_child(node));
-		char *aux = strchr(node_name, ':') + 1;
-		snprintf(attr, strlen("xmlns:") + (strlen(node_name) - strlen(aux)), "xmlns:%s", node_name);
+		char *colon = strchr(node_name, ':');
+		snprintf(attr, sizeof(attr), "xmlns:%.*s",
+			(int)(colon - node_name), node_name);
 		node_ns = iks_find_attrib(iks_child(node), attr);
 		if (node_ns) {
 			pak->ns = node_ns;

--- a/res/stasis/control.c
+++ b/res/stasis/control.c
@@ -709,8 +709,18 @@ static int app_control_set_channel_var(struct stasis_app_control *control,
 	struct ast_channel *chan, void *data)
 {
 	struct chanvar *var = data;
+	/*
+	 * Save the current inhibit state then enable it.
+	 */
+	int inhibited = ast_thread_inhibit_escalations_swap(1);
 
 	pbx_builtin_setvar_helper(control->channel, var->name, var->value);
+	/*
+	 * Re-enable it if it was originally enabled.
+	 */
+	if (inhibited > 0) {
+		ast_thread_inhibit_escalations();
+	}
 
 	return 0;
 }


### PR DESCRIPTION
- **format_ogg_speex: Add bounds check to prevent heap buffer overflow**
- **codec_codec2: Only process complete Codec2 frames in decoder**
- **http: Escape error page text to prevent reflected XSS**
- **cel_pgsql, cel_tds: Escape eventtype field to prevent SQL injection**
- **res_config_ldap: Escape LDAP filter values per RFC 4515**
- **res_pjsip_pubsub: Add width limit to sscanf in MWI NOTIFY parser**
- **res_xmpp: Fix stack buffer overflow in namespace prefix handling**
- **app_sms: Bound protocol 1 SMS unpacking to fixed-size buffers**
- **ooh323: Prevent potential buffer overflow in trace logging**
- **manager: Use remote address in user error logging**
- **res/res_pjsip_pubsub.c: Fix buffer over-read in MWI body parser**
- **res_rtp_asterisk.c: Address 2 potential T.140 RED buffer overruns.**
- **ARI: Make ARI applications respect live_dangerously.**
- **ooh323c/ooq931.c: Ensure ooQ931Decode doesn't run out-of-bounds.**
- **pjsip_message_filter: Use pj_strdup instead of pj_strassign to save local address.**
- **chan_unistim.c: Prevent overrun of phone_number field.**
- **ast_loggrabber: Install the ast_tsconvert.py script to a secure temp directory.**
