### PR TITLE
res_http_websocket: Unref session when it fails to establish.

### DIFF
--- a/res/res_http_websocket.c
+++ b/res/res_http_websocket.c
@@ -1089,6 +1089,7 @@ int AST_OPTIONAL_API_NAME(ast_websocket_uri_cb)(struct ast_tcptls_session_instan
 			ast_log(LOG_WARNING, "WebSocket connection from '%s' could not be accepted - failed to generate a session id\n",
 				ast_sockaddr_stringify(&ser->remote_address));
 			ast_http_error(ser, 500, "Internal Server Error", "Allocation failed");
+			ao2_ref(session, -1);
 			ao2_ref(protocol_handler, -1);
 			return 0;
 		}
@@ -1098,6 +1099,7 @@ int AST_OPTIONAL_API_NAME(ast_websocket_uri_cb)(struct ast_tcptls_session_instan
 			ast_debug(3, "WebSocket connection from '%s' rejected by protocol handler '%s'\n",
 				ast_sockaddr_stringify(&ser->remote_address), protocol_handler->name);
 			websocket_bad_request(ser);
+			ao2_ref(session, -1);
 			ao2_ref(protocol_handler, -1);
 			return 0;
 		}


### PR DESCRIPTION
Two error paths in res_http_websocket could leak an ast_websocket session by failing to drop a reference after the session had been allocated.

The first occurs when session ID generation fails. While this is largely theoretical, as it would require an out-of-memory condition, the session reference should still be released correctly.

The second occurs when the ast_websocket_pre_callback session_attempted callback returns an error. This path is reachable through ari_websockets, which implements this callback and can legitimately fail under certain conditions.

Fixes: #2020 