### PR TITLE
res_pjsip: Document 'none' option for 'dtmf_mode'.

### DIFF
--- a/res/res_pjsip/pjsip_config.xml
+++ b/res/res_pjsip/pjsip_config.xml
@@ -533,6 +533,9 @@
 							<enum name="inband">
 								<para>DTMF is sent as part of audio stream.</para>
 							</enum>
+							<enum name="none">
+								<para>DTMF is not sent or received.</para>
+							</enum>
 							<enum name="info">
 								<para>DTMF is sent as SIP INFO packets.</para>
 							</enum>


### PR DESCRIPTION
The 'none' value can be used to disable DSP processing for DTMF
on PJSIP channels and is sometimes necessary for this reason,
and already exists in the code, but is not documented. Add it to
the documentation enum.

Resolves: #2026
