### PR TITLE
file.c: Fix write-format race when opening a stream for playback

### DIFF
--- a/main/file.c
+++ b/main/file.c
@@ -840,19 +840,26 @@ static struct ast_filestream *openstream_internal(struct ast_channel *chan,
 		return NULL;
 	}
 
-	/* Set the channel to a format we can work with and save off the previous format. */
+	/*
+	 * Keep the channel locked across setting the write format and filehelper(ACTION_OPEN)
+	 * to avoid race conditions with the bridging / format-negotiation code. Otherwise the
+	 * write format may be changed concurrently, leading to a valid file being rejected as
+	 * not supported.
+	 */
 	ast_channel_lock(chan);
+	/* Set the channel to a format we can work with and save off the previous format. */
 	ast_channel_set_oldwriteformat(chan, ast_channel_writeformat(chan));
 	/* Set the channel to the best format that exists for the file. */
 	res = ast_set_write_format_from_cap(chan, file_fmt_cap);
-	ast_channel_unlock(chan);
 	/* don't need this anymore now that the channel's write format is set. */
 	ao2_ref(file_fmt_cap, -1);
 
 	if (res == -1) {	/* No format available that works with this channel */
+		ast_channel_unlock(chan);
 		return NULL;
 	}
 	res = filehelper(buf, chan, NULL, ACTION_OPEN);
+	ast_channel_unlock(chan);
 	if (res >= 0)
 		return ast_channel_stream(chan);
 	return NULL;


### PR DESCRIPTION
openstream_internal() set the channel write format under the channel lock, released the lock, then re-checked that format in filehelper() (ACTION_OPEN) while holding only the formats RWLIST.  The bridging and format-negotiation code changes the same channel's write format concurrently (always under the channel lock), so the re-check could observe a different format and wrongly reject a valid sound file with:

  Unable to open beep (format (alaw)): No such file or directory

Because the reader never took the channel lock, the set and the re-check were two separate critical sections with the lock dropped in between.

Hold the channel lock across both the write-format set and the filehelper(ACTION_OPEN) re-check so the two accesses share a common lock.

Confirmed with ThreadSanitizer: the data race on the channel write format no longer appears and the intermittent warning no longer reproduces.

Resolves: #1623