### PR TITLE
app_queue: Update lastpause on realtime pause transition

### DIFF
--- a/apps/app_queue.c
+++ b/apps/app_queue.c
@@ -3826,8 +3826,12 @@ static void rt_handle_member_record(struct call_queue *q, char *category, struct
 			ast_copy_string(m->rt_uniqueid, rt_uniqueid, sizeof(m->rt_uniqueid));
 			if (paused_str) {
 				m->paused = paused;
-				if (paused && m->lastpause == 0) {
-					time(&m->lastpause); /* XXX: Should this come from realtime? */
+				if (paused) {
+					if (m->lastpause == 0) {
+						time(&m->lastpause); /* XXX: Should this come from realtime? */
+					}
+				} else {
+					m->lastpause = 0; /* Reset lastpause when unpaused from Realtime */
 				}
 				ast_devstate_changed(m->paused ? QUEUE_PAUSED_DEVSTATE : QUEUE_UNPAUSED_DEVSTATE,
 					AST_DEVSTATE_CACHABLE, "Queue:%s_pause_%s", q->name, m->interface);
@@ -8058,6 +8062,8 @@ static void set_queue_member_pause(struct call_queue *q, struct member *mem, con
 	mem->paused = paused;
 	if (paused) {
 		time(&mem->lastpause); /* update last pause field */
+	} else {
+		mem->lastpause = 0;    /* reset last pause field when unpaused */
 	}
 	if (paused && !ast_strlen_zero(reason)) {
 		ast_copy_string(mem->reason_paused, reason, sizeof(mem->reason_paused));

--- a/apps/app_queue.c
+++ b/apps/app_queue.c
@@ -3825,10 +3825,10 @@ static void rt_handle_member_record(struct call_queue *q, char *category, struct
 			m->dead = 0;	/* Do not delete this one. */
 			ast_copy_string(m->rt_uniqueid, rt_uniqueid, sizeof(m->rt_uniqueid));
 			if (paused_str) {
-				m->paused = paused;
-				if (paused && m->lastpause == 0) {
+				if (paused && !m->paused) {
 					time(&m->lastpause); /* XXX: Should this come from realtime? */
 				}
+				m->paused = paused;
 				ast_devstate_changed(m->paused ? QUEUE_PAUSED_DEVSTATE : QUEUE_UNPAUSED_DEVSTATE,
 					AST_DEVSTATE_CACHABLE, "Queue:%s_pause_%s", q->name, m->interface);
 			}


### PR DESCRIPTION
Realtime queue members used lastpause to determine whether a member
had transitioned from unpaused to paused. However, lastpause also
stores the timestamp of the member's most recent pause and should not
be cleared when the member is unpaused.

Compare the existing paused state with the new realtime value instead,
and update lastpause only when the member transitions from unpaused to
paused.

Resolves: #1760