### PR TITLE
Fix GCC compile issues in branch certified/20.7

### DIFF
--- a/apps/app_externalivr.c
+++ b/apps/app_externalivr.c
@@ -309,12 +309,11 @@ static void ast_eivr_getvariable(struct ast_channel *chan, char *data, char *out
 
 	char *inbuf, *variable;
 	const char *value;
-	int j;
 	struct ast_str *newstring = ast_str_alloca(outbuflen);
 
 	outbuf[0] = '\0';
 
-	for (j = 1, inbuf = data; ; j++) {
+	for (inbuf = data; ; ) {
 		variable = strsep(&inbuf, ",");
 		if (variable == NULL) {
 			int outstrlen = strlen(outbuf);

--- a/apps/app_minivm.c
+++ b/apps/app_minivm.c
@@ -2604,14 +2604,14 @@ static int timezone_add(const char *zonename, const char *config)
 }
 
 /*! \brief Read message template from file */
-static char *message_template_parse_filebody(const char *filename) {
+static char *message_template_parse_filebody(const char *filename)
+{
 	char buf[BUFSIZ * 6];
 	char readbuf[BUFSIZ];
 	char filenamebuf[BUFSIZ];
 	char *writepos;
 	char *messagebody;
 	FILE *fi;
-	int lines = 0;
 
 	if (ast_strlen_zero(filename))
 		return NULL;
@@ -2626,7 +2626,6 @@ static char *message_template_parse_filebody(const char *filename) {
 	}
 	writepos = buf;
 	while (fgets(readbuf, sizeof(readbuf), fi)) {
-		lines ++;
 		if (writepos != buf) {
 			*writepos = '\n';		/* Replace EOL with new line */
 			writepos++;

--- a/channels/chan_dahdi.c
+++ b/channels/chan_dahdi.c
@@ -18304,7 +18304,7 @@ static void parse_busy_pattern(struct ast_variable *v, struct ast_dsp_busy_patte
 {
 	int count_pattern = 0;
 	int norval = 0;
-	char *temp = NULL;
+	const char *temp = NULL;
 
 	for (; ;) {
 		/* Scans the string for the next value in the pattern. If none, it checks to see if any have been entered so far. */
@@ -19405,7 +19405,8 @@ static int process_dahdi(struct dahdi_chan_conf *confp, const char *cat, struct 
 				}
 				if (!link->ss7.ss7) {
 					ast_log(LOG_ERROR, "Please specify isup timers after sigchan!\n");
-				} else if (!ss7_set_isup_timer(link->ss7.ss7, strstr(v->name, ".") + 1, atoi(v->value))) {
+					/*! \todo Remove cast after libss7 API is changed to const char */
+				} else if (!ss7_set_isup_timer(link->ss7.ss7, (char*) strstr(v->name, ".") + 1, atoi(v->value))) {
 					ast_log(LOG_ERROR, "Invalid isup timer %s\n", v->name);
 				}
 			} else if (!strncasecmp(v->name, "mtp3_timer.", 11)) {
@@ -19417,7 +19418,8 @@ static int process_dahdi(struct dahdi_chan_conf *confp, const char *cat, struct 
 				}
 				if (!link->ss7.ss7) {
 					ast_log(LOG_ERROR, "Please specify mtp3 timers after sigchan!\n");
-				} else if (!ss7_set_mtp3_timer(link->ss7.ss7, strstr(v->name, ".") + 1, atoi(v->value))) {
+					/*! \todo Remove cast after libss7 API is changed to const char */
+				} else if (!ss7_set_mtp3_timer(link->ss7.ss7, (char*) strstr(v->name, ".") + 1, atoi(v->value))) {
 					ast_log(LOG_ERROR, "Invalid mtp3 timer %s\n", v->name);
 				}
 			} else if (!strcasecmp(v->name, "inr_if_no_calling")) {
@@ -19831,7 +19833,7 @@ static int setup_dahdi_int(int reload, struct dahdi_chan_conf *default_conf, str
 	int res;
 
 #ifdef HAVE_PRI
-	char *c;
+	const char *c;
 	int spanno;
 	int i;
 	int logicalspan;

--- a/channels/chan_sip.c
+++ b/channels/chan_sip.c
@@ -1221,7 +1221,7 @@ static int get_address_family_filter(unsigned int transport);
 /*--- Transmitting responses and requests */
 static int sipsock_read(int *id, int fd, short events, void *ignore);
 static int __sip_xmit(struct sip_pvt *p, struct ast_str *data);
-static int __sip_reliable_xmit(struct sip_pvt *p, uint32_t seqno, int resp, struct ast_str *data, int fatal, int sipmethod);
+static enum sip_result __sip_reliable_xmit(struct sip_pvt *p, uint32_t seqno, int resp, struct ast_str *data, int fatal, int sipmethod);
 static void add_cc_call_info_to_response(struct sip_pvt *p, struct sip_request *resp);
 static int __transmit_response(struct sip_pvt *p, const char *msg, const struct sip_request *req, enum xmittype reliable);
 static int retrans_pkt(const void *data);

--- a/channels/chan_unistim.c
+++ b/channels/chan_unistim.c
@@ -5100,7 +5100,6 @@ static int unistimsock_read(int *id, int fd, short events, void *ignore)
 	struct sockaddr_in addr_from = { 0, };
 	struct unistimsession *cur = NULL;
 	int found = 0;
-	int tmp = 0;
 	int dw_num_bytes_rcvd;
 	unsigned int size_addr_from;
 #ifdef DUMP_PACKET
@@ -5128,7 +5127,6 @@ static int unistimsock_read(int *id, int fd, short events, void *ignore)
 			found = 1;
 			break;
 		}
-		tmp++;
 		cur = cur->next;
 	}
 	ast_mutex_unlock(&sessionlock);

--- a/funcs/func_curl.c
+++ b/funcs/func_curl.c
@@ -619,8 +619,8 @@ static int curl_instance_init(void *data)
 	if (!(*curl = curl_easy_init()))
 		return -1;
 
-	curl_easy_setopt(*curl, CURLOPT_NOSIGNAL, 1);
-	curl_easy_setopt(*curl, CURLOPT_TIMEOUT, 180);
+	curl_easy_setopt(*curl, CURLOPT_NOSIGNAL, 1L);
+	curl_easy_setopt(*curl, CURLOPT_TIMEOUT, 180L);
 	curl_easy_setopt(*curl, CURLOPT_WRITEFUNCTION, WriteMemoryCallback);
 	curl_easy_setopt(*curl, CURLOPT_USERAGENT, AST_CURL_USER_AGENT);
 

--- a/main/Makefile
+++ b/main/Makefile
@@ -148,6 +148,7 @@ endif
 stdtime/localtime.o: _ASTCFLAGS+=$(AST_NO_STRICT_OVERFLOW) -Wno-format-nonliteral
 
 asterisk.o: _ASTCFLAGS+=$(LIBEDIT_INCLUDE)
+ast_expr2.o: _ASTCFLAGS+=-Wno-unused
 ast_expr2f.o: _ASTCFLAGS+=-Wno-unused
 astmm.o: _ASTCFLAGS+=$(call get_menuselect_cflags,MALLOC_DEBUG DEBUG_CHAOS)
 astobj2.o astobj2_container.o astobj2_hash.o astobj2_rbtree.o: _ASTCFLAGS+=$(call get_menuselect_cflags,AO2_DEBUG)

--- a/main/fskmodem_float.c
+++ b/main/fskmodem_float.c
@@ -225,7 +225,6 @@ int fsk_serial(fsk_data *fskd, short *buffer, int *len, int *outbyte)
 {
 	int a;
 	int i,j,n1,r;
-	int samples = 0;
 	int olen;
 
 	switch (fskd->state) {
@@ -257,14 +256,12 @@ int fsk_serial(fsk_data *fskd, short *buffer, int *len, int *outbyte)
 		a start bit, perhaps. This whole thing stinks! */
 		if (demodulator(fskd, &fskd->x1, GET_SAMPLE))
 			return -1;
-		samples++;
 		for (;;) {
 search_startbit2:
 			if (*len <= 0) {
 				fskd->state  =  STATE_SEARCH_STARTBIT2;
 				return 0;
 			}
-			samples++;
 			if (demodulator(fskd, &fskd->x2, GET_SAMPLE))
 				return(-1);
 #if 0
@@ -286,7 +283,6 @@ search_startbit3:
 #if 0
 			printf("x1 = %5.5f ", fskd->x1);
 #endif
-			samples++;
 		}
 
 		/* x1 must be negative (start bit confirmation) */

--- a/main/say.c
+++ b/main/say.c
@@ -8202,8 +8202,6 @@ static int ast_say_number_full_gr(struct ast_channel *chan, int num, const char 
 {
 	int res = 0;
 	char fn[256] = "";
-	int i=0;
-
 
 	if (!num) {
 		ast_copy_string(fn, "digits/0", sizeof(fn));
@@ -8213,7 +8211,6 @@ static int ast_say_number_full_gr(struct ast_channel *chan, int num, const char 
 	}
 
 	while (!res && num ) {
-		i++;
 		if (num < 13) {
 			snprintf(fn, sizeof(fn), "digits/%d", num);
 			num = 0;

--- a/main/utils.c
+++ b/main/utils.c
@@ -298,14 +298,12 @@ int ast_base64decode(unsigned char *dst, const char *src, int max)
 	int cnt = 0;
 	unsigned int byte = 0;
 	unsigned int bits = 0;
-	int incnt = 0;
 	while(*src && *src != '=' && (cnt < max)) {
 		/* Shift in 6 bits of input */
 		byte <<= 6;
 		byte |= (b2a[(int)(*src)]) & 0x3f;
 		bits += 6;
 		src++;
-		incnt++;
 		/* If we have at least 8 bits left over, take that character
 		   off the top */
 		if (bits >= 8)  {

--- a/res/Makefile
+++ b/res/Makefile
@@ -32,7 +32,7 @@ ael/ael_lex.o: ael/ael_lex.c ../include/asterisk/ael_structs.h ael/ael.tab.h
 ael/ael_lex.o: _ASTCFLAGS+=-I. -Iael -Wno-unused $(AST_NO_FORMAT_TRUNCATION)
 
 ael/ael.tab.o: ael/ael.tab.c ael/ael.tab.h ../include/asterisk/ael_structs.h
-ael/ael.tab.o: _ASTCFLAGS+=-I. -Iael -DYYENABLE_NLS=0
+ael/ael.tab.o: _ASTCFLAGS+=-I. -Iael -Wno-unused -DYYENABLE_NLS=0
 
 ifneq ($(findstring REBUILD_PARSERS,$(MENUSELECT_CFLAGS)),)
 ael/ael_lex.c: ael/ael.flex
@@ -54,6 +54,7 @@ endif
 	$(CMD_PREFIX) (cd ael; $(BISON) -v -d ael.y)
 
 ael/pval.o: ael/pval.c
+ael/pval.o: _ASTCFLAGS+=-Wno-unused
 
 $(call MOD_ADD_C,res_ael_share,ael/ael_lex.c ael/ael.tab.c ael/pval.c)
 $(call MOD_ADD_C,res_stasis,$(wildcard stasis/*.c))

--- a/res/res_stir_shaken.c
+++ b/res/res_stir_shaken.c
@@ -285,12 +285,10 @@ static int reload_module(void)
 
 static int unload_module(void)
 {
-	int res = 0;
-
 	common_config_unload();
 	crypto_unload();
 
-	res |= ast_custom_function_unregister(&stir_shaken_function);
+	ast_custom_function_unregister(&stir_shaken_function);
 
 	return 0;
 }


### PR DESCRIPTION
Cherry-picks of existing fixes:

- **build: Fix unused-but-set-variable warnings with gcc 16.**
- **chan_dahdi: Fix discarded-qualifiers errors.**
- **chan_sip.c: Fix __sip_reliable_xmit build error**

Standalone fix that was fixed in other branches as part of a larger change which we don't want to include in this branch:

- **res_stir_shaken.c: Fix GCC set-but-not-used error in unload_module.**
