### PR TITLE
app_voicemail.c: Fix may-be-uninitialized error

### DIFF
--- a/apps/app_voicemail.c
+++ b/apps/app_voicemail.c
@@ -14176,7 +14176,7 @@ static int append_vmu_info_astman(
 		const char* actionid
 		)
 {
-	int new;
+	int new = 0;
 	int old;
 	char *mailbox;
 	int ret;


### PR DESCRIPTION
A pointer to `new` is passed to `inboxcount(...)` which increments the pointed-to value.