### PR TITLE
res_musiconhold: Fix mohclass reference leak on answeredonly early return.

### DIFF
--- a/res/res_musiconhold.c
+++ b/res/res_musiconhold.c
@@ -1916,6 +1916,7 @@ static int local_ast_moh_start(struct ast_channel *chan, const char *mclass, con
 
 	if (mohclass->answeredonly && (ast_channel_state(chan) != AST_STATE_UP)) {
 		ast_verb(3, "The channel '%s' is not answered yet. Ignore the moh request.\n", ast_channel_name(chan));
+		mohclass = mohclass_unref(mohclass, "unreffing local reference to mohclass (channel not answered)");
 		return -1;
 	}
 


### PR DESCRIPTION
local_ast_moh_start() returns -1 from the answeredonly check without
releasing the mohclass reference it holds, unlike every other exit path
in the function. Nothing else ever releases that reference, so
moh_class_destructor() never runs for the object. With realtime music
on hold and cachertclasses disabled, each suppressed request leaks the
class object, its monitor thread, the external application process and
two file descriptors for the lifetime of Asterisk. For static classes
the stale references prevent the class from ever being destroyed after
it is replaced by a reload.

Release the reference before returning, matching the other exit paths.

Fixes: #2051
