### PR TITLE
backtrace.c: Avoid removed bfd_boolean type.

### DIFF
--- a/main/backtrace.c
+++ b/main/backtrace.c
@@ -127,7 +127,7 @@ static void process_section(bfd *bfdobj, asection *section, void *obj)
 	bfd_vma offset;
 	bfd_vma vma;
 	bfd_size_type size;
-	bfd_boolean line_found = 0;
+	bool line_found = 0;
 	const char *fn;
 	int inlined = 0;
 


### PR DESCRIPTION
bfd_boolean has been deprecated for some time and has now been removed in gdb, so use bool directly instead.

See: https://github.com/gnutools/binutils-gdb/commit/1d95b744c06974f0a00c143c6e0fc979af930908

Resolves: #2054