### PR TITLE
res_pjsip_sdp_rtp: Fix intermittent call drop on reINVITE sdp change

### DIFF
--- a/include/asterisk/res_pjsip_session.h
+++ b/include/asterisk/res_pjsip_session.h
@@ -51,6 +51,8 @@ struct pjmedia_sdp_media;
 struct pjmedia_sdp_session;
 struct ast_dsp;
 struct ast_udptl;
+struct ast_rtp_codecs;
+struct ast_rtp_instance;
 
 /*! \brief T.38 states for a session */
 enum ast_sip_session_t38state {
@@ -946,6 +948,66 @@ void ast_sip_session_media_stats_save(struct ast_sip_session *sip_session, struc
  * \param media_state The media state to reset
  */
 void ast_sip_session_media_state_reset(struct ast_sip_session_media_state *media_state);
+
+/*!
+ * \brief Merge provisional RTP payloads into a pending media state
+ * \since 23.5.0
+ * \since 22.11.0
+ * \since 20.21.0
+ *
+ * A single rollback snapshot is retained for each destination codecs
+ * structure even when multiple bundled streams update the same RTP instance.
+ *
+ * \param media_state The pending media state that owns the merge transaction
+ * \param src The source codecs structure whose payloads are merged in
+ * \param dest The destination codecs structure that the values from src will be merged into
+ * \param instance Optionally the instance that the dest codecs structure belongs to
+ *
+ * \retval 0 on success
+ * \retval -1 on allocation failure
+ */
+int ast_sip_session_media_state_payloads_merge(
+	struct ast_sip_session_media_state *media_state,
+	struct ast_rtp_codecs *src, struct ast_rtp_codecs *dest,
+	struct ast_rtp_instance *instance);
+
+/*!
+ * \brief Roll back all provisional RTP payload merges in a media state
+ * \since 23.5.0
+ * \since 22.11.0
+ * \since 20.21.0
+ *
+ * \param media_state The media state whose pending merges are rolled back
+ */
+void ast_sip_session_media_state_payloads_rollback(
+	struct ast_sip_session_media_state *media_state);
+
+/*!
+ * \brief Commit the provisional merge for one RTP codecs structure
+ * \since 23.5.0
+ * \since 22.11.0
+ * \since 20.21.0
+ *
+ * \param media_state The media state that owns the merge transaction
+ * \param codecs The destination codecs structure whose pending merge is committed
+ */
+void ast_sip_session_media_state_payloads_commit_one(
+	struct ast_sip_session_media_state *media_state,
+	struct ast_rtp_codecs *codecs);
+
+/*!
+ * \brief Determine whether a media state has provisional RTP payload merges
+ * \since 23.5.0
+ * \since 22.11.0
+ * \since 20.21.0
+ *
+ * \param media_state The media state to check
+ *
+ * \retval 1 if provisional payload merges are present
+ * \retval 0 otherwise
+ */
+int ast_sip_session_media_state_payloads_pending(
+	const struct ast_sip_session_media_state *media_state);
 
 /*!
  * \brief Clone a media state

--- a/include/asterisk/rtp_engine.h
+++ b/include/asterisk/rtp_engine.h
@@ -1593,6 +1593,86 @@ void ast_rtp_codecs_payloads_clear(struct ast_rtp_codecs *codecs, struct ast_rtp
  */
 void ast_rtp_codecs_payloads_copy(struct ast_rtp_codecs *src, struct ast_rtp_codecs *dest, struct ast_rtp_instance *instance);
 
+/*! \brief Opaque transaction for a provisional RTP payload merge. */
+struct ast_rtp_codecs_payloads_merge_txn;
+
+/*!
+ * \brief Begin a provisional payload merge transaction
+ * \since 23.5.0
+ * \since 22.11.0
+ * \since 20.21.0
+ *
+ * \param src The source codecs structure
+ * \param dest The destination codecs structure that the values from src will be merged into
+ * \param instance Optionally the instance that the dest codecs structure belongs to
+ *
+ * This adds/updates the payloads from src into dest, without removing any
+ * existing dest mappings that src doesn't itself have. Unlike
+ * ast_rtp_codecs_payloads_copy(), this is safe to use when dest is a live,
+ * in-use RTP instance's codecs and some of its existing mappings must remain
+ * usable until a later, separate commit point (e.g. reflecting a new SDP
+ * offer's payloads before the channel's own read/write formats have caught
+ * up to match). This merges payload mappings and framing, since both are
+ * needed while generating the SDP answer. It never touches dest's preferred
+ * format or preferred DTMF metadata; those are only ever changed by
+ * ast_rtp_codecs_payloads_copy().
+ *
+ * The destination's pre-merge payload mappings and framing are retained as a
+ * rollback snapshot, so they can be restored if the surrounding SDP
+ * negotiation is abandoned.
+ *
+ * \retval non-NULL transaction on success
+ * \retval NULL on allocation failure; dest is not modified
+ */
+struct ast_rtp_codecs_payloads_merge_txn *ast_rtp_codecs_payloads_merge_begin(
+	struct ast_rtp_codecs *src, struct ast_rtp_codecs *dest,
+	struct ast_rtp_instance *instance);
+
+/*!
+ * \brief Add an additional provisional merge to an existing transaction
+ * \since 23.5.0
+ * \since 22.11.0
+ * \since 20.21.0
+ *
+ * \retval 0 on success
+ * \retval -1 if txn is invalid
+ */
+int ast_rtp_codecs_payloads_merge_update(
+	struct ast_rtp_codecs_payloads_merge_txn *txn,
+	struct ast_rtp_codecs *src);
+
+/*!
+ * \brief Determine whether a transaction belongs to a codecs structure
+ * \since 23.5.0
+ * \since 22.11.0
+ * \since 20.21.0
+ */
+int ast_rtp_codecs_payloads_merge_matches(
+	const struct ast_rtp_codecs_payloads_merge_txn *txn,
+	const struct ast_rtp_codecs *codecs);
+
+/*!
+ * \brief Commit a provisional merge and release its rollback state
+ * \since 23.5.0
+ * \since 22.11.0
+ * \since 20.21.0
+ *
+ * The transaction is consumed by this call; txn must not be used afterward.
+ */
+void ast_rtp_codecs_payloads_merge_commit(
+	struct ast_rtp_codecs_payloads_merge_txn *txn);
+
+/*!
+ * \brief Restore the state retained before a provisional merge
+ * \since 23.5.0
+ * \since 22.11.0
+ * \since 20.21.0
+ *
+ * The transaction is consumed by this call; txn must not be used afterward.
+ */
+void ast_rtp_codecs_payloads_merge_rollback(
+	struct ast_rtp_codecs_payloads_merge_txn *txn);
+
 /*!
  * \brief Crossover copy the tx payload mapping of src to the rx payload mapping of dest.
  * \since 14.0.0

--- a/main/rtp_engine.c
+++ b/main/rtp_engine.c
@@ -1335,6 +1335,247 @@ void ast_rtp_codecs_payloads_copy(struct ast_rtp_codecs *src, struct ast_rtp_cod
 	ast_rwlock_unlock(&dest->codecs_lock);
 }
 
+static void rtp_codecs_payloads_merge_locked(struct ast_rtp_codecs *src,
+	struct ast_rtp_codecs *dest, struct ast_rtp_instance *instance,
+	unsigned char payload_changed[AST_RTP_MAX_PT])
+{
+	int idx;
+
+	if (payload_changed) {
+		for (idx = 0; idx < AST_RTP_MAX_PT; ++idx) {
+			if ((idx < AST_VECTOR_SIZE(&src->payload_mapping_rx)
+					&& AST_VECTOR_GET(&src->payload_mapping_rx, idx))
+				|| (idx < AST_VECTOR_SIZE(&src->payload_mapping_tx)
+					&& AST_VECTOR_GET(&src->payload_mapping_tx, idx))) {
+				payload_changed[idx] = 1;
+			}
+		}
+	}
+
+	/*
+	 * Unlike ast_rtp_codecs_payloads_copy(), dest's existing rx/tx mappings
+	 * that src doesn't have are intentionally left alone here.
+	 */
+	rtp_codecs_payloads_copy_rx(src, dest, instance);
+	rtp_codecs_payloads_copy_tx(src, dest, instance);
+	dest->framing = src->framing;
+}
+
+struct ast_rtp_codecs_payloads_merge_txn {
+	struct ast_rtp_codecs *codecs;
+	struct ast_rtp_instance *instance;
+	struct ast_rtp_payload_type *payload_mapping_rx[AST_RTP_MAX_PT];
+	struct ast_rtp_payload_type *payload_mapping_tx[AST_RTP_MAX_PT];
+	unsigned char payload_changed[AST_RTP_MAX_PT];
+	unsigned int framing;
+};
+
+static struct ast_rtp_codecs *rtp_codecs_payloads_merge_txn_get_codecs(
+	struct ast_rtp_codecs_payloads_merge_txn *txn)
+{
+	if (!txn) {
+		return NULL;
+	}
+
+	return txn->instance ? ast_rtp_instance_get_codecs(txn->instance) : txn->codecs;
+}
+
+static void rtp_codecs_payloads_merge_txn_destroy(
+	struct ast_rtp_codecs_payloads_merge_txn *txn)
+{
+	int idx;
+
+	if (!txn) {
+		return;
+	}
+
+	for (idx = 0; idx < AST_RTP_MAX_PT; ++idx) {
+		ao2_cleanup(txn->payload_mapping_rx[idx]);
+		ao2_cleanup(txn->payload_mapping_tx[idx]);
+	}
+	ao2_cleanup(txn->instance);
+	ast_free(txn);
+}
+
+struct ast_rtp_codecs_payloads_merge_txn *ast_rtp_codecs_payloads_merge_begin(
+	struct ast_rtp_codecs *src, struct ast_rtp_codecs *dest,
+	struct ast_rtp_instance *instance)
+{
+	struct ast_rtp_codecs_payloads_merge_txn *txn;
+	int idx;
+
+	txn = ast_calloc(1, sizeof(*txn));
+	if (!txn) {
+		return NULL;
+	}
+
+	txn->codecs = dest;
+	txn->instance = ao2_bump(instance);
+
+	ast_rwlock_wrlock(&dest->codecs_lock);
+	if (src == dest) {
+		for (idx = 0; idx < AST_RTP_MAX_PT; ++idx) {
+			if (idx < AST_VECTOR_SIZE(&dest->payload_mapping_rx)) {
+				txn->payload_mapping_rx[idx] =
+					ao2_bump(AST_VECTOR_GET(&dest->payload_mapping_rx, idx));
+			}
+			if (idx < AST_VECTOR_SIZE(&dest->payload_mapping_tx)) {
+				txn->payload_mapping_tx[idx] =
+					ao2_bump(AST_VECTOR_GET(&dest->payload_mapping_tx, idx));
+			}
+		}
+		txn->framing = dest->framing;
+		ast_rwlock_unlock(&dest->codecs_lock);
+		return txn;
+	}
+
+	/* Deadlock avoidance because of held write lock. */
+	while (ast_rwlock_tryrdlock(&src->codecs_lock)) {
+		ast_rwlock_unlock(&dest->codecs_lock);
+		sched_yield();
+		ast_rwlock_wrlock(&dest->codecs_lock);
+	}
+
+	for (idx = 0; idx < AST_RTP_MAX_PT; ++idx) {
+		if (idx < AST_VECTOR_SIZE(&dest->payload_mapping_rx)) {
+			txn->payload_mapping_rx[idx] =
+				ao2_bump(AST_VECTOR_GET(&dest->payload_mapping_rx, idx));
+		}
+		if (idx < AST_VECTOR_SIZE(&dest->payload_mapping_tx)) {
+			txn->payload_mapping_tx[idx] =
+				ao2_bump(AST_VECTOR_GET(&dest->payload_mapping_tx, idx));
+		}
+	}
+	txn->framing = dest->framing;
+
+	rtp_codecs_payloads_merge_locked(src, dest, instance,
+		txn->payload_changed);
+
+	ast_rwlock_unlock(&src->codecs_lock);
+	ast_rwlock_unlock(&dest->codecs_lock);
+
+	return txn;
+}
+
+int ast_rtp_codecs_payloads_merge_update(
+	struct ast_rtp_codecs_payloads_merge_txn *txn,
+	struct ast_rtp_codecs *src)
+{
+	struct ast_rtp_codecs *codecs;
+
+	if (!txn) {
+		return -1;
+	}
+
+	codecs = rtp_codecs_payloads_merge_txn_get_codecs(txn);
+	if (!codecs) {
+		return -1;
+	}
+	if (src == codecs) {
+		return 0;
+	}
+
+	ast_rwlock_wrlock(&codecs->codecs_lock);
+
+	/* Deadlock avoidance because of held write lock. */
+	while (ast_rwlock_tryrdlock(&src->codecs_lock)) {
+		ast_rwlock_unlock(&codecs->codecs_lock);
+		sched_yield();
+		ast_rwlock_wrlock(&codecs->codecs_lock);
+	}
+
+	rtp_codecs_payloads_merge_locked(src, codecs, txn->instance,
+		txn->payload_changed);
+
+	ast_rwlock_unlock(&src->codecs_lock);
+	ast_rwlock_unlock(&codecs->codecs_lock);
+	return 0;
+}
+
+int ast_rtp_codecs_payloads_merge_matches(
+	const struct ast_rtp_codecs_payloads_merge_txn *txn,
+	const struct ast_rtp_codecs *codecs)
+{
+	if (!txn) {
+		return 0;
+	}
+
+	return (txn->instance ? ast_rtp_instance_get_codecs(txn->instance) : txn->codecs) == codecs;
+}
+
+void ast_rtp_codecs_payloads_merge_commit(
+	struct ast_rtp_codecs_payloads_merge_txn *txn)
+{
+	rtp_codecs_payloads_merge_txn_destroy(txn);
+}
+
+void ast_rtp_codecs_payloads_merge_rollback(
+	struct ast_rtp_codecs_payloads_merge_txn *txn)
+{
+	struct ast_rtp_codecs *codecs;
+	int idx;
+
+	if (!txn) {
+		return;
+	}
+
+	codecs = rtp_codecs_payloads_merge_txn_get_codecs(txn);
+	if (!codecs) {
+		rtp_codecs_payloads_merge_txn_destroy(txn);
+		return;
+	}
+	ast_rwlock_wrlock(&codecs->codecs_lock);
+
+	if (txn->instance && txn->instance->engine
+		&& txn->instance->engine->payload_set) {
+		ao2_lock(txn->instance);
+	}
+
+	for (idx = 0; idx < AST_RTP_MAX_PT; ++idx) {
+		struct ast_rtp_payload_type *type;
+
+		if (!txn->payload_changed[idx]) {
+			continue;
+		}
+
+		if (idx < AST_VECTOR_SIZE(&codecs->payload_mapping_rx)) {
+			ao2_cleanup(AST_VECTOR_GET(&codecs->payload_mapping_rx, idx));
+			AST_VECTOR_REPLACE(&codecs->payload_mapping_rx, idx,
+				ao2_bump(txn->payload_mapping_rx[idx]));
+		}
+		if (idx < AST_VECTOR_SIZE(&codecs->payload_mapping_tx)) {
+			ao2_cleanup(AST_VECTOR_GET(&codecs->payload_mapping_tx, idx));
+			AST_VECTOR_REPLACE(&codecs->payload_mapping_tx, idx,
+				ao2_bump(txn->payload_mapping_tx[idx]));
+		}
+
+		if (!txn->instance || !txn->instance->engine
+			|| !txn->instance->engine->payload_set) {
+			continue;
+		}
+
+		type = txn->payload_mapping_rx[idx]
+			? txn->payload_mapping_rx[idx] : txn->payload_mapping_tx[idx];
+		if (type) {
+			txn->instance->engine->payload_set(txn->instance, idx,
+				type->asterisk_format, type->format, type->rtp_code);
+		} else {
+			txn->instance->engine->payload_set(txn->instance, idx,
+				0, NULL, 0);
+		}
+	}
+
+	if (txn->instance && txn->instance->engine
+		&& txn->instance->engine->payload_set) {
+		ao2_unlock(txn->instance);
+	}
+
+	codecs->framing = txn->framing;
+
+	ast_rwlock_unlock(&codecs->codecs_lock);
+	rtp_codecs_payloads_merge_txn_destroy(txn);
+}
+
 void ast_rtp_codecs_payloads_xover(struct ast_rtp_codecs *src, struct ast_rtp_codecs *dest, struct ast_rtp_instance *instance)
 {
 	int idx;

--- a/res/res_pjsip_sdp_rtp.c
+++ b/res/res_pjsip_sdp_rtp.c
@@ -509,8 +509,19 @@ static struct ast_format_cap *set_incoming_call_offer_cap(
 	 */
 	ast_rtp_codecs_payloads_xover(&codecs, &codecs, NULL);
 
-	ast_rtp_codecs_payloads_copy(&codecs,
-		ast_rtp_instance_get_codecs(session_media->rtp), session_media->rtp);
+	/*
+	 * This only merges the newly offered payloads into the live RTP instance
+	 * rather than doing a destructive replace, so any format the channel is
+	 * still actively sending in (e.g. while a reINVITE is in flight) remains
+	 * usable right up until set_caps() commits the channel to the new
+	 * negotiated format.
+	 */
+	if (ast_sip_session_media_state_payloads_merge(session->pending_media_state,
+			&codecs, ast_rtp_instance_get_codecs(session_media->rtp),
+			session_media->rtp)) {
+		ao2_cleanup(incoming_call_offer_cap);
+		incoming_call_offer_cap = NULL;
+	}
 
 	ast_rtp_codecs_payloads_destroy(&codecs);
 
@@ -581,13 +592,35 @@ static int set_caps(struct ast_sip_session *session,
 		 */
 		ast_rtp_codecs_payloads_xover(&codecs, &codecs, NULL);
 	}
+
+	/*
+	 * The channel lock is held from here through the nativeformats/read-write
+	 * format update below so the destructive RTP payload mapping replace and
+	 * the channel format switch happen as one atomic step with respect to a
+	 * concurrent bridge write (which also locks the channel before writing).
+	 * apply_negotiated_sdp_stream(), our only caller, guarantees session->channel
+	 * is non-NULL before calling set_caps().
+	 */
+	ast_channel_lock(session->channel);
 	ast_rtp_codecs_payloads_copy(&codecs, ast_rtp_instance_get_codecs(session_media->rtp),
 		session_media->rtp);
 
+	/*
+	 * The destructive replace above is the authoritative commit point for
+	 * this stream's RTP payloads, so retire the provisional merge transaction
+	 * immediately rather than after the channel format switch below. Leaving
+	 * it marked pending across the rest of this function would let a
+	 * rollback triggered elsewhere (e.g. session_inv_on_tsx_state_changed()
+	 * on a late failure response) find it still pending and restore the
+	 * stale pre-negotiation snapshot over payloads that were already
+	 * committed here.
+	 */
+	ast_sip_session_media_state_payloads_commit_one(session->pending_media_state,
+		ast_rtp_instance_get_codecs(session_media->rtp));
+
 	apply_cap_to_bundled(session_media, session_media_transport, asterisk_stream, joint);
 
-	if (session->channel && ast_sip_session_is_pending_stream_default(session, asterisk_stream)) {
-		ast_channel_lock(session->channel);
+	if (ast_sip_session_is_pending_stream_default(session, asterisk_stream)) {
 		ast_format_cap_remove_by_type(caps, AST_MEDIA_TYPE_UNKNOWN);
 		ast_format_cap_append_from_cap(caps, ast_channel_nativeformats(session->channel),
 			AST_MEDIA_TYPE_UNKNOWN);
@@ -641,9 +674,9 @@ static int set_caps(struct ast_sip_session *session,
 		if (ast_channel_is_bridged(session->channel)) {
 			ast_channel_set_unbridged_nolock(session->channel, 1);
 		}
-
-		ast_channel_unlock(session->channel);
 	}
+
+	ast_channel_unlock(session->channel);
 
 	ast_rtp_codecs_payloads_destroy(&codecs);
 	SCOPE_EXIT_RTN_VALUE(0);

--- a/res/res_pjsip_session.c
+++ b/res/res_pjsip_session.c
@@ -52,10 +52,19 @@
 #include "asterisk/test.h"
 #include "asterisk/stream.h"
 #include "asterisk/vector.h"
+#include "asterisk/rtp_engine.h"
 
 #include "res_pjsip_session/pjsip_session.h"
 
 #define SDP_HANDLER_BUCKETS 11
+
+/*
+ * Sized for call volume: every session's active and pending media_state gets
+ * an entry here while a payload merge is outstanding, so this scales with
+ * concurrent calls. Matches DIALOG_ASSOCIATIONS_BUCKETS in pjsip_distributor.c,
+ * which is sized for the same reason.
+ */
+#define MEDIA_STATE_PAYLOAD_MERGE_BUCKETS 251
 
 #define MOD_DATA_ON_RESPONSE "on_response"
 
@@ -93,6 +102,80 @@ static struct ast_sip_nat_hook *nat_hook;
  * handlers for the stream type.
  */
 static struct ao2_container *sdp_handlers;
+
+struct media_state_payload_merge_state {
+	struct ast_sip_session_media_state *media_state;
+	AST_VECTOR(, struct ast_rtp_codecs_payloads_merge_txn *) payload_merge_txns;
+};
+
+static struct ao2_container *media_state_payload_merges;
+
+static int media_state_payload_merge_state_hash(const void *obj, int flags)
+{
+	const struct media_state_payload_merge_state *state = obj;
+	const struct ast_sip_session_media_state *media_state =
+		(flags & OBJ_KEY) ? obj : state->media_state;
+	uintptr_t value = (uintptr_t) media_state;
+	value ^= value >> 4;
+	value ^= value >> 9;
+	return (unsigned int) value;
+}
+
+static int media_state_payload_merge_state_cmp(void *obj, void *arg, int flags)
+{
+	const struct media_state_payload_merge_state *left = obj;
+	const struct ast_sip_session_media_state *right_media_state =
+		(flags & OBJ_KEY) ? arg : ((const struct media_state_payload_merge_state *) arg)->media_state;
+
+	return left->media_state == right_media_state ? CMP_MATCH | CMP_STOP : 0;
+}
+
+static void media_state_payload_merge_state_dtor(void *obj)
+{
+	struct media_state_payload_merge_state *state = obj;
+
+	while (AST_VECTOR_SIZE(&state->payload_merge_txns)) {
+		struct ast_rtp_codecs_payloads_merge_txn *txn;
+
+		txn = AST_VECTOR_REMOVE_ORDERED(&state->payload_merge_txns,
+			AST_VECTOR_SIZE(&state->payload_merge_txns) - 1);
+		ast_rtp_codecs_payloads_merge_rollback(txn);
+	}
+
+	AST_VECTOR_FREE(&state->payload_merge_txns);
+}
+
+static struct media_state_payload_merge_state *media_state_payload_merge_state_get(
+	struct ast_sip_session_media_state *media_state, int create, size_t initial_capacity)
+{
+	struct media_state_payload_merge_state *state;
+
+	if (!media_state || !media_state_payload_merges) {
+		return NULL;
+	}
+
+	state = ao2_find(media_state_payload_merges, media_state, OBJ_SEARCH_KEY);
+	if (state || !create) {
+		return state;
+	}
+
+	state = ao2_alloc(sizeof(*state), media_state_payload_merge_state_dtor);
+	if (!state) {
+		return NULL;
+	}
+
+	state->media_state = media_state;
+	if (AST_VECTOR_INIT(&state->payload_merge_txns, initial_capacity) < 0) {
+		ao2_ref(state, -1);
+		return NULL;
+	}
+
+	if (!ao2_link(media_state_payload_merges, state)) {
+		ao2_ref(state, -1);
+		return NULL;
+	}
+	return state;
+}
 
 /*!
  * These are the objects in the sdp_handlers container
@@ -241,6 +324,7 @@ static struct ast_sip_session_media_state *internal_sip_session_media_state_allo
 		return NULL;
 	}
 
+
 	return media_state;
 }
 
@@ -287,9 +371,21 @@ void ast_sip_session_media_stats_save(struct ast_sip_session *sip_session, struc
 void ast_sip_session_media_state_reset(struct ast_sip_session_media_state *media_state)
 {
 	int index;
+	RAII_VAR(struct media_state_payload_merge_state *, payload_state, NULL, ao2_cleanup);
 
 	if (!media_state) {
 		return;
+	}
+
+	payload_state = media_state_payload_merge_state_get(media_state, 0, 0);
+	if (payload_state) {
+		while (AST_VECTOR_SIZE(&payload_state->payload_merge_txns)) {
+			struct ast_rtp_codecs_payloads_merge_txn *txn;
+
+			txn = AST_VECTOR_REMOVE_ORDERED(&payload_state->payload_merge_txns,
+				AST_VECTOR_SIZE(&payload_state->payload_merge_txns) - 1);
+			ast_rtp_codecs_payloads_merge_rollback(txn);
+		}
 	}
 
 	AST_VECTOR_RESET(&media_state->sessions, ao2_cleanup);
@@ -301,6 +397,96 @@ void ast_sip_session_media_state_reset(struct ast_sip_session_media_state *media
 
 	ast_stream_topology_free(media_state->topology);
 	media_state->topology = NULL;
+}
+
+int ast_sip_session_media_state_payloads_merge(
+	struct ast_sip_session_media_state *media_state,
+	struct ast_rtp_codecs *src, struct ast_rtp_codecs *dest,
+	struct ast_rtp_instance *instance)
+{
+	RAII_VAR(struct media_state_payload_merge_state *, payload_state, NULL, ao2_cleanup);
+	struct ast_rtp_codecs_payloads_merge_txn *txn;
+	int index;
+
+	payload_state = media_state_payload_merge_state_get(media_state, 1,
+		DEFAULT_NUM_SESSION_MEDIA);
+	if (!payload_state) {
+		return -1;
+	}
+
+	for (index = 0; index < AST_VECTOR_SIZE(&payload_state->payload_merge_txns); ++index) {
+		txn = AST_VECTOR_GET(&payload_state->payload_merge_txns, index);
+		if (ast_rtp_codecs_payloads_merge_matches(txn, dest)) {
+			return ast_rtp_codecs_payloads_merge_update(txn, src);
+		}
+	}
+
+	txn = ast_rtp_codecs_payloads_merge_begin(src, dest, instance);
+	if (!txn) {
+		return -1;
+	}
+	if (AST_VECTOR_APPEND(&payload_state->payload_merge_txns, txn)) {
+		ast_rtp_codecs_payloads_merge_rollback(txn);
+		return -1;
+	}
+
+	return 0;
+}
+
+void ast_sip_session_media_state_payloads_rollback(
+	struct ast_sip_session_media_state *media_state)
+{
+	RAII_VAR(struct media_state_payload_merge_state *, payload_state, NULL, ao2_cleanup);
+
+	payload_state = media_state_payload_merge_state_get(media_state, 0, 0);
+	if (!payload_state) {
+		return;
+	}
+
+	while (AST_VECTOR_SIZE(&payload_state->payload_merge_txns)) {
+		struct ast_rtp_codecs_payloads_merge_txn *txn;
+
+		txn = AST_VECTOR_REMOVE_ORDERED(&payload_state->payload_merge_txns,
+			AST_VECTOR_SIZE(&payload_state->payload_merge_txns) - 1);
+		ast_rtp_codecs_payloads_merge_rollback(txn);
+	}
+}
+
+void ast_sip_session_media_state_payloads_commit_one(
+	struct ast_sip_session_media_state *media_state,
+	struct ast_rtp_codecs *codecs)
+{
+	RAII_VAR(struct media_state_payload_merge_state *, payload_state, NULL, ao2_cleanup);
+	int index;
+
+	payload_state = media_state_payload_merge_state_get(media_state, 0, 0);
+	if (!payload_state) {
+		return;
+	}
+
+	for (index = 0; index < AST_VECTOR_SIZE(&payload_state->payload_merge_txns); ++index) {
+		struct ast_rtp_codecs_payloads_merge_txn *txn;
+
+		txn = AST_VECTOR_GET(&payload_state->payload_merge_txns, index);
+		if (!ast_rtp_codecs_payloads_merge_matches(txn, codecs)) {
+			continue;
+		}
+
+		AST_VECTOR_REMOVE_ORDERED(&payload_state->payload_merge_txns, index);
+		ast_rtp_codecs_payloads_merge_commit(txn);
+		return;
+	}
+}
+
+int ast_sip_session_media_state_payloads_pending(
+	const struct ast_sip_session_media_state *media_state)
+{
+	RAII_VAR(struct media_state_payload_merge_state *, payload_state, NULL, ao2_cleanup);
+
+	payload_state = media_state_payload_merge_state_get(
+		(struct ast_sip_session_media_state *) media_state, 0, 0);
+
+	return payload_state && AST_VECTOR_SIZE(&payload_state->payload_merge_txns);
 }
 
 struct ast_sip_session_media_state *ast_sip_session_media_state_clone(const struct ast_sip_session_media_state *media_state)
@@ -358,6 +544,10 @@ void ast_sip_session_media_state_free(struct ast_sip_session_media_state *media_
 
 	/* This will reset the internal state so we only have to free persistent things */
 	ast_sip_session_media_state_reset(media_state);
+	if (media_state_payload_merges) {
+		ao2_find(media_state_payload_merges, media_state,
+			OBJ_SEARCH_KEY | OBJ_UNLINK | OBJ_NODATA);
+	}
 
 	AST_VECTOR_FREE(&media_state->sessions);
 	AST_VECTOR_FREE(&media_state->read_callbacks);
@@ -1216,6 +1406,12 @@ static int handle_negotiated_sdp(struct ast_sip_session *session, const pjmedia_
 
 	/* Active and pending flip flop as needed */
 	ast_sip_session_media_stats_save(session, session->active_media_state);
+	/*
+	 * set_caps() commits each stream after synchronizing its RTP payloads and
+	 * channel formats. Any transaction still pending here belongs to a stream
+	 * that did not reach that authoritative commit point.
+	 */
+	ast_sip_session_media_state_payloads_rollback(session->pending_media_state);
 	SWAP(session->active_media_state, session->pending_media_state);
 	ast_sip_session_media_state_reset(session->pending_media_state);
 
@@ -4061,6 +4257,7 @@ static int new_invite(struct new_invite *invite)
 	sdp_info = pjsip_rdata_get_sdp_info(invite->rdata);
 	if (sdp_info && (sdp_info->sdp_err == PJ_SUCCESS) && sdp_info->sdp) {
 		if (handle_incoming_sdp(invite->session, sdp_info->sdp)) {
+			ast_sip_session_media_state_reset(invite->session->pending_media_state);
 			tdata = NULL;
 			if (pjsip_inv_end_session(invite->session->inv_session, 488, NULL, &tdata) == PJ_SUCCESS
 				&& tdata) {
@@ -4077,6 +4274,7 @@ static int new_invite(struct new_invite *invite)
 
 	/* If we were unable to create a local SDP terminate the session early, it won't go anywhere */
 	if (!local) {
+		ast_sip_session_media_state_reset(invite->session->pending_media_state);
 		tdata = NULL;
 		if (pjsip_inv_end_session(invite->session->inv_session, 500, NULL, &tdata) == PJ_SUCCESS
 			&& tdata) {
@@ -5000,6 +5198,24 @@ static void session_inv_on_tsx_state_changed(pjsip_inv_session *inv, pjsip_trans
 		session->terminate_on_invite_timeout = 0;
 	}
 
+	if (tsx->method.id == PJSIP_INVITE_METHOD) {
+		if (tsx->role == PJSIP_ROLE_UAS
+			&& tsx->state == PJSIP_TSX_STATE_COMPLETED
+			&& tsx->status_code >= 300
+			&& ast_sip_session_media_state_payloads_pending(session->pending_media_state)) {
+			/*
+			 * A received offer provisionally updates the live RTP mappings
+			 * before its INVITE transaction is complete.  A successful media
+			 * update commits and removes those transactions.  If the UAS
+			 * transaction instead completes with a final failure response
+			 * while they are still present (for example, 487 after CANCEL),
+			 * the session's pending media state must not leak into the
+			 * established dialog.
+			 */
+			ast_sip_session_media_state_reset(session->pending_media_state);
+		}
+	}
+
 	if (AST_LIST_EMPTY(&session->delayed_requests)) {
 		/* No delayed request pending, so just return */
 		SCOPE_EXIT_RTN("Nothing delayed\n");
@@ -5341,6 +5557,7 @@ static void session_inv_on_rx_offer(pjsip_inv_session *inv, const pjmedia_sdp_se
 		pjsip_inv_set_sdp_answer(inv, answer);
 		SCOPE_EXIT_RTN("%s: Set SDP answer\n", ast_sip_session_get_name(session));
 	}
+	ast_sip_session_media_state_reset(session->pending_media_state);
 	SCOPE_EXIT_RTN("%s: create_local_sdp failed\n", ast_sip_session_get_name(session));
 }
 
@@ -6211,6 +6428,14 @@ static int load_module(void)
 	if (!sdp_handlers) {
 		return AST_MODULE_LOAD_DECLINE;
 	}
+	media_state_payload_merges = ao2_container_alloc_hash(AO2_ALLOC_OPT_LOCK_MUTEX, 0,
+		MEDIA_STATE_PAYLOAD_MERGE_BUCKETS, media_state_payload_merge_state_hash, NULL,
+		media_state_payload_merge_state_cmp);
+	if (!media_state_payload_merges) {
+		ao2_cleanup(sdp_handlers);
+		sdp_handlers = NULL;
+		return AST_MODULE_LOAD_DECLINE;
+	}
 	endpt = ast_sip_get_pjsip_endpoint();
 	pjsip_inv_usage_init(endpt, &inv_callback);
 	pjsip_100rel_init_module(endpt);
@@ -6243,6 +6468,8 @@ static int unload_module(void)
 	ast_sorcery_delete(ast_sip_get_sorcery(), nat_hook);
 	ao2_cleanup(nat_hook);
 	ao2_cleanup(sdp_handlers);
+	ao2_cleanup(media_state_payload_merges);
+	media_state_payload_merges = NULL;
 	return 0;
 }
 

--- a/tests/test_res_pjsip_session_caps.c
+++ b/tests/test_res_pjsip_session_caps.c
@@ -42,6 +42,8 @@
 #include "asterisk/format_cap.h"
 #include "asterisk/res_pjsip_session.h"
 #include "asterisk/res_pjsip_session_caps.h"
+#include "asterisk/rtp_engine.h"
+#include "asterisk/format_cache.h"
 
 static enum ast_test_result_state test_create_joint(struct ast_test *test, const char *local_string,
 	const char *remote_string, const char *pref_string, int is_outgoing, const char *expected_string,
@@ -156,14 +158,186 @@ AST_TEST_DEFINE(low_level)
 	return rc >= 1 ? AST_TEST_FAIL : AST_TEST_PASS;
 }
 
+static int payload_merge_test_mapping(struct ast_rtp_codecs *codecs,
+	int payload, const char *subtype)
+{
+	if (ast_rtp_codecs_payloads_set_rtpmap_type(
+			codecs, NULL, payload, "audio", (char *) subtype, 0)) {
+		return -1;
+	}
+	ast_rtp_codecs_payloads_xover(codecs, codecs, NULL);
+	return 0;
+}
+
+static int payload_merge_test_has_rx(struct ast_rtp_codecs *codecs,
+	int payload, struct ast_format *format)
+{
+	RAII_VAR(struct ast_rtp_payload_type *, type,
+		ast_rtp_codecs_get_payload(codecs, payload), ao2_cleanup);
+
+	if (!format) {
+		return !type;
+	}
+	return type && type->asterisk_format
+		&& ast_format_cmp(type->format, format) == AST_FORMAT_CMP_EQUAL;
+}
+
+AST_TEST_DEFINE(payload_merge_pending_state)
+{
+	struct ast_sip_session_media_state *state = NULL;
+	struct ast_rtp_codecs active1 = AST_RTP_CODECS_NULL_INIT;
+	struct ast_rtp_codecs active2 = AST_RTP_CODECS_NULL_INIT;
+	struct ast_rtp_codecs offer1 = AST_RTP_CODECS_NULL_INIT;
+	struct ast_rtp_codecs offer2 = AST_RTP_CODECS_NULL_INIT;
+	enum ast_test_result_state result = AST_TEST_PASS;
+	int active1_initialized = 0;
+	int active2_initialized = 0;
+	int offer1_initialized = 0;
+	int offer2_initialized = 0;
+
+	switch (cmd) {
+	case TEST_INIT:
+		info->name = "pending_state";
+		info->category = "/res/res_pjsip_session/payload_merge/";
+		info->summary = "Test pending media state ownership of RTP payload merge transactions";
+		info->description =
+			"Verifies aggregated rollback for a shared RTP codecs structure and "
+			"commit isolation between separate RTP codecs structures. Also "
+			"verifies the pending marker used to detect abandoned offers.";
+		return AST_TEST_NOT_RUN;
+	case TEST_EXECUTE:
+		break;
+	}
+
+	state = ast_sip_session_media_state_alloc();
+	if (!state) {
+		ast_test_status_update(test, "Unable to initialize pending media transaction test\n");
+		result = AST_TEST_FAIL;
+		goto cleanup;
+	}
+	if (ast_rtp_codecs_payloads_initialize(&active1)) {
+		result = AST_TEST_FAIL;
+		goto cleanup;
+	}
+	active1_initialized = 1;
+	if (ast_rtp_codecs_payloads_initialize(&active2)) {
+		result = AST_TEST_FAIL;
+		goto cleanup;
+	}
+	active2_initialized = 1;
+	if (ast_rtp_codecs_payloads_initialize(&offer1)) {
+		result = AST_TEST_FAIL;
+		goto cleanup;
+	}
+	offer1_initialized = 1;
+	if (ast_rtp_codecs_payloads_initialize(&offer2)) {
+		result = AST_TEST_FAIL;
+		goto cleanup;
+	}
+	offer2_initialized = 1;
+
+	if (payload_merge_test_mapping(&active1, 96, "PCMU")
+		|| payload_merge_test_mapping(&active2, 98, "G722")
+		|| payload_merge_test_mapping(&offer1, 97, "PCMA")
+		|| payload_merge_test_mapping(&offer2, 99, "PCMA")) {
+		ast_test_status_update(test, "Unable to create dynamic RTP mappings\n");
+		result = AST_TEST_FAIL;
+		goto cleanup;
+	}
+
+	/*
+	 * Two provisional updates to the same destination must share the original
+	 * snapshot. Payload-only rollback at media-state activation must restore
+	 * the pre-negotiation state, not the state present between the first and
+	 * second merges.
+	 */
+	if (ast_sip_session_media_state_payloads_merge(
+			state, &offer1, &active1, NULL)
+		|| ast_sip_session_media_state_payloads_merge(
+			state, &offer2, &active1, NULL)) {
+		ast_test_status_update(test, "Unable to add aggregated provisional merges\n");
+		result = AST_TEST_FAIL;
+		goto cleanup;
+	}
+	if (!ast_sip_session_media_state_payloads_pending(state)) {
+		ast_test_status_update(test, "Provisional merges were not marked pending\n");
+		result = AST_TEST_FAIL;
+		goto cleanup;
+	}
+	ast_sip_session_media_state_payloads_rollback(state);
+
+	if (ast_sip_session_media_state_payloads_pending(state)) {
+		ast_test_status_update(test, "Finalization rollback left a merge pending\n");
+		result = AST_TEST_FAIL;
+		goto cleanup;
+	}
+	if (!payload_merge_test_has_rx(&active1, 96, ast_format_ulaw)
+		|| !payload_merge_test_has_rx(&active1, 97, NULL)
+		|| !payload_merge_test_has_rx(&active1, 99, NULL)) {
+		ast_test_status_update(test, "Finalization rollback did not restore the original shared RTP state\n");
+		result = AST_TEST_FAIL;
+		goto cleanup;
+	}
+
+	/*
+	 * Committing one destination must not commit another. Reset retains the
+	 * committed provisional state on active1 and rolls active2 back.
+	 */
+	if (ast_sip_session_media_state_payloads_merge(
+			state, &offer1, &active1, NULL)
+		|| ast_sip_session_media_state_payloads_merge(
+			state, &offer2, &active2, NULL)) {
+		ast_test_status_update(test, "Unable to add isolated provisional merges\n");
+		result = AST_TEST_FAIL;
+		goto cleanup;
+	}
+	ast_sip_session_media_state_payloads_commit_one(state, &active1);
+	if (!ast_sip_session_media_state_payloads_pending(state)) {
+		ast_test_status_update(test, "Commit-one incorrectly cleared another pending merge\n");
+		result = AST_TEST_FAIL;
+		goto cleanup;
+	}
+	ast_sip_session_media_state_reset(state);
+
+	if (ast_sip_session_media_state_payloads_pending(state)) {
+		ast_test_status_update(test, "Reset did not clear the remaining pending merge\n");
+		result = AST_TEST_FAIL;
+		goto cleanup;
+	}
+	if (!payload_merge_test_has_rx(&active1, 97, ast_format_alaw)
+		|| !payload_merge_test_has_rx(&active2, 98, ast_format_g722)
+		|| !payload_merge_test_has_rx(&active2, 99, NULL)) {
+		ast_test_status_update(test, "Commit-one did not isolate pending RTP transactions\n");
+		result = AST_TEST_FAIL;
+	}
+
+cleanup:
+	ast_sip_session_media_state_free(state);
+	if (offer2_initialized) {
+		ast_rtp_codecs_payloads_destroy(&offer2);
+	}
+	if (offer1_initialized) {
+		ast_rtp_codecs_payloads_destroy(&offer1);
+	}
+	if (active2_initialized) {
+		ast_rtp_codecs_payloads_destroy(&active2);
+	}
+	if (active1_initialized) {
+		ast_rtp_codecs_payloads_destroy(&active1);
+	}
+	return result;
+}
+
 static int load_module(void)
 {
 	AST_TEST_REGISTER(low_level);
+	AST_TEST_REGISTER(payload_merge_pending_state);
 	return AST_MODULE_LOAD_SUCCESS;
 }
 
 static int unload_module(void)
 {
+	AST_TEST_UNREGISTER(payload_merge_pending_state);
 	AST_TEST_UNREGISTER(low_level);
 	return 0;
 }

--- a/tests/test_res_rtp.c
+++ b/tests/test_res_rtp.c
@@ -690,8 +690,279 @@ AST_TEST_DEFINE(mes)
 	return AST_TEST_PASS;
 }
 
+AST_TEST_DEFINE(payload_merge_abandoned_offer)
+{
+	struct ast_rtp_codecs offered = AST_RTP_CODECS_NULL_INIT;
+	struct ast_rtp_codecs active = AST_RTP_CODECS_NULL_INIT;
+	struct ast_rtp_payload_type *payload;
+	RAII_VAR(struct ast_format *, preferred, NULL, ao2_cleanup);
+	struct ast_rtp_codecs_payloads_merge_txn *txn = NULL;
+	enum ast_test_result_state result = AST_TEST_PASS;
+	int offered_initialized = 0;
+	int active_initialized = 0;
+
+	switch (cmd) {
+	case TEST_INIT:
+		info->name = "payload_merge_abandoned_offer";
+		info->category = "/res/res_rtp/payload_merge/";
+		info->summary = "Verify an abandoned payload merge is rolled back";
+		info->description =
+			"Verifies that abandoning an SDP offer restores mappings, framing, "
+			"and leaves the preferred format and DTMF metadata present before "
+			"its provisional payload merge unchanged.";
+		return AST_TEST_NOT_RUN;
+	case TEST_EXECUTE:
+		break;
+	}
+
+	if (ast_rtp_codecs_payloads_initialize(&offered)) {
+		ast_test_status_update(test, "Unable to initialize RTP codecs\n");
+		result = AST_TEST_FAIL;
+		goto cleanup;
+	}
+	offered_initialized = 1;
+	if (ast_rtp_codecs_payloads_initialize(&active)) {
+		ast_test_status_update(test, "Unable to initialize RTP codecs\n");
+		result = AST_TEST_FAIL;
+		goto cleanup;
+	}
+	active_initialized = 1;
+
+	/* Use dynamic PTs so lookup cannot fall back to the global static table. */
+	if (ast_rtp_codecs_payloads_set_rtpmap_type(
+			&active, NULL, 96, "audio", "PCMU", 0)
+		|| ast_rtp_codecs_payloads_set_rtpmap_type(
+			&offered, NULL, 97, "audio", "PCMA", 0)) {
+		ast_test_status_update(test, "Unable to create dynamic RTP mappings\n");
+		result = AST_TEST_FAIL;
+		goto cleanup;
+	}
+	ast_rtp_codecs_payloads_xover(&active, &active, NULL);
+	ast_rtp_codecs_payloads_xover(&offered, &offered, NULL);
+	ast_rtp_codecs_set_preferred_format(&active, ast_format_ulaw);
+	ast_rtp_codecs_set_preferred_dtmf_format(&active, 101, 8000);
+	ast_rtp_codecs_set_framing(&active, 20);
+	ast_rtp_codecs_set_preferred_format(&offered, ast_format_alaw);
+	ast_rtp_codecs_set_preferred_dtmf_format(&offered, 110, 16000);
+	ast_rtp_codecs_set_framing(&offered, 30);
+
+	txn = ast_rtp_codecs_payloads_merge_begin(&offered, &active, NULL);
+	if (!txn) {
+		ast_test_status_update(test, "Unable to begin payload merge transaction\n");
+		result = AST_TEST_FAIL;
+		goto cleanup;
+	}
+
+	ast_rtp_codecs_payloads_merge_rollback(txn);
+	txn = NULL;
+
+	payload = ast_rtp_codecs_get_payload(&active, 96);
+	if (!payload || !payload->asterisk_format
+		|| ast_format_cmp(payload->format, ast_format_ulaw) != AST_FORMAT_CMP_EQUAL) {
+		ast_test_status_update(test, "Rollback did not restore active PCMU payload 96\n");
+		result = AST_TEST_FAIL;
+	}
+	ao2_cleanup(payload);
+
+	payload = ast_rtp_codecs_get_payload(&active, 97);
+	if (payload) {
+		ast_test_status_update(test, "Rollback retained provisional PCMA payload 97\n");
+		result = AST_TEST_FAIL;
+	}
+	ao2_cleanup(payload);
+	if (ast_rtp_codecs_get_framing(&active) != 20
+		|| ast_rtp_codecs_get_preferred_dtmf_format_pt(&active) != 101
+		|| ast_rtp_codecs_get_preferred_dtmf_format_rate(&active) != 8000) {
+		ast_test_status_update(test, "Rollback did not restore active RTP metadata\n");
+		result = AST_TEST_FAIL;
+	}
+	preferred = ast_rtp_codecs_get_preferred_format(&active);
+	if (!preferred
+		|| ast_format_cmp(preferred, ast_format_ulaw) != AST_FORMAT_CMP_EQUAL) {
+		ast_test_status_update(test, "Rollback did not restore preferred format\n");
+		result = AST_TEST_FAIL;
+	}
+
+cleanup:
+	ast_rtp_codecs_payloads_merge_commit(txn);
+	if (active_initialized) {
+		ast_rtp_codecs_payloads_destroy(&active);
+	}
+	if (offered_initialized) {
+		ast_rtp_codecs_payloads_destroy(&offered);
+	}
+	return result;
+}
+
+AST_TEST_DEFINE(payload_merge_commit)
+{
+	struct ast_rtp_codecs offered = AST_RTP_CODECS_NULL_INIT;
+	struct ast_rtp_codecs active = AST_RTP_CODECS_NULL_INIT;
+	struct ast_rtp_codecs_payloads_merge_txn *txn = NULL;
+	enum ast_test_result_state result = AST_TEST_PASS;
+	int offered_initialized = 0;
+	int active_initialized = 0;
+
+	switch (cmd) {
+	case TEST_INIT:
+		info->name = "payload_merge_commit";
+		info->category = "/res/res_rtp/payload_merge/";
+		info->summary = "Verify a committed payload merge retains negotiated state";
+		info->description =
+			"Verifies that committing a provisional merge releases rollback "
+			"state without changing the final negotiated payloads and framing.";
+		return AST_TEST_NOT_RUN;
+	case TEST_EXECUTE:
+		break;
+	}
+
+	if (ast_rtp_codecs_payloads_initialize(&offered)) {
+		ast_test_status_update(test, "Unable to initialize offered RTP codecs\n");
+		result = AST_TEST_FAIL;
+		goto cleanup;
+	}
+	offered_initialized = 1;
+	if (ast_rtp_codecs_payloads_initialize(&active)) {
+		ast_test_status_update(test, "Unable to initialize active RTP codecs\n");
+		result = AST_TEST_FAIL;
+		goto cleanup;
+	}
+	active_initialized = 1;
+
+	if (ast_rtp_codecs_payloads_set_rtpmap_type(
+			&active, NULL, 96, "audio", "PCMU", 0)
+		|| ast_rtp_codecs_payloads_set_rtpmap_type(
+			&offered, NULL, 97, "audio", "PCMA", 0)) {
+		ast_test_status_update(test, "Unable to create dynamic RTP mappings\n");
+		result = AST_TEST_FAIL;
+		goto cleanup;
+	}
+	ast_rtp_codecs_payloads_xover(&active, &active, NULL);
+	ast_rtp_codecs_payloads_xover(&offered, &offered, NULL);
+	ast_rtp_codecs_set_framing(&active, 20);
+	ast_rtp_codecs_set_framing(&offered, 30);
+
+	txn = ast_rtp_codecs_payloads_merge_begin(&offered, &active, NULL);
+	if (!txn) {
+		ast_test_status_update(test, "Unable to begin payload merge transaction\n");
+		result = AST_TEST_FAIL;
+		goto cleanup;
+	}
+	ast_rtp_codecs_payloads_copy(&offered, &active, NULL);
+	ast_rtp_codecs_payloads_merge_commit(txn);
+	txn = NULL;
+
+	if (ast_rtp_codecs_payload_code_tx(&active, 1, ast_format_ulaw, 0) != -1) {
+		ast_test_status_update(test, "Commit retained obsolete PCMU TX mapping\n");
+		result = AST_TEST_FAIL;
+	}
+	if (ast_rtp_codecs_payload_code_tx(&active, 1, ast_format_alaw, 0) != 97) {
+		ast_test_status_update(test, "Commit did not retain negotiated PCMA TX payload 97\n");
+		result = AST_TEST_FAIL;
+	}
+	if (ast_rtp_codecs_get_framing(&active) != 30) {
+		ast_test_status_update(test, "Commit did not retain negotiated framing\n");
+		result = AST_TEST_FAIL;
+	}
+
+cleanup:
+	ast_rtp_codecs_payloads_merge_commit(txn);
+	if (active_initialized) {
+		ast_rtp_codecs_payloads_destroy(&active);
+	}
+	if (offered_initialized) {
+		ast_rtp_codecs_payloads_destroy(&offered);
+	}
+	return result;
+}
+
+AST_TEST_DEFINE(payload_merge_preserves_preferences)
+{
+	struct ast_rtp_codecs offered = AST_RTP_CODECS_NULL_INIT;
+	struct ast_rtp_codecs active = AST_RTP_CODECS_NULL_INIT;
+	struct ast_rtp_codecs_payloads_merge_txn *txn = NULL;
+	RAII_VAR(struct ast_format *, preferred, NULL, ao2_cleanup);
+	enum ast_test_result_state result = AST_TEST_PASS;
+	int offered_initialized = 0;
+	int active_initialized = 0;
+
+	switch (cmd) {
+	case TEST_INIT:
+		info->name = "payload_merge_preserves_preferences";
+		info->category = "/res/res_rtp/payload_merge/";
+		info->summary = "Verify a payload merge preserves active preferences";
+		info->description =
+			"Verifies that merging an SDP offer's provisional payload mappings "
+			"updates framing needed to generate the SDP answer without changing "
+			"the active preferred format or preferred DTMF metadata before the "
+			"offer is committed.";
+		return AST_TEST_NOT_RUN;
+	case TEST_EXECUTE:
+		break;
+	}
+
+	if (ast_rtp_codecs_payloads_initialize(&offered)) {
+		ast_test_status_update(test, "Unable to initialize RTP codecs\n");
+		result = AST_TEST_FAIL;
+		goto cleanup;
+	}
+	offered_initialized = 1;
+	if (ast_rtp_codecs_payloads_initialize(&active)) {
+		ast_test_status_update(test, "Unable to initialize RTP codecs\n");
+		result = AST_TEST_FAIL;
+		goto cleanup;
+	}
+	active_initialized = 1;
+
+	ast_rtp_codecs_set_preferred_format(&active, ast_format_ulaw);
+	ast_rtp_codecs_set_preferred_dtmf_format(&active, 101, 8000);
+	ast_rtp_codecs_set_framing(&active, 20);
+	ast_rtp_codecs_set_preferred_format(&offered, ast_format_alaw);
+	ast_rtp_codecs_set_preferred_dtmf_format(&offered, 110, 16000);
+	ast_rtp_codecs_set_framing(&offered, 30);
+
+	txn = ast_rtp_codecs_payloads_merge_begin(&offered, &active, NULL);
+	if (!txn) {
+		ast_test_status_update(test, "Unable to begin payload merge transaction\n");
+		result = AST_TEST_FAIL;
+		goto cleanup;
+	}
+	ast_rtp_codecs_payloads_merge_commit(txn);
+	txn = NULL;
+
+	preferred = ast_rtp_codecs_get_preferred_format(&active);
+	if (!preferred
+		|| ast_format_cmp(preferred, ast_format_ulaw) != AST_FORMAT_CMP_EQUAL) {
+		ast_test_status_update(test, "Payload merge changed the active preferred format\n");
+		result = AST_TEST_FAIL;
+	}
+	if (ast_rtp_codecs_get_preferred_dtmf_format_pt(&active) != 101
+		|| ast_rtp_codecs_get_preferred_dtmf_format_rate(&active) != 8000) {
+		ast_test_status_update(test,
+			"Payload merge changed the active preferred DTMF metadata\n");
+		result = AST_TEST_FAIL;
+	}
+	if (ast_rtp_codecs_get_framing(&active) != 30) {
+		ast_test_status_update(test, "Payload merge did not update offered framing\n");
+		result = AST_TEST_FAIL;
+	}
+
+cleanup:
+	ast_rtp_codecs_payloads_merge_commit(txn);
+	if (active_initialized) {
+		ast_rtp_codecs_payloads_destroy(&active);
+	}
+	if (offered_initialized) {
+		ast_rtp_codecs_payloads_destroy(&offered);
+	}
+	return result;
+}
+
 static int unload_module(void)
 {
+	AST_TEST_UNREGISTER(payload_merge_preserves_preferences);
+	AST_TEST_UNREGISTER(payload_merge_commit);
+	AST_TEST_UNREGISTER(payload_merge_abandoned_offer);
 	AST_TEST_UNREGISTER(mes);
 	AST_TEST_UNREGISTER(nack_no_packet_loss);
 	AST_TEST_UNREGISTER(nack_nominal);
@@ -705,6 +976,9 @@ static int unload_module(void)
 
 static int load_module(void)
 {
+	AST_TEST_REGISTER(payload_merge_abandoned_offer);
+	AST_TEST_REGISTER(payload_merge_commit);
+	AST_TEST_REGISTER(payload_merge_preserves_preferences);
 	AST_TEST_REGISTER(nack_no_packet_loss);
 	AST_TEST_REGISTER(nack_nominal);
 	AST_TEST_REGISTER(nack_overflow);


### PR DESCRIPTION
A reINVITE that changed the offered codec set (e.g. ulaw+alaw -> alaw
only) could lead to call teardown when a bridge write still using the
old format occurred during the re-negotiation.

This change avoids the termination by making the following changes.

First, Asterisk now holds the lock across both the tx payload update
and the channel format update so they commit atomically.

Second, when processing the sdp on the new incoming offer, merge the
new offer with the old until the negotiation is complete. Only replace
the sdp if and when the negotion completes. Roll back if it fails.

Also Adds unit tests for the merge/rollback/commit semantics and pending
media-state transaction ownership.

Fixes: #2059
