### PR TITLE
backtrace.c: Include stdbool.h

### DIFF
--- a/main/backtrace.c
+++ b/main/backtrace.c
@@ -72,6 +72,8 @@
 
 #include <pthread.h>
 
+#include <stdbool.h>
+
 /* simple definition of S_OR so we don't have include strings.h */
 #define S_OR(a, b) (a && a[0] != '\0') ? a : b
 


### PR DESCRIPTION
stdbool.h is needed now that we use the bool type directly
instead of bfd_boolean. See also 1d95b744c06974f0a00c143c6e0fc979af930908.

Resolves: #2061
