### PR TITLE
app_voicemail.c: Guard VM_INFO email against a NULL vmu->email

### DIFF
--- a/apps/app_voicemail.c
+++ b/apps/app_voicemail.c
@@ -13658,7 +13658,7 @@ static int acf_vm_info(struct ast_channel *chan, const char *cmd, char *args, ch
 		} else if (!strncasecmp(arg.attribute, "fullname", 8)) {
 			ast_copy_string(buf, vmu->fullname, len);
 		} else if (!strncasecmp(arg.attribute, "email", 5)) {
-			ast_copy_string(buf, vmu->email, len);
+			ast_copy_string(buf, S_OR(vmu->email, ""), len);
 		} else if (!strncasecmp(arg.attribute, "pager", 5)) {
 			ast_copy_string(buf, vmu->pager, len);
 		} else if (!strncasecmp(arg.attribute, "language", 8)) {
@@ -16130,6 +16130,22 @@ AST_TEST_DEFINE(test_voicemail_vm_info)
 			ast_test_status_update(test, "VM_INFO return code was: '%i', but expected '%i'\n", test_ret, test_items[test_counter].vminfo_ret);
 			res = AST_TEST_FAIL;
 		}
+	}
+
+	/* A valid mailbox with no configured email must return an empty string,
+	 * not dereference a NULL vmu->email (issue #2063). The cases above all run
+	 * with vmu->email set, so clear it and re-check. */
+	ast_free(vmu->email);
+	vmu->email = NULL;
+	ast_copy_string(vminfo_args, "00000000@test,email", sizeof(vminfo_args));
+	test_ret = acf_vm_info(chan, vminfo_cmd, vminfo_args, vminfo_buf, sizeof(vminfo_buf));
+	if (strcmp(vminfo_buf, "")) {
+		ast_test_status_update(test, "VM_INFO email for a mailbox with no email was: '%s', but expected empty\n", vminfo_buf);
+		res = AST_TEST_FAIL;
+	}
+	if (test_ret != 0) {
+		ast_test_status_update(test, "VM_INFO email return code was: '%i', but expected '0'\n", test_ret);
+		res = AST_TEST_FAIL;
 	}
 
 	chan = ast_channel_unref(chan);


### PR DESCRIPTION
VM_INFO with the "email" attribute copied vmu->email unconditionally.
For a valid mailbox that has no email configured, vmu->email is NULL
(populate_defaults() frees and NULLs it), so ast_copy_string()
dereferenced NULL and segfaulted.

Guard the copy with S_OR(vmu->email, ""), matching the idiom already
used for the "language" attribute two lines below, and extend the
VM_INFO unit test with a mailbox that has no email configured.

Resolves: #2063
