### PR TITLE
alembic: Preserve sub-second precision in the queue_log time column.

### DIFF
--- a/contrib/ast-db-manage/queue_log/versions/8e6a9c2f4b17_increase_queue_log_time_precision.py
+++ b/contrib/ast-db-manage/queue_log/versions/8e6a9c2f4b17_increase_queue_log_time_precision.py
@@ -1,0 +1,38 @@
+"""increase queue_log time precision
+
+Revision ID: 8e6a9c2f4b17
+Revises: 4105ee839f58
+Create Date: 2026-08-03 00:00:00.000000
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "8e6a9c2f4b17"
+down_revision = "4105ee839f58"
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.mysql import DATETIME as MYSQL_DATETIME
+
+
+def upgrade():
+    # MariaDB is reported as the 'mysql' dialect, so this covers both.
+    if op.get_context().bind.dialect.name == "mysql":
+        op.alter_column(
+            "queue_log",
+            "time",
+            existing_type=sa.DateTime(),
+            type_=MYSQL_DATETIME(fsp=6),
+            existing_nullable=True,
+        )
+
+
+def downgrade():
+    if op.get_context().bind.dialect.name == "mysql":
+        op.alter_column(
+            "queue_log",
+            "time",
+            existing_type=MYSQL_DATETIME(fsp=6),
+            type_=sa.DateTime(),
+            existing_nullable=True,
+        )


### PR DESCRIPTION
ast_queue_log() formats realtime queue_log timestamps with microseconds
("%F %T.%6q" in main/logger.c), but the queue_log table declares 'time' as
a generic SQLAlchemy DateTime.  That renders on MySQL and MariaDB as bare
DATETIME, which has a fractional-seconds precision of 0, so MariaDB
truncates the fraction and MySQL rounds it.  Every event of a single queue
entry can collapse onto one second, or move to the next one, and neither
server warns, not even in strict mode.

Once that happens, queue_log rows can no longer be ordered against each
other, or against the CEL records that cel_odbc and cel_pgsql do stamp
with microseconds.

This adds a revision that widens the queue_log column to DATETIME(6) on
MySQL and MariaDB.  PostgreSQL is unaffected and left untouched: DateTime
already renders as TIMESTAMP, which keeps microseconds by default.

Fixes: #2072

UpgradeNote: (schema) On MySQL and MariaDB the queue_log 'time' column is widened
from DATETIME to DATETIME(6) so that the microsecond timestamps Asterisk
already writes are stored rather than discarded. This ALTER rewrites the
table, a datetime precision change is neither INSTANT nor INPLACE, so
queue_log writes will block for its duration on a large table. PostgreSQL
installations are unaffected. Rows already written at whole-second precision will remain as-is and won't be updated.