### PR TITLE
res_pjsip_config_wizard: Fix documentation errors.

### DIFF
--- a/configs/samples/pjsip_wizard.conf.sample
+++ b/configs/samples/pjsip_wizard.conf.sample
@@ -72,12 +72,12 @@
 ;  SYNOPSIS: Provides configuration wizard for common scenarios.
 ;sends_auth=    ; Will create an outbound auth object for the endpoint and
                 ; registration.
-                ; If yes, outbound/username must be specified.
-                ; (default = "no")
+                ; If yes, outbound_auth/username must be specified.
+                ; (default: "no")
 
 ;accepts_auth=  ; Will create an inbound auth object for the endpoint.
-                ; If yes, inbound/username must be specified.
-                ; (default = "no")
+                ; If yes, inbound_auth/username must be specified.
+                ; (default: "no")
 
 ;sends_registrations=    ; Will create an outbound registration object and an
                          ; identify match for each host in remote_hosts (which
@@ -102,7 +102,7 @@
                  ; If specified, a static contact for each host will be created
                  ; in the aor.  If accepts_registrations is no, an identify
                  ; object is also created with a match line for each remote host.
-                 ; If an aor/contact or match/identify is explicitly supplied,
+                 ; If an aor/contact or identify/match is explicitly supplied,
                  ; remote_hosts will not be used to automatically create contacts
                  ; or matches respectively.
                  ; (default: "")
@@ -116,7 +116,7 @@
                  ; (default: the pjsip default)
 
 ;server_uri_pattern= ; The pattern used to construct the registration
-                     ; server_uri. The replaceable parameter ${REMOTE_HOST} isa
+                     ; server_uri. The replaceable parameter ${REMOTE_HOST} is
                      ; available for use.
                      ; (default: "sip:${REMOTE_HOST}")
 
@@ -143,14 +143,14 @@
 
 ;hint_exten          ; If specified, a PJSIP/<wizard_id> hint will be created
                      ; for this extension in 'hint_context'.
-                     ; context.
                      ; (default: none)
 
 ;hint_application    ; If specified, an extension will be placed in 'hint_context'
                      ; at priority 1 that calls this application.  Could be any
                      ; valid dialplan expression like
                      ; "Gosub(stdexten,${EXTEN},1(${HINT}))"
-                     ; (default: "Dial(${HINT})")
+                     ; If not specified, no priority 1 extension is created.
+                     ; (default: none)
 
 ;endpoint/<param>      ; Any parameters to be passed directly to and validated
 ;aor/<param>           ; by their respective objects.

--- a/res/res_pjsip_config_wizard.c
+++ b/res/res_pjsip_config_wizard.c
@@ -137,7 +137,7 @@
 					<description><para>A comma-separated list of remote hosts in the form of
 					<replaceable>host</replaceable>[:<replaceable>port</replaceable>].
 					If set, an aor static contact and an identify match will be created for each
-					entry in the list.  If send_registrations is also set, a registration will
+					entry in the list.  If sends_registrations is also set, a registration will
 					also be created for each.</para></description>
 				</configOption>
 				<configOption name="outbound_proxy">
@@ -157,11 +157,11 @@
 				<configOption name="sends_registrations" default="no">
 					<synopsis>Send outbound registrations to remote hosts.</synopsis>
 					<description><para>remote_hosts is required and a registration object will
-					be created for each host in the remote _hosts string.  If authentication is required,
+					be created for each host in the remote_hosts string.  If authentication is required,
 					sends_auth and an outbound_auth/username must also be supplied.</para></description>
 				</configOption>
 				<configOption name="sends_line_with_registrations" default="no">
-					<synopsis>Sets "line" and "endpoint parameters on registrations.</synopsis>
+					<synopsis>Sets "line" and "endpoint" parameters on registrations.</synopsis>
 					<description><para>Setting this to true will cause the wizard to skip the
 					creation of an identify object to match incoming requests to the endpoint and
 					instead add the line and endpoint parameters to the outbound registration object.
@@ -170,7 +170,7 @@
 				<configOption name="accepts_registrations" default="no">
 					<synopsis>Accept inbound registration from remote hosts.</synopsis>
 					<description><para>An AOR with dynamic contacts will be created.  If
-					the number of contacts nneds to be limited, set aor/max_contacts.</para></description>
+					the number of contacts needs to be limited, set aor/max_contacts.</para></description>
 				</configOption>
 				<configOption name="has_phoneprov" default="no">
 					<synopsis>Create a phoneprov object for this endpoint.</synopsis>
@@ -1183,7 +1183,7 @@ static void object_type_registered_observer(const char *name,
 		if (ast_sorcery_object_type_apply_wizard(sorcery, object_type,
 			"memory", "pjsip_wizard", AST_SORCERY_WIZARD_APPLY_READONLY | AST_SORCERY_WIZARD_APPLY_ALLOW_DUPLICATE,
 			&wizard, &wizard_data) != AST_SORCERY_APPLY_SUCCESS) {
-			ast_log(LOG_ERROR, "Unable to apply sangoma wizard to object type '%s'\n", object_type);
+			ast_log(LOG_ERROR, "Unable to apply pjsip_wizard to object type '%s'\n", object_type);
 			return;
 		}
 
@@ -1245,7 +1245,7 @@ static char *handle_export_primitives(struct ast_cli_entry *e, int cmd, struct a
 	case CLI_INIT:
 		e->command = "pjsip export config_wizard primitives [to]";
 		e->usage =
-			"Usage: pjsip export config_wizard primitives [ to <filename ]\n"
+			"Usage: pjsip export config_wizard primitives [ to <filename> ]\n"
 			"       Export the config_wizard objects as pjsip primitives to\n"
 			"       the console or to <filename>\n";
 		return NULL;


### PR DESCRIPTION
The sample configuration and the module's XML documentation contained
several errors, two of which actively misled users:

* The sample said that sends_auth and accepts_auth require
  "outbound/username" and "inbound/username".  The wizard looks for
  "outbound_auth/username" and "inbound_auth/username", so a
  configuration written by following the sample fails to load with
  "Wizard 'xxx' must have 'outbound_auth/username' if it sends
  authentication."

* The sample claimed that hint_application defaults to "Dial(${HINT})".
  There is no such default.  When hint_application is not specified the
  wizard removes the priority 1 extension it manages rather than
  creating one.

The remaining corrections are a reversed object/field reference
(match/identify), a leftover line in the hint_exten description, an
option name (send_registrations), a stray space (remote _hosts), an
unbalanced quote in a synopsis, a misspelling (nneds), an unbalanced
bracket in the CLI usage text, and a copy/paste error in a log message
that referred to the "sangoma wizard" instead of pjsip_wizard.  Two
"(default = ...)" annotations became "(default: ...)" to match the
other fourteen in the same file.

No functional change.

UserNote: The pjsip_wizard.conf sample documented the wrong option
names for sends_auth and accepts_auth, and claimed a default for
hint_application that does not exist.  Configurations written by
following the sample would have failed to load.
