### PR TITLE
res_stasis_recording: Allow recording a channel that is dialing via ARI

### DIFF
--- a/res/res_stasis_recording.c
+++ b/res/res_stasis_recording.c
@@ -34,6 +34,7 @@
 #include "asterisk/file.h"
 #include "asterisk/module.h"
 #include "asterisk/paths.h"
+#include "asterisk/bridge.h"
 #include "asterisk/stasis_app_impl.h"
 #include "asterisk/stasis_app_recording.h"
 #include "asterisk/stasis_channels.h"
@@ -297,12 +298,24 @@ static int record_file(struct stasis_app_control *control,
 	struct ast_channel *chan, void *data)
 {
 	struct stasis_app_recording *recording = data;
+	struct ast_bridge *bridge;
 	char *acceptdtmf;
 	int res;
 
 	ast_assert(recording != NULL);
 
-	if (stasis_app_get_bridge(control)) {
+	/*
+	 * Recording is not allowed while the channel is in a "real" bridge,
+	 * but ARI places an originated channel into an internal, invisible
+	 * holding bridge (the dial bridge) while dialing. That bridge is not
+	 * a bridge the application created - it is flagged invisible - so
+	 * recording must still be permitted there. Otherwise, channels.record
+	 * fails with "Cannot record channel while in bridge" even though the
+	 * application never joined the channel to a bridge of its own.
+	 * See GH issue #2044.
+	 */
+	bridge = stasis_app_get_bridge(control);
+	if (bridge && !ast_test_flag(&bridge->feature_flags, AST_BRIDGE_FLAG_INVISIBLE)) {
 		ast_log(LOG_ERROR, "Cannot record channel while in bridge\n");
 		recording_fail(control, recording, "Cannot record channel while in bridge");
 		return -1;


### PR DESCRIPTION
When an ARI application dials a channel with channels.dial, the channel
is placed into an internal, invisible holding bridge (the dial bridge)
while dialing. record_file() rejected recording for any channel that was
in a bridge, so channels.record failed with "Cannot record channel while
in bridge" even though the application never joined the channel to a
bridge of its own.

Narrow the check so it only rejects recording when the channel is in a
bridge that is NOT flagged invisible. The internal dial bridge is flagged
AST_BRIDGE_FLAG_INVISIBLE (it is created by ARI internally, not by the
application), so recording is still permitted there. A "real" bridge
created by the application - including a user-created ARI holding bridge
- is not invisible, so recording stays rejected. This keeps the fix
targeted at the internal dial bridge only, rather than allowing recording
in every holding bridge.

Resolves: #2044