### PR TITLE
chore: update .gitignore for clangd LSP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ tests/CI/output
 .develvars
 .devcontainer/
 .claude/
+.cache/
+compile_commands.json


### PR DESCRIPTION
Ignore clangd auto‑generated artifacts:
1. compile_commands.json: compile database exported by CMake/Bear
2. .cache/: local project index & AST cache directory