### PR TITLE
res_audiosocket: Bound idle poll retries while reading header

### DIFF
--- a/res/res_audiosocket.c
+++ b/res/res_audiosocket.c
@@ -44,6 +44,9 @@
 
 #define MAX_CONNECT_TIMEOUT_MSEC 2000
 
+/*! \brief Maximum consecutive idle polls tolerated before a header read yields. */
+#define IDLE_POLL_MAX 4
+
 /*!
  * \internal
  * \brief Attempt to complete the audiosocket connection.
@@ -288,6 +291,7 @@ struct ast_frame *ast_audiosocket_receive_frame_with_hangup(const int svc,
 	int *const hangup)
 {
 	int i = 0, n = 0, ret = 0;
+	unsigned int idle_polls = 0;
 	struct ast_frame f = {
 		.frametype = AST_FRAME_VOICE,
 		.src = "AudioSocket",
@@ -312,6 +316,9 @@ struct ast_frame *ast_audiosocket_receive_frame_with_hangup(const int svc,
 					continue;
 				} else if (poll_result == 0) {
 					ast_debug(1, "Poll timed out while waiting for header data\n");
+					if (i == 0 && ++idle_polls > IDLE_POLL_MAX) {
+						return &ast_null_frame;
+					}
 					continue;
 				} else {
 					ast_log(LOG_WARNING, "Poll error: %s\n", strerror(errno));
@@ -324,6 +331,7 @@ struct ast_frame *ast_audiosocket_receive_frame_with_hangup(const int svc,
 		if (n == 0) {
 			break;
 		}
+		idle_polls = 0;
 		i += n;
 	}
 


### PR DESCRIPTION
ast_audiosocket_receive_frame_with_hangup() reads a 3-byte AudioSocket
frame header before it reads the payload. When read() returns EAGAIN
and no header bytes have been consumed yet (i == 0), a poll timeout
on ast_wait_for_input() falls through to a bare continue, with no
limit on how many times that may happen.

The AudioSocket channel and application both service a connection
from a single dedicated thread that does both the read and the write
side. While that thread is spinning in this loop it never returns to
drain its outbound write queue, so an idle peer that keeps the TCP
connection open without sending further data can starve the channel's
outbound audio indefinitely, even though nothing is actually wrong
with the connection.

Bound the retry, but only while i == 0. In that state no header bytes
have been consumed from the socket, so giving up and returning is
lossless: the caller can simply try again on its own schedule. Once
i > 0 a partial header is already in hand, so that path is left to
retry unconditionally as before, since discarding it would
desynchronize the stream. The idle counter resets on any real read
progress.

After IDLE_POLL_MAX (4, roughly 20ms of polling) consecutive idle
polls at i == 0, the function now returns &ast_null_frame instead of
continuing to loop. Both existing callers of this function already
tolerate that return value: apps/app_audiosocket.c passes it straight
to ast_write(), and channels/chan_audiosocket.c returns it from its
.read channel tech callback. AST_FRAME_NULL is an existing, explicitly
handled no-op frame type in both ast_write() and __ast_read() in
main/channel.c, and &ast_null_frame is already the established idiom
elsewhere in the tree for exactly this "nothing to deliver this cycle"
case.

The payload read loop later in the same function is intentionally
left unchanged: it already treats a single poll timeout as fatal, so
it has no equivalent unbounded-retry condition to fix.

UserNote: An idle AudioSocket peer (one that stops sending data
mid-call without closing the connection) can no longer prevent the
channel from delivering outbound audio to the far end.

UpgradeNote: ast_audiosocket_receive_frame_with_hangup() may now
return &ast_null_frame after a short bounded idle period instead of
continuing to block. Out-of-tree callers of this public API should
handle an AST_FRAME_NULL return the same way apps/app_audiosocket.c
and channels/chan_audiosocket.c do, rather than assuming every
non-NULL return carries audio data.

Fixes: #2089

