### PR TITLE
chore: update .gitignore for clangd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,8 @@ tests/CI/output
 .develvars
 .devcontainer/
 .claude/
+.clangd
+.clang-format
+.clang-tidy
+compile_commands.json
+.cache/


### PR DESCRIPTION
Ignore clangd generated artifacts: compile_commands.json, .cache

Ignores for .clangd, .clang-format, .clang-tidy tooling files