### PR TITLE
res_geolocation: Load when explicitly configured in sorcery.conf

### DIFF
--- a/res/res_geolocation/geoloc_config.c
+++ b/res/res_geolocation/geoloc_config.c
@@ -672,7 +672,7 @@ int geoloc_config_load(void)
 
 	ast_sorcery_apply_config(geoloc_sorcery, "location");
 	result = ast_sorcery_apply_default(geoloc_sorcery, "location", "config", "geolocation.conf,criteria=type=location");
-	if (result != AST_SORCERY_APPLY_SUCCESS) {
+	if (result == AST_SORCERY_APPLY_FAIL) {
 		ast_log(LOG_ERROR, "Failed to apply defaults for geoloc location object with sorcery\n");
 		return AST_MODULE_LOAD_DECLINE;
 	}


### PR DESCRIPTION
If you've explicitly configured your configuration objects in sorcery.conf, it is normal for `ast_sorcery_apply_default` to return something other than
`AST_SORCERY_APPLY_SUCCESS` (e.g. `AST_SORCERY_APPLY_DEFAULT_UNNECESSARY`).

This is one of the few places (outside of unit tests) that we actual pay attention to the return value of `ast_sorcery_apply_default` at all.