### PR TITLE
res_prometheus: add toggle config for channels metrics

### DIFF
--- a/configs/samples/prometheus.conf.sample
+++ b/configs/samples/prometheus.conf.sample
@@ -43,6 +43,9 @@ core_metrics_enabled = yes        ; Enable/disable core metrics. Core metrics
                                   ; version of Asterisk, uptime, last reload
                                   ; time, and the overall time it takes to
                                   ; scrape metrics. Default is "yes"
+channels_detail_metrics_enabled = yes
+                                  ; Enable/disable channels_detail. channels_detail
+                                  ; include channels state and channels duration. Default is "yes"
 uri = metrics                     ; The HTTP route to expose metrics on.
                                   ; Default is "metrics".
 

--- a/include/asterisk/res_prometheus.h
+++ b/include/asterisk/res_prometheus.h
@@ -70,6 +70,8 @@ struct prometheus_general_config {
 	unsigned int enabled;
 	/*! \brief Whether or not core metrics are enabled */
 	unsigned int core_metrics_enabled;
+	/*! \brief Whether or not channel detail metrics are enabled */
+	unsigned int channels_detail_metrics_enabled;
 	AST_DECLARE_STRING_FIELDS(
 		/*! \brief The HTTP URI we register ourselves to */
 		AST_STRING_FIELD(uri);

--- a/res/prometheus/channels.c
+++ b/res/prometheus/channels.c
@@ -26,9 +26,11 @@
  */
 
 #include "asterisk.h"
+#include "asterisk/astobj2.h"
 #include "asterisk/res_prometheus.h"
 #include "asterisk/stasis_channels.h"
 #include "asterisk/pbx.h"
+#include "asterisk/utils.h"
 #include "prometheus_internal.h"
 
 #define CHANNELS_STATE_HELP "Individual channel states. 0=down; 1=reserved; 2=offhook; 3=dialing; 4=ring; 5=ringing; 6=up; 7=busy; 8=dialing_offhook; 9=prering."
@@ -129,6 +131,8 @@ static struct prometheus_metric global_channel_metrics[] = {
  */
 static void channels_scrape_cb(struct ast_str **response)
 {
+	RAII_VAR(struct prometheus_general_config *, config, prometheus_general_config_get(), ao2_cleanup);
+
 	struct ao2_container *channel_cache;
 	struct ao2_container *channels;
 	struct ao2_iterator it_chans;
@@ -175,6 +179,12 @@ static void channels_scrape_cb(struct ast_str **response)
 		ao2_ref(channels, -1);
 		return;
 	}
+
+	if (!config || config->channels_detail_metrics_enabled == 0) {
+		ao2_ref(channels, -1);
+		return;
+	}
+	
 
 	/* Channel dependent values */
 	channel_metrics = ast_calloc(ARRAY_LEN(channel_metric_defs) * num_channels, sizeof(*channel_metrics));

--- a/res/res_prometheus.c
+++ b/res/res_prometheus.c
@@ -991,6 +991,7 @@ static int load_module(void)
 	}
 	aco_option_register(&cfg_info, "enabled", ACO_EXACT, global_options, "no", OPT_BOOL_T, 1, FLDSET(struct prometheus_general_config, enabled));
 	aco_option_register(&cfg_info, "core_metrics_enabled", ACO_EXACT, global_options, "yes", OPT_BOOL_T, 1, FLDSET(struct prometheus_general_config, core_metrics_enabled));
+	aco_option_register(&cfg_info, "channels_detail_metrics_enabled", ACO_EXACT, global_options, "yes", OPT_BOOL_T, 1, FLDSET(struct prometheus_general_config, channels_detail_metrics_enabled));
 	aco_option_register(&cfg_info, "uri", ACO_EXACT, global_options, "", OPT_STRINGFIELD_T, 1, STRFLDSET(struct prometheus_general_config, uri));
 	aco_option_register(&cfg_info, "auth_username", ACO_EXACT, global_options, "", OPT_STRINGFIELD_T, 0, STRFLDSET(struct prometheus_general_config, auth_username));
 	aco_option_register(&cfg_info, "auth_password", ACO_EXACT, global_options, "", OPT_STRINGFIELD_T, 0, STRFLDSET(struct prometheus_general_config, auth_password));


### PR DESCRIPTION
In high‑volume call scenarios, Prometheus exposes a large number of channels‑related metrics.

Not all users require channels_state and channels_duration.

Add configuration options to enable or disable these two metrics.

UserNote: "channels_detail_metrics_enabled" defaults to "yes" for backward‑compatibility.
Set it to "no" if you do not need channels detail metrics (channels_state and channels_duration). 