### PR TITLE
res_geolocation: Don't crash on invalid sorcery configuration

### DIFF
--- a/res/res_geolocation/geoloc_config.c
+++ b/res/res_geolocation/geoloc_config.c
@@ -611,13 +611,12 @@ int geoloc_config_unload(void)
 {
 	ast_cli_unregister_multiple(geoloc_location_cli_commands, ARRAY_LEN(geoloc_location_cli_commands));
 
-	ast_sorcery_object_unregister(geoloc_sorcery, "profile");
-	ast_sorcery_object_unregister(geoloc_sorcery, "location");
-
 	if (geoloc_sorcery) {
+		ast_sorcery_object_unregister(geoloc_sorcery, "profile");
+		ast_sorcery_object_unregister(geoloc_sorcery, "location");
 		ast_sorcery_unref(geoloc_sorcery);
+		geoloc_sorcery = NULL;
 	}
-	geoloc_sorcery = NULL;
 
 	return 0;
 }


### PR DESCRIPTION
A crash will occur when you've configured object mappings using the realtime wizard but neglect to set up your realtime configuration in `extconfig.conf`. For example, adding the following to `sorcery.conf`:

    [res_geolocation]
    location = realtime,geo_location
    profile = realtime,geo_profile

But not defining `geo_location` or `geo_profile` in `extconfig.conf` will cause Asterisk to crash on startup.