### PR TITLE
res_pjsip: Don't log dialog retransmissions as errors

### DIFF
--- a/res/res_pjsip.c
+++ b/res/res_pjsip.c
@@ -1156,8 +1156,21 @@ static pjsip_dialog *create_dialog_uas(const struct ast_sip_endpoint *endpoint,
 		char err[PJ_ERR_MSG_SIZE];
 
 		pj_strerror(*status, err, sizeof(err));
-		ast_log(LOG_ERROR, "Could not create dialog with endpoint %s. %s\n",
-				ast_sorcery_object_get_id(endpoint), err);
+		if (*status == PJ_EEXISTS) {
+			/*
+			 * A dialog already exists for this request, which means the request
+			 * is a retransmission of one we are already processing. Callers
+			 * treat PJ_EEXISTS as an expected condition and silently discard
+			 * the duplicate rather than responding with an error, so logging
+			 * this at ERROR level misreports normal operation as a fault.
+			 */
+			ast_debug(3, "Endpoint '%s': A dialog already exists for this request; "
+					"treating it as a retransmission. %s\n",
+					ast_sorcery_object_get_id(endpoint), err);
+		} else {
+			ast_log(LOG_ERROR, "Could not create dialog with endpoint %s. %s\n",
+					ast_sorcery_object_get_id(endpoint), err);
+		}
 		ast_sip_tpselector_unref(&selector);
 		return NULL;
 	}


### PR DESCRIPTION
**AI has been used to generate this PR**
### Change

`create_dialog_uas()` in `res/res_pjsip.c` logs every `pjsip_dlg_create_uas()` failure at `LOG_ERROR`, including `PJ_EEXISTS`. `PJ_EEXISTS` means a dialog already exists for the request — the request is a retransmission of one already being processed.

Both callers already treat this as an expected condition rather than a fault:

- `res_pjsip_session.c` deliberately skips the 500 response when `dlg_status` is `PJ_EEXISTS`, so the in-progress call is not disturbed:
  ```c
  dlg = ast_sip_create_dialog_uas_locked(endpoint, rdata, &dlg_status);
  if (!dlg) {
      if (dlg_status != PJ_EEXISTS) {
          pjsip_endpt_respond_stateless(..., 500, NULL, NULL, NULL);
      }
      return NULL;
  }
  ```
- `res_pjsip_pubsub.c` skips its `LOG_WARNING` for the same status.

The shared helper nevertheless reports the condition at `ERROR`. The result is that a UAS receiving ordinary INVITE retransmissions over UDP emits a steady stream of

```
res_pjsip.c: Could not create dialog with endpoint <name>. Object already exists (PJ_EEXISTS)
```

for calls that set up and complete successfully. Nothing failed, and by the callers' own logic nothing was supposed to be reported as a failure.

This is disruptive in production: on a busy trunk the line drowns genuine errors in the log and fires log-based alerting (any rule matching `ERROR` on Asterisk's log) for a non-event. Distinguishing it from real dialog-creation failures currently requires reading the source.

This patch logs `PJ_EEXISTS` at debug level with a message that states what actually happened, and leaves every other failure status at `LOG_ERROR` with the existing wording.

### Testing

Built against master. The changed branch is reached only when `pjsip_dlg_create_uas*()` returns non-`PJ_SUCCESS`; behaviour for all other statuses, and the control flow in both callers, is unchanged — only the severity and text of one log message differ.

Observed in production on Asterisk receiving inbound INVITEs from a carrier trunk over UDP: the error appeared repeatedly for calls that connected and completed normally.
