### PR TITLE
cli: Propagate remote command failures to -rx

### DIFF
--- a/include/asterisk/_private.h
+++ b/include/asterisk/_private.h
@@ -39,6 +39,8 @@ int ast_channels_init(void);		/*!< Provided by channel.c */
 void ast_builtins_init(void);		/*!< Provided by cli.c */
 void ast_cli_channels_init(void);	/*!< Provided by cli.c */
 int ast_cli_perms_init(int reload);	/*!< Provided by cli.c */
+int ast_cli_command_multiple_full_result(int uid, int gid, int fd, size_t size,
+	const char *s, int *result); /*!< Provided by cli.c */
 void dnsmgr_start_refresh(void);	/*!< Provided by dnsmgr.c */
 int ast_dns_system_resolver_init(void); /*!< Provided by dns_system_resolver.c */
 void threadstorage_init(void);		/*!< Provided by threadstorage.c */

--- a/main/asterisk.c
+++ b/main/asterisk.c
@@ -1089,6 +1089,11 @@ static int fdprint(int fd, const char *s)
 	return write(fd, s, strlen(s));
 }
 
+enum remote_cli_result_markers {
+	REMOTE_CLI_RESULT_SUCCESS_MARKERS = 1,
+	REMOTE_CLI_RESULT_FAILURE_MARKERS = 2,
+};
+
 /*! \brief NULL handler so we can collect the child exit status */
 static void _null_sig_handler(int sig)
 {
@@ -1475,7 +1480,20 @@ static void *netconsole(void *vconsole)
 			}
 			/* XXX This will only work if it is the first command, and I'm not sure fixing it is worth the effort. */
 			if (strncmp(inbuf, "cli quit after ", 15) == 0) {
-				ast_cli_command_multiple_full(con->uid, con->gid, con->fd, bytes_read - 15, inbuf + 15);
+				char result_marker[2] = { '\0', '\0' };
+				int command_result;
+
+				ast_cli_command_multiple_full_result(con->uid, con->gid, con->fd,
+					bytes_read - 15, inbuf + 15, &command_result);
+				/*
+				 * CLI output never contains NUL bytes.  A single trailing NUL marks
+				 * success and two mark failure.  Older clients silently ignore both.
+				 */
+				ast_carefulwrite(con->fd, result_marker,
+					command_result == RESULT_SUCCESS
+						? REMOTE_CLI_RESULT_SUCCESS_MARKERS
+						: REMOTE_CLI_RESULT_FAILURE_MARKERS,
+					100);
 				break;
 			}
 			/* ast_cli_command_multiple_full will only process individual commands terminated by a
@@ -2149,7 +2167,7 @@ static void really_quit(int num, shutdown_nice_t niceness, int restart)
 		clean_time_zones();
 	}
 
-	exit(0);
+	exit(num);
 }
 
 static void __quit_handler(int num)
@@ -3255,7 +3273,7 @@ static void ast_el_write_default_histfile(void)
 	process_histfile(ast_el_write_history);
 }
 
-static void ast_remotecontrol(char *data)
+static int ast_remotecontrol(char *data)
 {
 	char buf[256] = "";
 	int res;
@@ -3277,9 +3295,12 @@ static void ast_remotecontrol(char *data)
 	signal(SIGTERM, __remote_quit_handler);
 	signal(SIGHUP, __remote_quit_handler);
 
-	if (read(ast_consock, buf, sizeof(buf) - 1) < 0) {
-		ast_log(LOG_ERROR, "read() failed: %s\n", strerror(errno));
-		return;
+	res = read(ast_consock, buf, sizeof(buf) - 1);
+	if (res <= 0) {
+		if (res < 0) {
+			ast_log(LOG_ERROR, "read() failed: %s\n", strerror(errno));
+		}
+		return 1;
 	}
 	if (data) {
 		char prefix[] = "cli quit after ";
@@ -3287,9 +3308,7 @@ static void ast_remotecontrol(char *data)
 		sprintf(tmp, "%s%s", prefix, data);
 		if (write(ast_consock, tmp, strlen(tmp) + 1) < 0) {
 			ast_log(LOG_ERROR, "write() failed: %s\n", strerror(errno));
-			if (sig_flags.need_quit || sig_flags.need_quit_handler || sig_flags.need_el_end) {
-				return;
-			}
+			return 1;
 		}
 	}
 	stringp = buf;
@@ -3310,21 +3329,50 @@ static void ast_remotecontrol(char *data)
 
 	if (ast_opt_exec && data) {  /* hack to print output then exit if asterisk -rx is used */
 		int linefull = 1, prev_linefull = 1, prev_line_verbose = 0;
+		int remote_result = 0;
+		int result_markers = 0;
 		struct pollfd fds;
 		fds.fd = ast_consock;
 		fds.events = POLLIN;
 		fds.revents = 0;
 
-		while (ast_poll(&fds, 1, 60000) > 0) {
+		for (;;) {
 			char buffer[512] = "", *curline = buffer, *nextline;
 			int not_written = 1;
+			ssize_t bytes_read;
 
+			res = ast_poll(&fds, 1, 60000);
+			if (res <= 0) {
+				if (res < 0 && errno != EINTR) {
+					ast_log(LOG_WARNING, "poll failed: %s\n", strerror(errno));
+				}
+				remote_result = 1;
+				break;
+			}
 			if (sig_flags.need_quit || sig_flags.need_quit_handler || sig_flags.need_el_end) {
+				remote_result = 1;
 				break;
 			}
 
-			if (read(ast_consock, buffer, sizeof(buffer) - 1) <= 0) {
+			bytes_read = read(ast_consock, buffer, sizeof(buffer) - 1);
+			if (bytes_read < 0) {
+				if (errno != EINTR) {
+					ast_log(LOG_WARNING, "read() failed: %s\n", strerror(errno));
+				}
+				remote_result = 1;
 				break;
+			}
+			if (!bytes_read) {
+				break;
+			}
+			/* Remove the result trailer before copying command output to stdout. */
+			while (bytes_read && buffer[bytes_read - 1] == '\0') {
+				result_markers++;
+				bytes_read--;
+			}
+			buffer[bytes_read] = '\0';
+			if (!bytes_read) {
+				continue;
 			}
 
 			do {
@@ -3353,6 +3401,7 @@ static void ast_remotecontrol(char *data)
 					not_written = 0;
 					if (write(STDOUT_FILENO, curline, nextline - curline) < 0) {
 						ast_log(LOG_WARNING, "write() failed: %s\n", strerror(errno));
+						remote_result = 1;
 					}
 				} else {
 					prev_line_verbose = 1;
@@ -3361,11 +3410,12 @@ static void ast_remotecontrol(char *data)
 			} while (!ast_strlen_zero(curline));
 
 			/* No non-verbose output in 60 seconds. */
-			if (not_written) {
+			if (not_written && !result_markers) {
 				break;
 			}
 		}
-		return;
+		/* A server predating result trailers sends no markers; preserve its legacy behavior. */
+		return remote_result || result_markers >= REMOTE_CLI_RESULT_FAILURE_MARKERS;
 	}
 
 	ast_verbose("Connected to Asterisk %s currently running on %s (pid = %d)\n", version, hostname, pid);
@@ -3401,6 +3451,7 @@ static void ast_remotecontrol(char *data)
 		}
 	}
 	printf("\nDisconnected from Asterisk server\n");
+	return 0;
 }
 
 static int show_version(void)
@@ -4081,9 +4132,9 @@ int main(int argc, char *argv[])
 		if (ast_opt_remote) {
 			multi_thread_safe = 1;
 			if (ast_opt_exec) {
-				ast_remotecontrol(xarg);
-				quit_handler(0, SHUTDOWN_FAST, 0);
-				exit(0);
+				c = ast_remotecontrol(xarg);
+				quit_handler(c, SHUTDOWN_FAST, 0);
+				exit(c);
 			}
 			ast_term_init();
 			printf("%s", term_end());

--- a/main/cli.c
+++ b/main/cli.c
@@ -240,6 +240,11 @@ static int cli_has_permissions(int uid, int gid, const char *command)
 
 static AST_RWLIST_HEAD_STATIC(helpers, ast_cli_entry);
 
+static int module_reload_succeeded(enum ast_module_reload_result result)
+{
+	return result == AST_MODULE_RELOAD_SUCCESS || result == AST_MODULE_RELOAD_QUEUED;
+}
+
 static char *handle_load(struct ast_cli_entry *e, int cmd, struct ast_cli_args *a)
 {
 	/* "module load <mod>" */
@@ -271,6 +276,7 @@ static char *handle_load(struct ast_cli_entry *e, int cmd, struct ast_cli_args *
 static char *handle_reload(struct ast_cli_entry *e, int cmd, struct ast_cli_args *a)
 {
 	int x;
+	char *retval = CLI_SUCCESS;
 
 	switch (cmd) {
 	case CLI_INIT:
@@ -285,8 +291,7 @@ static char *handle_reload(struct ast_cli_entry *e, int cmd, struct ast_cli_args
 		return ast_module_helper(a->line, a->word, a->pos, a->n, a->pos, AST_MODULE_HELPER_RELOAD);
 	}
 	if (a->argc == e->args) {
-		ast_module_reload(NULL);
-		return CLI_SUCCESS;
+		return module_reload_succeeded(ast_module_reload(NULL)) ? CLI_SUCCESS : CLI_FAILURE;
 	}
 	for (x = e->args; x < a->argc; x++) {
 		enum ast_module_reload_result res = ast_module_reload(a->argv[x]);
@@ -315,8 +320,11 @@ static char *handle_reload(struct ast_cli_entry *e, int cmd, struct ast_cli_args
 			ast_cli(a->fd, "Module '%s' reloaded successfully.\n", a->argv[x]);
 			break;
 		}
+		if (!module_reload_succeeded(res)) {
+			retval = CLI_FAILURE;
+		}
 	}
-	return CLI_SUCCESS;
+	return retval;
 }
 
 static char *handle_core_reload(struct ast_cli_entry *e, int cmd, struct ast_cli_args *a)
@@ -337,9 +345,7 @@ static char *handle_core_reload(struct ast_cli_entry *e, int cmd, struct ast_cli
 		return CLI_SHOWUSAGE;
 	}
 
-	ast_module_reload(NULL);
-
-	return CLI_SUCCESS;
+	return module_reload_succeeded(ast_module_reload(NULL)) ? CLI_SUCCESS : CLI_FAILURE;
 }
 
 /*!
@@ -3120,21 +3126,36 @@ done:
 	return retval == CLI_SUCCESS ? RESULT_SUCCESS : RESULT_FAILURE;
 }
 
-int ast_cli_command_multiple_full(int uid, int gid, int fd, size_t size, const char *s)
+int ast_cli_command_multiple_full_result(int uid, int gid, int fd, size_t size,
+	const char *s, int *result)
 {
 	char cmd[512];
 	int x, y = 0, count = 0;
+	int command_result = RESULT_FAILURE;
 
 	for (x = 0; x < size; x++) {
 		cmd[y] = s[x];
 		y++;
 		if (s[x] == '\0') {
-			ast_cli_command_full(uid, gid, fd, cmd);
+			if (!count) {
+				command_result = RESULT_SUCCESS;
+			}
+			if (ast_cli_command_full(uid, gid, fd, cmd) != RESULT_SUCCESS) {
+				command_result = RESULT_FAILURE;
+			}
 			y = 0;
 			count++;
 		}
 	}
+	if (result) {
+		*result = command_result;
+	}
 	return count;
+}
+
+int ast_cli_command_multiple_full(int uid, int gid, int fd, size_t size, const char *s)
+{
+	return ast_cli_command_multiple_full_result(uid, gid, fd, size, s, NULL);
 }
 
 void ast_cli_print_timestr_fromseconds(int fd, int seconds, const char *prefix)


### PR DESCRIPTION
## Summary

- propagate the aggregate CLI handler result through the remote console socket
- encode success as one trailing NUL and failure as two, keeping the trailer invisible to older clients
- make `asterisk -rx` return non-zero for failed commands and local transport errors
- make `module reload` and `core reload` report unsuccessful reload results as CLI failures

A new client connected to an older server keeps the legacy behavior when no result trailer is present. An older client connected to a new server silently ignores the NUL trailer.

## Testing

- `make -j4 main`
- `asterisk -rx "core show version"` returns 0
- `asterisk -rx "pjsip reload"` returns 1 when the command does not exist
- `asterisk -rx "module reload definitely_missing.so"` returns 1 when the handler reports failure

Fixes #2116