### PR TITLE
res_prometheus: add toggle config for metrics

### DIFF
--- a/configs/samples/prometheus.conf.sample
+++ b/configs/samples/prometheus.conf.sample
@@ -43,6 +43,15 @@ core_metrics_enabled = yes        ; Enable/disable core metrics. Core metrics
                                   ; version of Asterisk, uptime, last reload
                                   ; time, and the overall time it takes to
                                   ; scrape metrics. Default is "yes"
+channels_detail_metrics_enabled = yes
+                                  ; Enable/disable channels_detail. This controls 
+                                  ; export of asterisk_channels_state and 
+                                  ; asterisk_channels_duration_seconds
+                                  ; Default is "yes"
+bridges_detail_metrics_enabled = yes
+                                  ; Enable/disable bridges_detail. This controls 
+                                  ; export of asterisk_bridges_channels_count
+                                  ; Default is "yes"
 uri = metrics                     ; The HTTP route to expose metrics on.
                                   ; Default is "metrics".
 

--- a/include/asterisk/res_prometheus.h
+++ b/include/asterisk/res_prometheus.h
@@ -70,6 +70,10 @@ struct prometheus_general_config {
 	unsigned int enabled;
 	/*! \brief Whether or not core metrics are enabled */
 	unsigned int core_metrics_enabled;
+	/*! \brief Whether or not channel detail metrics are enabled */
+	unsigned int channels_detail_metrics_enabled;
+	/*! \brief Whether or not bridge detail metrics are enabled */
+	unsigned int bridges_detail_metrics_enabled;
 	AST_DECLARE_STRING_FIELDS(
 		/*! \brief The HTTP URI we register ourselves to */
 		AST_STRING_FIELD(uri);

--- a/res/prometheus/bridges.c
+++ b/res/prometheus/bridges.c
@@ -77,6 +77,7 @@ struct bridge_metric_defs {
  */
 static void bridges_scrape_cb(struct ast_str **response)
 {
+	RAII_VAR(struct prometheus_general_config *, config, prometheus_general_config_get(), ao2_cleanup);
 	struct ao2_container *bridge_cache;
 	struct ao2_container *bridges;
 	struct ao2_iterator it_bridges;
@@ -113,6 +114,11 @@ static void bridges_scrape_cb(struct ast_str **response)
 	prometheus_metric_to_string(&bridge_count, response);
 
 	if (num_bridges == 0) {
+		ao2_ref(bridges, -1);
+		return;
+	}
+
+	if (!config || !config->bridges_detail_metrics_enabled) {
 		ao2_ref(bridges, -1);
 		return;
 	}

--- a/res/prometheus/channels.c
+++ b/res/prometheus/channels.c
@@ -129,6 +129,7 @@ static struct prometheus_metric global_channel_metrics[] = {
  */
 static void channels_scrape_cb(struct ast_str **response)
 {
+	RAII_VAR(struct prometheus_general_config *, config, prometheus_general_config_get(), ao2_cleanup);
 	struct ao2_container *channel_cache;
 	struct ao2_container *channels;
 	struct ao2_iterator it_chans;
@@ -172,6 +173,11 @@ static void channels_scrape_cb(struct ast_str **response)
 	}
 
 	if (num_channels == 0) {
+		ao2_ref(channels, -1);
+		return;
+	}
+
+	if (!config || !config->channels_detail_metrics_enabled) {
 		ao2_ref(channels, -1);
 		return;
 	}

--- a/res/res_prometheus.c
+++ b/res/res_prometheus.c
@@ -83,6 +83,44 @@
 						</enumlist>
 					</description>
 				</configOption>
+				<configOption name="channels_detail_metrics_enabled" default="yes">
+					<since>
+						<version>20.22.0</version>
+						<version>22.12.0</version>
+						<version>23.6.0</version>
+						<version>24.1.0</version>
+					</since>
+					<synopsis>Enable or disable asterisk_channels_state and asterisk_channels_duration_seconds metrics.</synopsis>
+					<description>
+						<para>
+						channels_detail_metrics_enabled defaults to yes to maintain backward‑compatibility.
+						Set to no to disable the high‑cardinality channel detail metrics.
+						</para>
+						<enumlist>
+							<enum name="no" />
+							<enum name="yes" />
+						</enumlist>
+					</description>
+				</configOption>
+				<configOption name="bridges_detail_metrics_enabled" default="yes">
+					<since>
+						<version>20.22.0</version>
+						<version>22.12.0</version>
+						<version>23.6.0</version>
+						<version>24.1.0</version>
+					</since>
+					<synopsis>Enable or disable asterisk_bridges_channels_count metric.</synopsis>
+					<description>
+						<para>
+						bridges_detail_metrics_enabled defaults to yes to maintain backward‑compatibility.
+						Set to no to disable the high‑cardinality bridge detail metrics.
+						</para>
+						<enumlist>
+							<enum name="no" />
+							<enum name="yes" />
+						</enumlist>
+					</description>
+				</configOption>
 				<configOption name="uri" default="metrics">
 					<since>
 						<version>17.0.0</version>
@@ -991,6 +1029,8 @@ static int load_module(void)
 	}
 	aco_option_register(&cfg_info, "enabled", ACO_EXACT, global_options, "no", OPT_BOOL_T, 1, FLDSET(struct prometheus_general_config, enabled));
 	aco_option_register(&cfg_info, "core_metrics_enabled", ACO_EXACT, global_options, "yes", OPT_BOOL_T, 1, FLDSET(struct prometheus_general_config, core_metrics_enabled));
+	aco_option_register(&cfg_info, "channels_detail_metrics_enabled", ACO_EXACT, global_options, "yes", OPT_BOOL_T, 1, FLDSET(struct prometheus_general_config, channels_detail_metrics_enabled));
+	aco_option_register(&cfg_info, "bridges_detail_metrics_enabled", ACO_EXACT, global_options, "yes", OPT_BOOL_T, 1, FLDSET(struct prometheus_general_config, bridges_detail_metrics_enabled));
 	aco_option_register(&cfg_info, "uri", ACO_EXACT, global_options, "", OPT_STRINGFIELD_T, 1, STRFLDSET(struct prometheus_general_config, uri));
 	aco_option_register(&cfg_info, "auth_username", ACO_EXACT, global_options, "", OPT_STRINGFIELD_T, 0, STRFLDSET(struct prometheus_general_config, auth_username));
 	aco_option_register(&cfg_info, "auth_password", ACO_EXACT, global_options, "", OPT_STRINGFIELD_T, 0, STRFLDSET(struct prometheus_general_config, auth_password));

--- a/tests/test_res_prometheus.c
+++ b/tests/test_res_prometheus.c
@@ -727,6 +727,7 @@ AST_TEST_DEFINE(bridge_to_string)
 	RAII_VAR(struct ast_bridge *, bridge1, NULL, safe_bridge_destroy);
 	RAII_VAR(struct ast_bridge *, bridge2, NULL, safe_bridge_destroy);
 	RAII_VAR(struct ast_bridge *, bridge3, NULL, safe_bridge_destroy);
+	struct prometheus_general_config *config;
 	struct ast_str *response;
 
 	switch (cmd) {
@@ -741,6 +742,14 @@ AST_TEST_DEFINE(bridge_to_string)
 	case TEST_EXECUTE:
 		break;
 	}
+
+	config = config_alloc();
+	if (!config) {
+		return AST_TEST_NOT_RUN;
+	}
+	config->bridges_detail_metrics_enabled = 1;
+	prometheus_general_config_set(config);
+	ao2_ref(config, -1);
 
 	bridge1 = ast_bridge_basic_new();
 	ast_test_validate(test, bridge1 != NULL);


### PR DESCRIPTION
In high‑volume call scenarios, Prometheus exports a large number of channels‑related and bridges-related metrics.Not all users require channels_state, channels_duration and bridges_channels.Add conf options to enable or disable channel_details(covering channels_state, channels_duration) and bridge_details(covering bridges_channels).

UserNote: Add new config option 'channels_detail_metrics_enabled' to disable export of 'asterisk_channels_state' and 'asterisk_channels_duration_seconds' metrics,It defaults to 'yes' to preserve existing behavior

Add new config option 'bridges_detail_metrics_enabled' to disable export of 'asterisk_bridges_channels_count' metric, It defaults to 'yes' to preserve existing behavior

Explicitly enable bridges_detail_metrics_enabled for the bridge_to_string unit‑test.