### PR TITLE
codec_ilbc: Build against system libilbc 3.x

### DIFF
--- a/codecs/codec_ilbc.c
+++ b/codecs/codec_ilbc.c
@@ -45,6 +45,21 @@
 typedef uint16_t ilbc_bytes;
 typedef int16_t  ilbc_block;
 #define BUF_TYPE i16
+/* libilbc 3.x removed the RFC 3951 compatibility macros that 2.x's <ilbc.h>
+ * provided.  Re-add them only when the header did not, so this is a no-op
+ * against libilbc 2.x and only takes effect on 3.x. */
+#ifndef initDecode
+#define initDecode WebRtcIlbcfix_InitDecode
+#endif
+#ifndef initEncode
+#define initEncode WebRtcIlbcfix_InitEncode
+#endif
+#ifndef iLBC_decode
+#define iLBC_decode WebRtcIlbcfix_DecodeImpl
+#endif
+#ifndef iLBC_encode
+#define iLBC_encode WebRtcIlbcfix_EncodeImpl
+#endif
 #else
 #include "ilbc/iLBC_encode.h"
 #include "ilbc/iLBC_decode.h"

--- a/configure
+++ b/configure
@@ -34380,19 +34380,19 @@ if test "${USE_ILBC}" != "no"; then
       if test "x${PBX_ILBC}" != "x1" -a "${USE_ILBC}" != "no"; then
 
 pkg_failed=no
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for libilbc < 3" >&5
-printf %s "checking for libilbc < 3... " >&6; }
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for libilbc" >&5
+printf %s "checking for libilbc... " >&6; }
 
 if test -n "$ILBC_CFLAGS"; then
     pkg_cv_ILBC_CFLAGS="$ILBC_CFLAGS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
-    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libilbc < 3\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "libilbc < 3") 2>&5
+    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libilbc\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "libilbc") 2>&5
   ac_status=$?
   printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
-  pkg_cv_ILBC_CFLAGS=`$PKG_CONFIG --cflags "libilbc < 3" 2>/dev/null`
+  pkg_cv_ILBC_CFLAGS=`$PKG_CONFIG --cflags "libilbc" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
 else
   pkg_failed=yes
@@ -34404,12 +34404,12 @@ if test -n "$ILBC_LIBS"; then
     pkg_cv_ILBC_LIBS="$ILBC_LIBS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
-    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libilbc < 3\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "libilbc < 3") 2>&5
+    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libilbc\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "libilbc") 2>&5
   ac_status=$?
   printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
-  pkg_cv_ILBC_LIBS=`$PKG_CONFIG --libs "libilbc < 3" 2>/dev/null`
+  pkg_cv_ILBC_LIBS=`$PKG_CONFIG --libs "libilbc" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
 else
   pkg_failed=yes
@@ -34430,9 +34430,9 @@ else
         _pkg_short_errors_supported=no
 fi
         if test $_pkg_short_errors_supported = yes; then
-                ILBC_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libilbc < 3" 2>&1`
+                ILBC_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libilbc" 2>&1`
         else
-                ILBC_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libilbc < 3" 2>&1`
+                ILBC_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libilbc" 2>&1`
         fi
         # Put the nasty error message in config.log where it belongs
         echo "$ILBC_PKG_ERRORS" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -1765,7 +1765,7 @@ if test "${USE_ILBC}" != "no"; then
       ILBC_INTERNAL="no"
    fi
    if test "${ILBC_SYSTEM}" = "yes"; then
-      AST_PKG_CONFIG_CHECK(ILBC, libilbc < 3)
+      AST_PKG_CONFIG_CHECK(ILBC, libilbc)
       if test "$PBX_ILBC" = "1"; then
 	 ILBC_INTERNAL="no"
       fi


### PR DESCRIPTION
libilbc 3.x removed the RFC 3951 compatibility function names (initDecode,
initEncode, iLBC_decode, iLBC_encode). Map them to the WebRtcIlbcfix_* symbols
the library exposes, and drop the "libilbc < 3" configure restriction, so
codec_ilbc is built against the system libilbc even when it is version 3.x.

Resolves: #2135

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>

