### PR TITLE
chan_dahdi: Make DAHDI device state cacheable to fix device state sync.

### DIFF
--- a/channels/chan_dahdi.c
+++ b/channels/chan_dahdi.c
@@ -3305,7 +3305,7 @@ static void dahdi_pri_update_span_devstate(struct sig_pri_span *pri)
 	}
 	if (pri->congestion_devstate != new_state) {
 		pri->congestion_devstate = new_state;
-		ast_devstate_changed(AST_DEVICE_UNKNOWN, AST_DEVSTATE_NOT_CACHABLE, "DAHDI/I%d/congestion", pri->span);
+		ast_devstate_changed(AST_DEVICE_UNKNOWN, AST_DEVSTATE_CACHABLE, "DAHDI/I%d/congestion", pri->span);
 	}
 #if defined(THRESHOLD_DEVSTATE_PLACEHOLDER)
 	/* Update the span threshold device state and report any change. */
@@ -3321,7 +3321,7 @@ static void dahdi_pri_update_span_devstate(struct sig_pri_span *pri)
 	}
 	if (pri->threshold_devstate != new_state) {
 		pri->threshold_devstate = new_state;
-		ast_devstate_changed(AST_DEVICE_UNKNOWN, AST_DEVSTATE_NOT_CACHABLE, "DAHDI/I%d/threshold", pri->span);
+		ast_devstate_changed(AST_DEVICE_UNKNOWN, AST_DEVSTATE_CACHABLE, "DAHDI/I%d/threshold", pri->span);
 	}
 #endif	/* defined(THRESHOLD_DEVSTATE_PLACEHOLDER) */
 }
@@ -9829,8 +9829,7 @@ static struct ast_channel *dahdi_new(struct dahdi_pvt *i, int state, int startpb
 	if (dashptr) {
 		*dashptr = '\0';
 	}
-	ast_set_flag(ast_channel_flags(tmp), AST_FLAG_DISABLE_DEVSTATE_CACHE);
-	ast_devstate_changed_literal(AST_DEVICE_UNKNOWN, AST_DEVSTATE_NOT_CACHABLE, device_name);
+	ast_devstate_changed_literal(AST_DEVICE_UNKNOWN, AST_DEVSTATE_CACHABLE, device_name);
 
 	for (v = i->vars ; v ; v = v->next)
 		pbx_builtin_setvar_helper(tmp, v->name, v->value);


### PR DESCRIPTION
Commit 8fb5bdce9ab9f7f3758545753cbc787653920753 disabled caching of
certain device states that weren't associated with real devices in
order to prevent a resource exhaustion attack from guest/unauthenticated
connections.

In most cases, code was converted to remain cacheable; the few exceptions
had mainly to do with certain paths in channel drivers for guest or
unauthenticated access. However, everything in chan_dahdi was made
uncachable for no apparent reason. This is not harmless, since it
prevents device state synchronization from working (e.g. with
res_pjsip_publish_asterisk) since device state updates that are
marked uncachable result in hints on remote systems always showing
"Unavailable" since uncached device state updates are simply discarded.

Since DAHDI devices very much correspond to real devices (perhaps more
so than in any other channel driver), we can safely cache device state
for DAHDI channels, which also ensures that device state
synchronization now works properly.

Resolves: #2138
