### PR TITLE
utils: fix SWAP64_32 macro precedence bug on big-endian

### DIFF
--- a/include/asterisk/utils.h
+++ b/include/asterisk/utils.h
@@ -128,7 +128,7 @@ extern unsigned int __unsigned_int_flags_dummy;
  * \retval The flags with the upper and lower 32 bits swapped if the system is big-endian,
  */
 #if defined(BYTE_ORDER) && (BYTE_ORDER == BIG_ENDIAN)
-#define SWAP64_32(flags) (((uint64_t)flags << 32) | ((uint64_t)flags >> 32))
+#define SWAP64_32(flags) (((uint64_t)(flags) << 32) | ((uint64_t)(flags) >> 32))
 #elif defined(BYTE_ORDER) && (BYTE_ORDER == LITTLE_ENDIAN)
 #define SWAP64_32(flags) (flags)
 #else

--- a/utils/extconf.c
+++ b/utils/extconf.c
@@ -675,7 +675,7 @@ struct ast_flags {  /* stolen from utils.h */
 	unsigned int flags;
 };
 #if __BYTE_ORDER == __BIG_ENDIAN
-#define SWAP64_32(flags) (((uint64_t)flags << 32) | ((uint64_t)flags >> 32))
+#define SWAP64_32(flags) (((uint64_t)(flags) << 32) | ((uint64_t)(flags) >> 32))
 #else
 #define SWAP64_32(flags) (flags)
 #endif


### PR DESCRIPTION
on my big endian S390x system:

$ asterisk -rx "core waitfullybooted"

gives an interactive prompt instead of executing the command

--- Proposed fix

The SWAP64_32 macro did not parenthesize its argument. When a combined flag mask such as (AST_OPT_FLAG_EXEC | AST_OPT_FLAG_NO_COLOR) was passed, the '<<' shift bound tighter than the '|', so the wrong bits were set. On big-endian systems (e.g. s390x) this caused ast_set_flag64() and a later single-flag ast_test_flag64() to disagree, so 'asterisk -rx <cmd>' dropped into the interactive console instead of executing the command.

Parenthesize the macro argument so the whole expression is evaluated before the word swap. Little-endian was unaffected.