### PR TITLE
res_pjsip_session: Add timers_refresher endpoint option

### DIFF
--- a/configs/samples/pjsip.conf.sample
+++ b/configs/samples/pjsip.conf.sample
@@ -734,6 +734,10 @@
 ;timers=yes     ; Session timers for SIP packets (default: "yes")
 ;timers_sess_expires=1800       ; Maximum session timer expiration period
                                 ; (default: "1800")
+;timers_refresher=auto  ; Preferred session timer refresher for inbound call
+                        ; legs when the remote sends Session-Expires without a
+                        ; refresher parameter.  Values: auto (default), uas
+                        ; (this side refreshes) or uac (the remote refreshes)
 ;transport=     ; Explicit transport configuration to use (default: "")
                 ; This will force the endpoint to use the specified transport
                 ; configuration to send SIP messages.  You need to already know

--- a/contrib/ast-db-manage/config/versions/1e65f5e27981_add_timers_refresher_to_ps_endpoints.py
+++ b/contrib/ast-db-manage/config/versions/1e65f5e27981_add_timers_refresher_to_ps_endpoints.py
@@ -1,0 +1,22 @@
+"""add timers_refresher to ps_endpoints
+
+Revision ID: 1e65f5e27981
+Revises: 2b45fd748a4f
+Create Date: 2026-09-05 10:30:00.000000
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '1e65f5e27981'
+down_revision = '2b45fd748a4f'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('ps_endpoints', sa.Column('timers_refresher', sa.String(40)))
+
+
+def downgrade():
+    op.drop_column('ps_endpoints', 'timers_refresher')

--- a/include/asterisk/res_pjsip.h
+++ b/include/asterisk/res_pjsip.h
@@ -809,6 +809,21 @@ struct ast_sip_timer_options {
 };
 
 /*!
+ * \brief Session timer refresher preference
+ *
+ * Used to control which side refreshes the session when the remote party
+ * sends a Session-Expires header without a refresher parameter.
+ */
+enum ast_sip_timer_refresher {
+	/*! Do not force a refresher; use the normal negotiation */
+	AST_SIP_TIMER_REFRESHER_AUTO,
+	/*! This side (the UAS on an inbound call leg) refreshes the session */
+	AST_SIP_TIMER_REFRESHER_UAS,
+	/*! The remote side (the UAC) refreshes the session */
+	AST_SIP_TIMER_REFRESHER_UAC,
+};
+
+/*!
  * \brief Endpoint configuration for SIP extensions.
  *
  * SIP extensions, in this case refers to features
@@ -819,6 +834,8 @@ struct ast_sip_endpoint_extensions {
 	unsigned int flags;
 	/*! Timer options */
 	struct ast_sip_timer_options timer;
+	/*! Session timer refresher preference for inbound (UAS) call legs */
+	enum ast_sip_timer_refresher refresher;
 };
 
 /*!

--- a/res/res_pjsip/pjsip_config.xml
+++ b/res/res_pjsip/pjsip_config.xml
@@ -895,6 +895,29 @@
 						Maximum session timer expiration period. Time in seconds.
 					</para></description>
 				</configOption>
+				<configOption name="timers_refresher" default="auto">
+					<synopsis>Preferred session timer refresher for inbound call legs</synopsis>
+					<description>
+						<para>Controls which side refreshes the session when the
+						remote party sends a <literal>Session-Expires</literal>
+						header without a <literal>refresher</literal> parameter.
+						</para>
+						<enumlist>
+							<enum name="auto">
+								<para>Do not force a refresher. The session timer
+								refresher is selected by normal negotiation.</para>
+							</enum>
+							<enum name="uas">
+								<para>This side, as the UAS on the inbound call leg,
+								refreshes the session.</para>
+							</enum>
+							<enum name="uac">
+								<para>The remote side, as the UAC, refreshes the
+								session.</para>
+							</enum>
+						</enumlist>
+					</description>
+				</configOption>
 				<configOption name="transport">
 					<since>
 						<version>12.0.0</version>

--- a/res/res_pjsip/pjsip_configuration.c
+++ b/res/res_pjsip/pjsip_configuration.c
@@ -257,6 +257,41 @@ static int timers_to_str(const void *obj, const intptr_t *args, char **buf)
 	return 0;
 }
 
+static const char *timer_refresher_map[] = {
+	[AST_SIP_TIMER_REFRESHER_AUTO] = "auto",
+	[AST_SIP_TIMER_REFRESHER_UAS] = "uas",
+	[AST_SIP_TIMER_REFRESHER_UAC] = "uac",
+};
+
+static int timers_refresher_handler(const struct aco_option *opt, struct ast_variable *var, void *obj)
+{
+	struct ast_sip_endpoint *endpoint = obj;
+
+	if (!strcasecmp(var->value, "auto")) {
+		endpoint->extensions.refresher = AST_SIP_TIMER_REFRESHER_AUTO;
+	} else if (!strcasecmp(var->value, "uas")) {
+		endpoint->extensions.refresher = AST_SIP_TIMER_REFRESHER_UAS;
+	} else if (!strcasecmp(var->value, "uac")) {
+		endpoint->extensions.refresher = AST_SIP_TIMER_REFRESHER_UAC;
+	} else {
+		ast_log(LOG_NOTICE, "Unrecognized option value %s for %s on endpoint %s\n",
+				var->value, var->name, ast_sorcery_object_get_id(endpoint));
+		return -1;
+	}
+
+	return 0;
+}
+
+static int timers_refresher_to_str(const void *obj, const intptr_t *args, char **buf)
+{
+	const struct ast_sip_endpoint *endpoint = obj;
+
+	if (ARRAY_IN_BOUNDS(endpoint->extensions.refresher, timer_refresher_map)) {
+		*buf = ast_strdup(timer_refresher_map[endpoint->extensions.refresher]);
+	}
+	return 0;
+}
+
 static int security_mechanism_to_str(const void *obj, const intptr_t *args, char **buf)
 {
 	const struct ast_sip_endpoint *endpoint = obj;
@@ -2293,6 +2328,7 @@ int ast_res_pjsip_initialize_configuration(void)
 	ast_sorcery_object_field_register_custom(sip_sorcery, "endpoint", "timers", "yes", timers_handler, timers_to_str, NULL, 0, 0);
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "timers_min_se", "90", OPT_UINT_T, 0, FLDSET(struct ast_sip_endpoint, extensions.timer.min_se));
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "timers_sess_expires", "1800", OPT_UINT_T, 0, FLDSET(struct ast_sip_endpoint, extensions.timer.sess_expires));
+	ast_sorcery_object_field_register_custom(sip_sorcery, "endpoint", "timers_refresher", "auto", timers_refresher_handler, timers_refresher_to_str, NULL, 0, 0);
 	ast_sorcery_object_field_register_custom(sip_sorcery, "endpoint", "auth", "", inbound_auth_handler, inbound_auths_to_str, NULL, 0, 0);
 	ast_sorcery_object_field_register_custom(sip_sorcery, "endpoint", "outbound_auth", "", outbound_auth_handler, outbound_auths_to_str, NULL, 0, 0);
 	ast_sorcery_object_field_register(sip_sorcery, "endpoint", "aors", "", OPT_STRINGFIELD_T, 0, STRFLDSET(struct ast_sip_endpoint, aors));

--- a/res/res_pjsip_session.c
+++ b/res/res_pjsip_session.c
@@ -26,6 +26,7 @@
 
 #include <pjsip.h>
 #include <pjsip_ua.h>
+#include <pjsip-ua/sip_timer.h>
 #include <pjlib.h>
 #include <pjmedia.h>
 
@@ -3955,6 +3956,45 @@ static int check_content_disposition(pjsip_rx_data *rdata)
 	return 0;
 }
 
+/*!
+ * \internal
+ * \brief Apply the configured session timer refresher preference.
+ *
+ * When an incoming INVITE carries a Session-Expires header without a refresher
+ * parameter, pjsip selects the refresher itself during session timer
+ * negotiation. This function lets an endpoint force its preference by
+ * supplying the refresher parameter in the request before the session timers
+ * are negotiated. An explicit refresher parameter chosen by the remote party
+ * is always respected.
+ */
+static void session_timer_set_refresher(struct ast_sip_session *session,
+					pjsip_rx_data *rdata)
+{
+	const struct ast_sip_endpoint *endpoint = session->endpoint;
+	static const pj_str_t str_session_expires = {"Session-Expires", 15};
+	static const pj_str_t str_session_expires_short = {"x", 1};
+	pjsip_sess_expires_hdr *se_hdr;
+
+	if (endpoint->extensions.refresher == AST_SIP_TIMER_REFRESHER_AUTO) {
+		return;
+	}
+
+	se_hdr = (pjsip_sess_expires_hdr *) pjsip_msg_find_hdr_by_names(
+		rdata->msg_info.msg, &str_session_expires,
+		&str_session_expires_short, NULL);
+
+	if (!se_hdr || se_hdr->refresher.slen) {
+		return;
+	}
+
+	if (endpoint->extensions.refresher == AST_SIP_TIMER_REFRESHER_UAS) {
+		se_hdr->refresher.ptr = (char *) "uas";
+	} else {
+		se_hdr->refresher.ptr = (char *) "uac";
+	}
+	se_hdr->refresher.slen = 3;
+}
+
 static int new_invite(struct new_invite *invite)
 {
 	pjsip_tx_data *tdata = NULL;
@@ -4031,6 +4071,8 @@ static int new_invite(struct new_invite *invite)
 		}
 		goto end;
 	}
+
+	session_timer_set_refresher(invite->session, invite->rdata);
 
 	pjsip_timer_setting_default(&timer);
 	timer.min_se = invite->session->endpoint->extensions.timer.min_se;


### PR DESCRIPTION
    res_pjsip_session: Add timers_refresher endpoint option
    
    When an incoming INVITE carries a Session-Expires header without a
    refresher parameter, pjsip defaults to the UAC as the session timer
    refresher. Some peer devices have issues with this default, so there
    is a need to be able to adjust which side refreshes the session for a
    given endpoint.
    
    This change adds the endpoint option timers_refresher with the values
    auto, uas and uac. On an inbound call leg, when the remote sends a
    Session-Expires header without a refresher parameter, the configured
    value is applied before the session timers are negotiated so the
    desired side refreshes the session. auto is the default and keeps the
    normal pjsip negotiation, uas makes this side (the UAS) refresh and uac
    makes the remote side (the UAC) refresh. An explicit refresher parameter
    sent by the remote party is always respected.
    
    UpgradeNote: An Alembic migration script has been added that creates
    the timers_refresher column on the ps_endpoints table for users of the
    realtime database backend.
    
    UserNote: A new endpoint option `timers_refresher` has been added to
    pjsip.conf that lets you control which side refreshes the session when
    the remote sends Session-Expires without a refresher parameter.
