### PR TITLE
res_resolver_unbound: Include libunbound error reason

### DIFF
--- a/res/res_resolver_unbound.c
+++ b/res/res_resolver_unbound.c
@@ -329,8 +329,8 @@ static int unbound_resolver_resolve(struct ast_dns_query *query)
 		ao2_bump(query), unbound_resolver_callback, &data->id);
 
 	if (res) {
-		ast_log(LOG_ERROR, "Failed to perform async DNS resolution of '%s'\n",
-			ast_dns_query_get_name(query));
+		ast_log(LOG_ERROR, "Failed to perform async DNS resolution of '%s': %s\n",
+			ast_dns_query_get_name(query), ub_strerror(res));
 		ao2_ref(query, -1);
 	}
 


### PR DESCRIPTION
Failures returned by ub_resolve_async() are currently logged without the
reason provided by libunbound, making resolver configuration failures
difficult to diagnose.

Include ub_strerror() in the error message so the underlying libunbound
failure reason is available in the Asterisk log.

Resolves: #2110
