### PR TITLE
app_mixmonitor: Prevent recording multiple times to the same file.

### DIFF
--- a/apps/app_dictate.c
+++ b/apps/app_dictate.c
@@ -161,7 +161,7 @@ static int dictate_exec(struct ast_channel *chan, const char *data)
 		}
 
 		snprintf(path, len, "%s/%s", base, filein);
-		fs = ast_writefile(path, "raw", NULL, O_CREAT|O_APPEND, 0, AST_FILE_MODE);
+		fs = ast_chan_writefile(chan, path, "raw", NULL, O_CREAT|O_APPEND, 0, AST_FILE_MODE);
 		mode = DMODE_PLAY;
 		memset(&flags, 0, sizeof(flags));
 		ast_set_flag(&flags, DFLAG_PAUSE);
@@ -319,7 +319,7 @@ static int dictate_exec(struct ast_channel *chan, const char *data)
 						} else {
 							oflags |= O_APPEND;
 						}
-						fs = ast_writefile(path, "raw", NULL, oflags, 0, AST_FILE_MODE);
+						fs = ast_chan_writefile(chan, path, "raw", NULL, oflags, 0, AST_FILE_MODE);
 						if (ast_test_flag(&flags, DFLAG_TRUNC)) {
 							ast_seekstream(fs, 0, SEEK_SET);
 							ast_clear_flag(&flags, DFLAG_TRUNC);

--- a/apps/app_meetme.c
+++ b/apps/app_meetme.c
@@ -5322,7 +5322,7 @@ static void *recordthread(void *args)
 			break;
 		}
 		if (!s && !(ast_strlen_zero(filename_buffer)) && (filename_buffer != oldrecordingfilename)) {
-			s = ast_writefile(filename_buffer, cnf->recordingformat, NULL, flags, 0, AST_FILE_MODE);
+			s = ast_chan_writefile(cnf->lchan, filename_buffer, cnf->recordingformat, NULL, flags, 0, AST_FILE_MODE);
 			oldrecordingfilename = filename_buffer;
 		}
 

--- a/apps/app_mixmonitor.c
+++ b/apps/app_mixmonitor.c
@@ -500,11 +500,14 @@ struct mixmonitor_ds {
 	 * immediately during stop_mixmonitor or channel destruction. */
 	int fs_quit;
 
+	struct ast_channel *chan; /* The channel that set up the MixMonitor, for duplicate recording avoidance */
+
 	struct ast_filestream *fs;
 	struct ast_filestream *fs_read;
 	struct ast_filestream *fs_write;
 
 	struct ast_audiohook *audiohook;
+	struct ast_datastore *datastore;
 
 	unsigned int samp_rate;
 	char *filename;
@@ -729,6 +732,9 @@ static void mixmonitor_save_prep(struct mixmonitor *mixmonitor, char *filename, 
 
 			last_slash = strrchr(filename, '/');
 
+			/* Pass filename to ast_chan_writefile before we butcher it */
+			*fs = ast_chan_writefile(mixmonitor->mixmonitor_ds->chan, filename, *ext, NULL, *oflags, 0, 0666);
+
 			if ((*ext = strrchr(filename, '.')) && (*ext > last_slash)) {
 				**ext = '\0';
 				*ext = *ext + 1;
@@ -736,7 +742,7 @@ static void mixmonitor_save_prep(struct mixmonitor *mixmonitor, char *filename, 
 				*ext = "raw";
 			}
 
-			if (!(*fs = ast_writefile(filename, *ext, NULL, *oflags, 0, 0666))) {
+			if (!*fs) {
 				ast_log(LOG_ERROR, "Cannot open %s.%s\n", filename, *ext);
 				*errflag = 1;
 			} else {
@@ -777,8 +783,6 @@ static void *mixmonitor_thread(void *obj)
 		ast_callid_threadassoc_add(mixmonitor->callid);
 	}
 
-	ast_verb(2, "Begin MixMonitor Recording %s\n", mixmonitor->name);
-
 	fs = &mixmonitor->mixmonitor_ds->fs;
 	fs_read = &mixmonitor->mixmonitor_ds->fs_read;
 	fs_write = &mixmonitor->mixmonitor_ds->fs_write;
@@ -789,6 +793,40 @@ static void *mixmonitor_thread(void *obj)
 	mixmonitor_save_prep(mixmonitor, mixmonitor->filename_write, fs_write, &oflags, &errflag, &fs_write_ext);
 
 	format_slin = ast_format_cache_get_slin_by_rate(mixmonitor->mixmonitor_ds->samp_rate);
+
+	if (errflag) {
+		/* Tear everything down and exit. */
+		struct ast_datastore *datastore;
+
+		mixmonitor_ds_close_fs(mixmonitor->mixmonitor_ds);
+		mixmonitor->mixmonitor_ds->audiohook = NULL;
+
+		ast_mutex_unlock(&mixmonitor->mixmonitor_ds->lock);
+
+		ast_autochan_channel_lock(mixmonitor->autochan);
+		ast_audiohook_remove(mixmonitor->autochan->chan, &mixmonitor->audiohook);
+		ast_autochan_channel_unlock(mixmonitor->autochan);
+		ast_autochan_destroy(mixmonitor->autochan);
+
+		datastore = mixmonitor->mixmonitor_ds->datastore;
+		if (!ast_channel_datastore_remove(mixmonitor->mixmonitor_ds->chan, datastore)) {
+			ast_datastore_free(datastore);
+		}
+
+		ast_mutex_lock(&mixmonitor->mixmonitor_ds->lock);
+		if (!mixmonitor->mixmonitor_ds->destruction_ok) {
+			ast_cond_wait(&mixmonitor->mixmonitor_ds->destruction_condition, &mixmonitor->mixmonitor_ds->lock);
+		}
+		ast_mutex_unlock(&mixmonitor->mixmonitor_ds->lock);
+
+		ast_audiohook_destroy(&mixmonitor->audiohook);
+		mixmonitor_free(mixmonitor);
+
+		ast_module_unref(ast_module_info->self);
+		return NULL;
+	}
+
+	ast_verb(2, "Begin MixMonitor Recording %s\n", mixmonitor->name);
 
 	ast_mutex_unlock(&mixmonitor->mixmonitor_ds->lock);
 
@@ -917,6 +955,7 @@ static void *mixmonitor_thread(void *obj)
 	if (!mixmonitor->mixmonitor_ds->destruction_ok) {
 		ast_cond_wait(&mixmonitor->mixmonitor_ds->destruction_condition, &mixmonitor->mixmonitor_ds->lock);
 	}
+
 	ast_mutex_unlock(&mixmonitor->mixmonitor_ds->lock);
 
 	/* kill the audiohook */
@@ -1000,12 +1039,14 @@ static int setup_mixmonitor_ds(struct mixmonitor *mixmonitor, struct ast_channel
 		ast_autochan_channel_unlock(mixmonitor->autochan);
 	}
 
+	mixmonitor_ds->chan = chan;
 	mixmonitor_ds->samp_rate = 8000;
 	mixmonitor_ds->audiohook = &mixmonitor->audiohook;
 	mixmonitor_ds->filename = ast_strdup(mixmonitor->filename);
 	if (!ast_strlen_zero(beep_id)) {
 		mixmonitor_ds->beep_id = ast_strdup(beep_id);
 	}
+	mixmonitor_ds->datastore = datastore;
 	datastore->data = mixmonitor_ds;
 
 	ast_channel_lock(chan);

--- a/apps/app_record.c
+++ b/apps/app_record.c
@@ -494,7 +494,7 @@ static int record_exec(struct ast_channel *chan, const char *data)
 	}
 
 	ioflags = ast_test_flag(&flags, OPTION_APPEND) ? O_CREAT|O_APPEND|O_WRONLY : O_CREAT|O_TRUNC|O_WRONLY;
-	s = ast_writefile(tmp, ext, NULL, ioflags, 0, AST_FILE_MODE);
+	s = ast_chan_writefile(chan, tmp, ext, NULL, ioflags, 0, AST_FILE_MODE);
 
 	if (!s) {
 		ast_log(LOG_WARNING, "Could not create file %s\n", args.filename);

--- a/include/asterisk/file.h
+++ b/include/asterisk/file.h
@@ -307,6 +307,24 @@ struct ast_filestream *ast_readfile(const char *filename, const char *type, cons
 struct ast_filestream *ast_writefile(const char *filename, const char *type, const char *comment, int flags, int check, mode_t mode);
 
 /*!
+ * \brief Same as ast_writefile, but take a handle to the channel for duplicate recording avoidance
+ * \param chan The channel running the recording
+ * \param filename the name of the file to write to
+ * \param type format of file you wish to write out to
+ * \param comment comment to go with
+ * \param flags output file flags
+ * \param check (unimplemented, hence negligible)
+ * \param mode Open mode
+ * Create an outgoing file stream.  oflags are flags for the open() command, and
+ * if check is non-zero, then it will not write a file if there are any files that
+ * start with that name and have an extension
+ * Please note, this is a blocking function.  Program execution will not return until ast_waitstream completes it's execution.
+ * \return a struct ast_filestream on success.
+ * \retval NULL on failure.
+ */
+struct ast_filestream *ast_chan_writefile(struct ast_channel *chan, const char *filename, const char *type, const char *comment, int flags, int check, mode_t mode);
+
+/*!
  * \brief Writes a frame to a stream
  * \param fs filestream to write to
  * \param f frame to write to the filestream

--- a/main/app.c
+++ b/main/app.c
@@ -1825,7 +1825,7 @@ static int __ast_play_and_record(struct ast_channel *chan, const char *playfile,
 
 	end = start = time(NULL);  /* pre-initialize end to be same as start in case we never get into loop */
 	for (x = 0; x < fmtcnt; x++) {
-		others[x] = ast_writefile(prepend ? prependfile : recordfile, sfmt[x], comment, ioflags, 0, AST_FILE_MODE);
+		others[x] = ast_chan_writefile(chan, prepend ? prependfile : recordfile, sfmt[x], comment, ioflags, 0, AST_FILE_MODE);
 		ast_trace(-1, "x=%d, open writing:  %s format: %s, %p\n", x, prepend ? prependfile : recordfile, sfmt[x], others[x]);
 
 		if (!others[x]) {

--- a/main/file.c
+++ b/main/file.c
@@ -396,6 +396,9 @@ static int type_in_list(const char *list, const char *type, int (*cmp)(const cha
 
 #define exts_compare(list, type) (type_in_list((list), (type), strcmp))
 
+/* Forward declaration */
+static void duplicate_recording_cleanup(struct ast_filestream *fs);
+
 /*!
  * \internal
  * \brief Close the file stream by canceling any pending read / write callbacks
@@ -403,6 +406,8 @@ static int type_in_list(const char *list, const char *type, int (*cmp)(const cha
 static void filestream_close(struct ast_filestream *f)
 {
 	enum ast_media_type format_type = ast_format_get_type(f->fmt->format);
+
+	duplicate_recording_cleanup(f); /* Free the list entry used to prevent duplicate recordings */
 
 	if (!f->owner) {
 		return;
@@ -1141,7 +1146,6 @@ int ast_closestream(struct ast_filestream *f)
 	return 0;
 }
 
-
 /*
  * Look the various language-specific places where a file could exist.
  */
@@ -1454,7 +1458,94 @@ struct ast_filestream *ast_readfile(const char *filename, const char *type, cons
 	return fs;
 }
 
+struct channel_recording {
+	const char *filename;
+	const char *channel;
+	AST_RWLIST_ENTRY(channel_recording) entry;
+	char data[];
+};
+
+static AST_RWLIST_HEAD_STATIC(channel_recordings, channel_recording);
+
+static void duplicate_recording_cleanup(struct ast_filestream *fs)
+{
+	struct channel_recording *cr;
+	const char *filename = S_OR(fs->realfilename, fs->filename); /* This should be the same filename passed to check_duplicate_recording */
+
+	AST_RWLIST_WRLOCK(&channel_recordings);
+	AST_RWLIST_TRAVERSE_SAFE_BEGIN(&channel_recordings, cr, entry) {
+		if (!strcmp(cr->filename, filename)) {
+			/* The channel name could have changed, e.g. due to a masquerade, so we pay no attention if that is different
+			 * (plus we lack a pointer to the channel here, so we don't know if it's changed anyways). */
+			AST_RWLIST_REMOVE_CURRENT(entry);
+			ast_free(cr);
+			break;
+		}
+	}
+	AST_RWLIST_TRAVERSE_SAFE_END;
+	AST_RWLIST_UNLOCK(&channel_recordings);
+	/* Don't emit warning about any unpaired closes here */
+}
+
+static int check_duplicate_recording(struct ast_channel *chan, const char *filename)
+{
+	struct channel_recording *cr;
+	size_t filename_len;
+
+	/* While the obvious thing to ensure is that we don't try to record to the same file multiple times
+	 * on the same channel (e.g. by making the same MixMonitor call multiple times in succession),
+	 * it's also not valid for different channels to write to the same file simultaneously, either,
+	 * so we check all the recordings currently in progress across all channels.
+	 *
+	 * Keep in mind a channel can record to multiple *different* files at the same time, but not the other way around. */
+
+	AST_RWLIST_WRLOCK(&channel_recordings);
+	AST_RWLIST_TRAVERSE(&channel_recordings, cr, entry) {
+		if (!strcmp(filename, cr->filename)) {
+			break;
+		}
+	}
+	if (cr) {
+		/* Found a match, that's not good. */
+		if (chan) {
+			if (cr->channel && strcasecmp(ast_channel_name(chan), cr->channel)) {
+				ast_log(LOG_WARNING, "Ignoring duplicate recording attempt on %s to %s (already opened by %s)\n", ast_channel_name(chan), filename, cr->channel);
+			} else {
+				ast_log(LOG_WARNING, "Ignoring duplicate recording attempt on %s to %s\n", ast_channel_name(chan), filename);
+			}
+		} else {
+			ast_log(LOG_WARNING, "Ignoring duplicate recording attempt on %s to %s\n", ast_channel_name(chan), filename);
+		}
+		AST_RWLIST_UNLOCK(&channel_recordings);
+		return 1;
+	}
+
+	/* Not a duplicate, so add ourselves and keep going */
+	filename_len = strlen(filename);
+	ast_channel_lock(chan); /* Lock the channel to ensure its name doesn't change */
+	cr = ast_calloc(1, sizeof(*cr) + filename_len + 1 + (chan ? strlen(ast_channel_name(chan)) + 1 : 0));
+	if (cr) {
+		strcpy(cr->data, filename); /* Safe */
+		cr->filename = cr->data;
+		if (chan) {
+			strcpy(cr->data + filename_len + 1, ast_channel_name(chan)); /* Safe */
+			cr->channel = cr->data + filename_len + 1;
+		}
+		/* Insert into the front, because if there is a duplicate and we get caught in a loop,
+		 * the duplicated recording will probably be at the front of the list. */
+		AST_RWLIST_INSERT_HEAD(&channel_recordings, cr, entry);
+	} /* else, if we fail to add ourselves, we're no worse off than if we had never done the check, so just keep going */
+	ast_channel_unlock(chan);
+	AST_RWLIST_UNLOCK(&channel_recordings);
+	return 0;
+}
+
 struct ast_filestream *ast_writefile(const char *filename, const char *type, const char *comment, int flags, int check, mode_t mode)
+{
+	return ast_chan_writefile(NULL, filename, type, comment, flags, check, mode);
+}
+
+struct ast_filestream *ast_chan_writefile(struct ast_channel *chan, const char *filename, const char *type, const char *comment, int flags, int check, mode_t mode)
 {
 	int fd, myflags = 0;
 	/* compiler claims this variable can be used before initialization... */
@@ -1464,6 +1555,11 @@ struct ast_filestream *ast_writefile(const char *filename, const char *type, con
 	char *buf = NULL;
 	size_t size = 0;
 	int format_found = 0;
+
+	/* This function takes the channel directly, even though f->owner is a channel, it's not usually set */
+	if (check_duplicate_recording(chan, filename)) {
+		return NULL;
+	}
 
 	AST_RWLIST_RDLOCK(&formats);
 

--- a/res/res_agi.c
+++ b/res/res_agi.c
@@ -3109,7 +3109,7 @@ static int handle_recordfile(struct ast_channel *chan, AGI *agi, int argc, const
 	if (res) {
 		ast_agi_send(agi->fd, chan, "200 result=%d (randomerror) endpos=%ld\n", res, sample_offset);
 	} else {
-		fs = ast_writefile(argv[2], argv[3], NULL, O_CREAT | O_WRONLY | (sample_offset ? O_APPEND : 0), 0, AST_FILE_MODE);
+		fs = ast_chan_writefile(chan, argv[2], argv[3], NULL, O_CREAT | O_WRONLY | (sample_offset ? O_APPEND : 0), 0, AST_FILE_MODE);
 		if (!fs) {
 			res = -1;
 			ast_agi_send(agi->fd, chan, "200 result=%d (writefile)\n", res);


### PR DESCRIPTION
MixMonitor has no restrictions on making multiple calls to it, which allows recording to different files simultaneously. However, nothing prevents users from writing to the same file multiple times. There would be no reason to do this intentionally, but if a user accidentally makes the same MixMonitor call in a loop (perhaps due to a bad branch), it will happily open the file for each iteration, quickly exhausting all available file descriptors and eventually crashing the process.

If we detect an attempt to record to a file that is already active, prevent it and log an error. While the user still has a dialplan bug that needs to be addressed, we can prevent the system from running away to oblivion.

Resolves: #1512