### PR TITLE
app_externalivr: Process buffered commands

### DIFF
--- a/apps/app_externalivr.c
+++ b/apps/app_externalivr.c
@@ -643,6 +643,8 @@ static int eivr_comm(struct ast_channel *chan, struct ivr_localuser *u,
 	struct ast_channel *rchan;
 	int res = -1;
 	int hangup_info_sent = 0;
+	int command_pending = 0;
+	int error_pending = 0;
 
 	waitfds[0] = ast_iostream_get_fd(eivr_commands);
 	waitfds[1] = eivr_errors ? ast_iostream_get_fd(eivr_errors) : -1;
@@ -669,7 +671,16 @@ static int eivr_comm(struct ast_channel *chan, struct ivr_localuser *u,
 		errno = 0;
 		exception = 0;
 
-		rchan = ast_waitfor_nandfds(&chan, 1, waitfds, (eivr_errors) ? 2 : 1, &exception, &ready_fd, &ms);
+		if (command_pending) {
+			rchan = NULL;
+			ready_fd = waitfds[0];
+		} else if (error_pending) {
+			rchan = NULL;
+			ready_fd = waitfds[1];
+		} else {
+			rchan = ast_waitfor_nandfds(&chan, 1, waitfds, (eivr_errors) ? 2 : 1,
+				&exception, &ready_fd, &ms);
+		}
 
 		if (ast_channel_state(chan) == AST_STATE_UP && !AST_LIST_EMPTY(&u->finishlist)) {
 			AST_LIST_LOCK(&u->finishlist);
@@ -724,6 +735,7 @@ static int eivr_comm(struct ast_channel *chan, struct ivr_localuser *u,
 			}
 
 			r = ast_iostream_gets(eivr_commands, input, sizeof(input));
+			command_pending = ast_iostream_has_buffered_line(eivr_commands);
 			if (r <= 0) {
 				if (r == 0) {
 					ast_chan_log(LOG_ERROR, chan, "Child process went away\n");
@@ -881,6 +893,7 @@ static int eivr_comm(struct ast_channel *chan, struct ivr_localuser *u,
 			}
 
 			r = ast_iostream_gets(eivr_errors, input, sizeof(input));
+			error_pending = ast_iostream_has_buffered_line(eivr_errors);
 			if (r > 0) {
 				ast_chan_log(LOG_NOTICE, chan, "stderr: %s\n", ast_strip(input));
 			} else if (r == 0) {

--- a/include/asterisk/iostream.h
+++ b/include/asterisk/iostream.h
@@ -142,6 +142,16 @@ int ast_iostream_get_fd(struct ast_iostream *stream);
 int ast_iostream_wait_for_input(struct ast_iostream *stream, int timeout);
 
 /*!
+ * \brief Check whether the iostream read buffer contains a complete line.
+ *
+ * \param stream A pointer to an iostream
+ *
+ * \retval 0 if no complete line is buffered
+ * \retval 1 if a complete line is buffered
+ */
+int ast_iostream_has_buffered_line(struct ast_iostream *stream);
+
+/*!
  * \brief Make an iostream non-blocking.
  *
  * \param stream A pointer to an iostream

--- a/main/iostream.c
+++ b/main/iostream.c
@@ -87,6 +87,11 @@ int ast_iostream_get_fd(struct ast_iostream *stream)
 	return stream->fd;
 }
 
+int ast_iostream_has_buffered_line(struct ast_iostream *stream)
+{
+	return stream->rbuflen && memchr(stream->rbufhead, '\n', stream->rbuflen) != NULL;
+}
+
 int ast_iostream_wait_for_input(struct ast_iostream *stream, int timeout)
 {
 #if defined(DO_SSL)


### PR DESCRIPTION
Process complete lines already buffered by ast_iostream_gets() before
waiting on the file descriptor again. This prevents trailing commands
such as E from being left unprocessed.

Resolves: #2148

DeveloperNote: Add ast_iostream_has_buffered_line().
